### PR TITLE
community: Qwen3.6 35B A3B Q8_0 llama.cpp SYCL recipe with benchmark data

### DIFF
--- a/community/dominick253-qwen36-35b-llamacpp-sycl/README.md
+++ b/community/dominick253-qwen36-35b-llamacpp-sycl/README.md
@@ -1,0 +1,125 @@
+# Qwen3.6 35B A3B Q8_0 on Intel Arc B70 (llama.cpp SYCL)
+
+Deployable llama.cpp SYCL recipe for serving `Qwen3.6-35B-A3B` in Q8_0
+quantization on Intel Arc B70 with MTP speculative decoding.
+
+## Model
+
+- HF repo: `Qwen/Qwen3.6-35B-A3B`
+- GGUF: `Qwen3.6-35B-A3B-Q8_0.gguf` (37GB)
+- mmproj: `mmproj-BF16.gguf` (861MB)
+
+## One-Command Start
+
+Requires llama.cpp built with SYCL support, Intel Arc B70 visible at
+`/dev/dri`, and the model downloaded locally.
+
+```bash
+LLAMA_SERVER=/path/to/llama.cpp/build/bin/llama-server
+MODEL_DIR=/path/to/models/Qwen
+MODEL="${MODEL_DIR}/Qwen3.6-35B-A3B-Q8_0.gguf"
+MMPOJ="${MODEL_DIR}/mmproj-BF16.gguf"
+PORT=8001
+CTX=512000
+SLOTS=2
+
+source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1
+export LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2026.1/lib:/opt/intel/oneapi/dnnl/2026.0/lib:/opt/intel/oneapi/mkl/2026.1/lib:$LD_LIBRARY_PATH
+export ZES_ENABLE_SYSMAN=1
+export GGML_SYSMAN=1
+export UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1
+export GGML_SYCL_ENABLE_FLASH_ATTN=1
+export ZE_COMMAND_QUEUE_SYNCHRONIZE_ASYNC=1
+export ZE_AFFINITY_MASK=0,1
+
+exec "${LLAMA_SERVER}" \
+  --model "${MODEL}" \
+  --mmproj "${MMPOJ}" \
+  --alias qwen36-35b-mtp \
+  --host 0.0.0.0 \
+  --port "${PORT}" \
+  --gpu-layers 99 \
+  --threads 16 \
+  --ctx-size "${CTX}" \
+  -np "${SLOTS}" \
+  --batch-size 2048 \
+  --ubatch-size 512 \
+  --temp 0.6 \
+  --top-p 0.95 \
+  --top-k 20 \
+  --min-p 0.0 \
+  --repeat-penalty 1.0 \
+  --presence-penalty 0.0 \
+  --spec-type draft-mtp \
+  --spec-draft-n-max 3 \
+  --reasoning on \
+  --reasoning-preserve \
+  --reasoning-budget 2048 \
+  --reasoning-budget-message "Thought complete, rendering final output." \
+  --reasoning-format deepseek \
+  --jinja
+```
+
+## systemd Service
+
+```ini
+[Unit]
+Description=Qwen3.6-35B-A3B llama-server on Intel Arc B70
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/home/dom/scripts
+ExecStart=/bin/bash /path/to/scripts/llama-qwen36-35b.sh
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=llama-qwen36-35b
+
+Environment=PATH=/opt/intel/oneapi/compiler/2026.1/bin:/opt/intel/oneapi/dnnl/2026.0/bin:/opt/intel/oneapi/mkl/2026.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2026.1/lib:/opt/intel/oneapi/dnnl/2026.0/lib:/opt/intel/oneapi/mkl/2026.1/lib
+Environment=ZE_AFFINITY_MASK=0,1
+Environment=ZES_ENABLE_SYSMAN=1
+Environment=GGML_SYSMAN=1
+Environment=UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1
+Environment=GGML_SYCL_ENABLE_FLASH_ATTN=1
+Environment=ZE_COMMAND_QUEUE_SYNCHRONIZE_ASYNC=1
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/dom/scripts
+PrivateTmp=true
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Environment
+
+- OS: Ubuntu 26.04 LTS
+- Kernel: 7.0.0-28-generic
+- GPU: Intel Arc B70 (Battlemage G31, 8086:e223)
+- Driver: xe
+- CPU: AMD Ryzen 9 9950X (16 cores)
+- Model: Qwen3.6-35B-A3B (35B total, 3B active MoE)
+- Quantization: Q8_0 weights, Q8_0 KV cache
+- Context: 512K tokens
+- Speculative decoding: draft-MTP n-max=3
+- Reasoning: deepseek format, 2048-token budget, --reasoning-preserve
+- Build: llama.cpp fb92d8f18, IntelLLVM 2026.1.0
+
+## Notes
+
+- `--jinja` enables Jinja2 chat template
+- `--reasoning-format deepseek` uses the DeepSeek-style reasoning parser
+- `--reasoning-budget 2048` limits thinking content to 2048 tokens
+- `--reasoning-preserve` keeps thought content in the response
+- `--spec-draft-n-max 3` with `--spec-type draft-mtp` enables MTP speculative decoding
+- `--ctx-size 512000` sets 512K context window
+- `-np 2` sets 2 request slots
+- Sampling: temp 0.6, top_p 0.95, top_k 20, min_p 0.0, presence_penalty 0.0, repeat_penalty 1.0
+- 39GB model size on disk; Q8_0 quantization

--- a/community/dominick253-qwen36-35b-llamacpp-sycl/README.md
+++ b/community/dominick253-qwen36-35b-llamacpp-sycl/README.md
@@ -5,9 +5,9 @@ quantization on Intel Arc B70 with MTP speculative decoding.
 
 ## Model
 
-- HF repo: `Qwen/Qwen3.6-35B-A3B`
-- GGUF: `Qwen3.6-35B-A3B-Q8_0.gguf` (37GB)
-- mmproj: `mmproj-BF16.gguf` (861MB)
+- HF repo: `unsloth/Qwen3.6-35B-A3B-MTP-GGUF` (MTP variant with nextn head)
+- GGUF: `Qwen3.6-35B-A3B-Q8_0.gguf` (from MTP repo)
+- mmproj: `mmproj-BF16.gguf`
 
 ## One-Command Start
 
@@ -56,7 +56,6 @@ exec "${LLAMA_SERVER}" \
   --reasoning-preserve \
   --reasoning-budget 2048 \
   --reasoning-budget-message "Thought complete, rendering final output." \
-  --reasoning-format deepseek \
   --jinja
 ```
 
@@ -109,17 +108,16 @@ WantedBy=multi-user.target
 - Quantization: Q8_0 weights, Q8_0 KV cache
 - Context: 512K tokens
 - Speculative decoding: draft-MTP n-max=3
-- Reasoning: deepseek format, 2048-token budget, --reasoning-preserve
+- Reasoning: enabled, 2048-token budget, --reasoning-preserve
 - Build: llama.cpp fb92d8f18, IntelLLVM 2026.1.0
 
 ## Notes
 
 - `--jinja` enables Jinja2 chat template
-- `--reasoning-format deepseek` uses the DeepSeek-style reasoning parser
-- `--reasoning-budget 2048` limits thinking content to 2048 tokens
-- `--reasoning-preserve` keeps thought content in the response
 - `--spec-draft-n-max 3` with `--spec-type draft-mtp` enables MTP speculative decoding
 - `--ctx-size 512000` sets 512K context window
 - `-np 2` sets 2 request slots
 - Sampling: temp 0.6, top_p 0.95, top_k 20, min_p 0.0, presence_penalty 0.0, repeat_penalty 1.0
 - 39GB model size on disk; Q8_0 quantization
+- IMPORTANT: Must use the MTP variant from `unsloth/Qwen3.6-35B-A3B-MTP-GGUF` — the standard
+  Unsloth Q8_0 GGUF has no nextn/MTP tensors and `--spec-type draft-mtp` will fail

--- a/community/dominick253-qwen36-35b-llamacpp-sycl/README.md
+++ b/community/dominick253-qwen36-35b-llamacpp-sycl/README.md
@@ -7,7 +7,8 @@ quantization on Intel Arc B70 with MTP speculative decoding.
 
 - HF repo: `unsloth/Qwen3.6-35B-A3B-MTP-GGUF` (MTP variant with nextn head)
 - GGUF: `Qwen3.6-35B-A3B-Q8_0.gguf` (from MTP repo)
-- mmproj: `mmproj-BF16.gguf`
+  - Download: `https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf?download=true`
+- mmproj: `mmproj-BF16.gguf` (from same repo)
 
 ## One-Command Start
 
@@ -15,6 +16,7 @@ Requires llama.cpp built with SYCL support, Intel Arc B70 visible at
 `/dev/dri`, and the model downloaded locally.
 
 ```bash
+# --- Abstracted top-level variables ---
 LLAMA_SERVER=/path/to/llama.cpp/build/bin/llama-server
 MODEL_DIR=/path/to/models/Qwen
 MODEL="${MODEL_DIR}/Qwen3.6-35B-A3B-Q8_0.gguf"
@@ -22,9 +24,11 @@ MMPOJ="${MODEL_DIR}/mmproj-BF16.gguf"
 PORT=8001
 CTX=512000
 SLOTS=2
+ONEAPI_ROOT=/opt/intel/oneapi
+# --- End variables ---
 
-source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1
-export LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2026.1/lib:/opt/intel/oneapi/dnnl/2026.0/lib:/opt/intel/oneapi/mkl/2026.1/lib:$LD_LIBRARY_PATH
+source "${ONEAPI_ROOT}/setvars.sh" --force >/dev/null 2>&1
+export LD_LIBRARY_PATH="${ONEAPI_ROOT}/compiler/2026.1/lib:${ONEAPI_ROOT}/dnnl/2026.0/lib:${ONEAPI_ROOT}/mkl/2026.1/lib:$LD_LIBRARY_PATH"
 export ZES_ENABLE_SYSMAN=1
 export GGML_SYSMAN=1
 export UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1
@@ -70,7 +74,7 @@ Wants=network.target
 [Service]
 Type=simple
 User=root
-WorkingDirectory=/home/dom/scripts
+WorkingDirectory=/path/to/scripts
 ExecStart=/bin/bash /path/to/scripts/llama-qwen36-35b.sh
 Restart=on-failure
 RestartSec=5
@@ -89,7 +93,7 @@ Environment=ZE_COMMAND_QUEUE_SYNCHRONIZE_ASYNC=1
 
 NoNewPrivileges=true
 ProtectSystem=strict
-ReadWritePaths=/home/dom/scripts
+ReadWritePaths=/path/to/scripts
 PrivateTmp=true
 ProtectHome=read-only
 
@@ -97,27 +101,144 @@ ProtectHome=read-only
 WantedBy=multi-user.target
 ```
 
+## Launch Script (llama-qwen36-35b.sh)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Abstracted top-level variables ---
+LLAMA_SERVER=/path/to/llama.cpp/build/bin/llama-server
+MODEL_DIR=/path/to/models/Qwen
+MODEL="${MODEL_DIR}/Qwen3.6-35B-A3B-Q8_0.gguf"
+MMPOJ="${MODEL_DIR}/mmproj-BF16.gguf"
+PORT=8001
+CTX=512000
+SLOTS=2
+ONEAPI_ROOT=/opt/intel/oneapi
+# --- End variables ---
+
+ONEAPI_SETUP() {
+  set +u
+  source "${ONEAPI_ROOT}/setvars.sh" --force >/dev/null 2>&1
+  set -u
+  export LD_LIBRARY_PATH="${ONEAPI_ROOT}/compiler/2026.1/lib:${ONEAPI_ROOT}/dnnl/2026.0/lib:${ONEAPI_ROOT}/mkl/2026.1/lib:$LD_LIBRARY_PATH"
+  export ZES_ENABLE_SYSMAN=1
+  export GGML_SYSMAN=1
+  export UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1
+  export GGML_SYCL_ENABLE_FLASH_ATTN=1
+  export ZE_COMMAND_QUEUE_SYNCHRONIZE_ASYNC=1
+}
+
+echo "=== Killing existing llama-server on port ${PORT} ==="
+pkill -9 -f "llama-server.*${PORT}" 2>/dev/null || true
+sleep 1
+
+echo "=== Starting Qwen3.6-35B-A3B with MTP on 2x B70 ==="
+echo "   Model: ${MODEL}"
+echo "   Port:  ${PORT}"
+echo "   Context: ${CTX}"
+echo "   Slots: ${SLOTS}"
+echo "   MTP: draft-mtp n-max=3"
+echo ""
+
+ONEAPI_SETUP
+export ZE_AFFINITY_MASK=0,1
+
+exec "${LLAMA_SERVER}" \
+  --model "${MODEL}" \
+  --mmproj "${MMPOJ}" \
+  --alias qwen36-35b-mtp \
+  --host 0.0.0.0 \
+  --port "${PORT}" \
+  --gpu-layers 99 \
+  --threads 16 \
+  --ctx-size "${CTX}" \
+  -np "${SLOTS}" \
+  --batch-size 2048 \
+  --ubatch-size 512 \
+  --temp 0.6 \
+  --top-p 0.95 \
+  --top-k 20 \
+  --min-p 0.0 \
+  --repeat-penalty 1.0 \
+  --presence-penalty 0.0 \
+  --spec-type draft-mtp \
+  --spec-draft-n-max 3 \
+  --reasoning on \
+  --reasoning-preserve \
+  --reasoning-budget 2048 \
+  --reasoning-budget-message "Thought complete, rendering final output." \
+  --jinja
+```
+
 ## Environment
 
-- OS: Ubuntu 26.04 LTS
-- Kernel: 7.0.0-28-generic
-- GPU: Intel Arc B70 (Battlemage G31, 8086:e223)
-- Driver: xe
-- CPU: AMD Ryzen 9 9950X (16 cores)
-- Model: Qwen3.6-35B-A3B (35B total, 3B active MoE)
-- Quantization: Q8_0 weights, Q8_0 KV cache
-- Context: 512K tokens
-- Speculative decoding: draft-MTP n-max=3
-- Reasoning: enabled, 2048-token budget, --reasoning-preserve
-- Build: llama.cpp fb92d8f18, IntelLLVM 2026.1.0
+| Field | Value |
+| --- | --- |
+| OS | Ubuntu 26.04 LTS |
+| Kernel | 7.0.0-28-generic |
+| CPU | AMD Ryzen 9 9950X (16 cores) |
+| GPU | 2x Intel Arc B70 (Battlemage G31, 8086:e223), PCIe 4.0 x8 |
+| VRAM | 32 GB per card (64 GB total) |
+| Driver | xe |
+| Runtime | llama.cpp fb92d8f18 (IntelLLVM 2026.1.0, SYCL backend) |
+| Model | Qwen3.6-35B-A3B (35B total, 3B active MoE) |
+| Quantization | Q8_0 weights, Q8_0 KV cache |
+| Model size | 39 GB on disk |
+| Context | 512K tokens (512000) |
+| Speculative decoding | draft-MTP n-max=3 |
+| Reasoning | enabled, 2048-token budget, --reasoning-preserve |
+| Sampling | temp 0.6, top_p 0.95, top_k 20, min_p 0.0 |
+| Concurrency | 2 request slots (-np 2) |
+| Batch | batch_size=2048, ubatch_size=512 |
 
-## Notes
+## Benchmark Results
+
+Measured 2026-07-27 against live service on port 8001.
+
+### Throughput
+
+| Metric | Result |
+| --- | --- |
+| Output throughput (200 tok, avg) | **40.12 tok/s** |
+| Output throughput range | 34.96 – 42.74 tok/s |
+| Output throughput (512 tok, server log) | 43.75 tok/s |
+| Prompt eval (short, 5 tok) | 2.1 tok/s (TTFT-dominant) |
+| Prompt eval (medium, 23 tok) | 9.3 tok/s |
+| Prompt eval (long, 96 tok) | 36.6 tok/s |
+| Prompt eval (server log, 57 tok) | 117.47 tok/s |
+
+First request is slower (~35 tok/s) due to graph compilation warm-up.
+Subsequent requests stabilize at ~42.5 tok/s.
+
+### MTP Speculation
+
+| Metric | Result |
+| --- | --- |
+| Draft acceptance rate | **86.5%** (237/274) |
+| Mean draft length | **1.86 tokens** |
+| Graphs reused | **29,892** |
+
+### Reasoning Mode
+
+- Fully functional: structured `<think>...</think>` reasoning with proper tag delimiters
+- Reasoning content served via `reasoning_content` field (not inline in `content`)
+- Tested with math word problem: correctly identifies problem, breaks into steps, structured output
+
+### GPU Status
+
+| Field | Value |
+| --- | --- |
+| GPU 1 | 2800 MHz, 25.4 GB / 31.9 GB VRAM, 57°C, 5 W |
+| GPU 2 | 2800 MHz, 27.6 GB / 31.9 GB VRAM, 59°C, 25 W |
+| Service memory | 10.2 GB resident, 14.8 GB peak, 11.6 MB swap |
+
+### Notes
 
 - `--jinja` enables Jinja2 chat template
 - `--spec-draft-n-max 3` with `--spec-type draft-mtp` enables MTP speculative decoding
 - `--ctx-size 512000` sets 512K context window
 - `-np 2` sets 2 request slots
-- Sampling: temp 0.6, top_p 0.95, top_k 20, min_p 0.0, presence_penalty 0.0, repeat_penalty 1.0
-- 39GB model size on disk; Q8_0 quantization
 - IMPORTANT: Must use the MTP variant from `unsloth/Qwen3.6-35B-A3B-MTP-GGUF` — the standard
   Unsloth Q8_0 GGUF has no nextn/MTP tensors and `--spec-type draft-mtp` will fail

--- a/community/dominick253-qwen36-35b-llamacpp-sycl/STATUS.md
+++ b/community/dominick253-qwen36-35b-llamacpp-sycl/STATUS.md
@@ -1,8 +1,5 @@
 # Qwen3.6 35B A3B Q8_0 on Intel Arc B70 (llama.cpp SYCL)
 
-Copy this file to `community/<entry>/STATUS.md` and fill it in. Delete guidance
-lines that do not apply. Mark unknown fields `unknown` rather than guessing.
-
 ## Classification
 
 | Field | Value |
@@ -31,18 +28,51 @@ serving on port 8001 with 512K context and reasoning enabled.
 
 | Field | Value |
 | --- | --- |
-| GPU model / count / VRAM | Intel Arc B70 (Battlemage G31, 8086:e223), count unstated |
+| GPU model / count / VRAM | Intel Arc B70 (Battlemage G31, 8086:e223), 2x cards, 32 GB each |
 | OS / kernel | Ubuntu 26.04 LTS, kernel 7.0.0-28-generic |
 | GPU driver (`i915` / `xe`) and version | xe (version unstated) |
 | compute-runtime / level-zero | unknown |
 | Engine / image and exact version | llama.cpp fb92d8f18, IntelLLVM 2026.1.0, SYCL backend |
-| Model repo and revision | Qwen/Qwen3.6-35B-A3B (Unsloth Dynamic 2.0 GGUF) |
+| Model repo and revision | unsloth/Qwen3.6-35B-A3B-MTP-GGUF |
 | Quantization (weights / KV / activations) | Q8_0 (weights and KV) |
 | Command and environment variables | See README.md |
 | Prompt / output / context lengths, concurrency | Context 512K (512000), slots 2 |
 | Cache and speculation policy | draft-MTP n-max=3 |
-| Metric definition, repeats, dispersion, TTFT | unknown |
-| Logs / JSON / durable links | none |
+| Metric definition, repeats, dispersion, TTFT | See benchmark results below |
+| Logs / JSON / durable links | llama server journal logs available |
+
+## Benchmark Results (measured 2026-07-27)
+
+### Throughput
+
+- Output throughput (200 tok, avg): **40.12 tok/s**
+- Output throughput range: 34.96 – 42.74 tok/s
+- Output throughput (512 tok, server log): 43.75 tok/s
+- Prompt eval (short, 5 tok): 2.1 tok/s (TTFT-dominant)
+- Prompt eval (medium, 23 tok): 9.3 tok/s
+- Prompt eval (long, 96 tok): 36.6 tok/s
+- Prompt eval (server log, 57 tok): 117.47 tok/s
+
+First request is slower (~35 tok/s) due to graph compilation warm-up.
+Subsequent requests stabilize at ~42.5 tok/s.
+
+### MTP Speculation
+
+- Draft acceptance rate: **86.5%** (237/274)
+- Mean draft length: **1.86 tokens**
+- Graphs reused: **29,892**
+
+### Reasoning Mode
+
+- Fully functional: structured `<think>...</think>` reasoning with proper tag delimiters
+- Reasoning content served via `reasoning_content` field (not inline in `content`)
+- Tested with math word problem: correctly identifies problem, breaks into steps, structured output
+
+### GPU Status
+
+- GPU 1: 2800 MHz, 25.4 GB / 31.9 GB VRAM, 57°C, 5 W
+- GPU 2: 2800 MHz, 27.6 GB / 31.9 GB VRAM, 59°C, 25 W
+- Service memory: 10.2 GB resident, 14.8 GB peak, 11.6 MB swap
 
 ## Reference Lab Environment
 
@@ -50,15 +80,36 @@ Not yet tested in the reference lab.
 
 ## What Was Actually Run Here
 
-Nothing. This is a community submission awaiting validation.
+Live service benchmarked against running instance. All measurements taken
+from live service on port 8001:
+
+- Completion throughput: 3x cold requests, 200 tokens each, measured via
+  streaming API
+- Server-side timing: extracted from llama.cpp journal logs
+- MTP stats: extracted from llama.cpp slot print_timing output
+- GPU status: extracted from intel_gpu_top and system monitoring
+- KV cache behavior: tested cold vs. warm completion requests
 
 ## Findings
 
-None yet.
+1. **MTP speculation is highly effective** — 86.5% draft acceptance with
+   n_max=3 means the MTP draft model is almost always agreeing with the
+   target. This is the primary driver of throughput.
+2. **Graph compilation warm-up is significant** — first request ~35 tok/s,
+   stabilizes to ~42.5 tok/s. This is expected for llama.cpp SYCL but worth
+   noting for production deployments.
+3. **Reasoning mode works correctly** — structured thinking with proper
+   tag delimiters, served via `reasoning_content` field.
+4. **GPU utilization is healthy** — both cards at 2800 MHz, temps 57-59°C,
+   reasonable power draw (5W/25W). VRAM usage ~25-28 GB per card.
+5. **No KV cache persistence across requests** — each `/v1/completions`
+   call is stateless. KV cache is per-slot/per-request within llama.cpp's
+   slot-based architecture.
 
 ## Known Issues
 
-None identified during review.
+- No KV cache persistence between independent API requests (expected behavior)
+- Graph compilation warm-up on first request (~35 tok/s vs ~42.5 tok/s stabilized)
 
 ## Open Questions For The Contributor
 

--- a/community/dominick253-qwen36-35b-llamacpp-sycl/STATUS.md
+++ b/community/dominick253-qwen36-35b-llamacpp-sycl/STATUS.md
@@ -1,0 +1,72 @@
+# Qwen3.6 35B A3B Q8_0 on Intel Arc B70 (llama.cpp SYCL)
+
+Copy this file to `community/<entry>/STATUS.md` and fill it in. Delete guidance
+lines that do not apply. Mark unknown fields `unknown` rather than guessing.
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `community-reported` |
+| Patch review status | unreviewed |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no until `B70-tested` |
+
+## Provenance
+
+- Contributor: dominick253
+- Source PR: community submission (PR pending)
+- Commits: pending
+- Right-to-submit statement present: yes
+- Third-party material: llama.cpp (GGML project), Qwen3.6-35B-A3B (Qwen team, Apache 2.0)
+
+## Claim
+
+The contributor reports a working llama.cpp SYCL deployment of `Qwen3.6-35B-A3B`
+in Q8_0 quantization on Intel Arc B70 with MTP speculative decoding (n-max=3),
+serving on port 8001 with 512K context and reasoning enabled.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | Intel Arc B70 (Battlemage G31, 8086:e223), count unstated |
+| OS / kernel | Ubuntu 26.04 LTS, kernel 7.0.0-28-generic |
+| GPU driver (`i915` / `xe`) and version | xe (version unstated) |
+| compute-runtime / level-zero | unknown |
+| Engine / image and exact version | llama.cpp fb92d8f18, IntelLLVM 2026.1.0, SYCL backend |
+| Model repo and revision | Qwen/Qwen3.6-35B-A3B (Unsloth Dynamic 2.0 GGUF) |
+| Quantization (weights / KV / activations) | Q8_0 (weights and KV) |
+| Command and environment variables | See README.md |
+| Prompt / output / context lengths, concurrency | Context 512K (512000), slots 2 |
+| Cache and speculation policy | draft-MTP n-max=3 |
+| Metric definition, repeats, dispersion, TTFT | unknown |
+| Logs / JSON / durable links | none |
+
+## Reference Lab Environment
+
+Not yet tested in the reference lab.
+
+## What Was Actually Run Here
+
+Nothing. This is a community submission awaiting validation.
+
+## Findings
+
+None yet.
+
+## Known Issues
+
+None identified during review.
+
+## Open Questions For The Contributor
+
+1. GPU count and VRAM per card.
+2. compute-runtime / level-zero versions.
+3. Benchmark methodology: how was speed measured, how many repeats, cold or warm?
+4. Any logs or JSON from the original run.
+
+## Disposition
+
+Entry stays in `community/` at `community-reported` level until validated on B70.


### PR DESCRIPTION
## Summary

llama.cpp SYCL serving of `Qwen3.6-35B-A3B` in Q8_0 quantization on Intel Arc B70 with MTP speculative decoding (n-max=3), 512K context, and reasoning mode enabled.

## Changes

- Updated README with measured benchmark results and abstracted top-level variables (`LLAMA_SERVER`, `MODEL_DIR`, `PORT`, `CTX`, `SLOTS`, `ONEAPI_ROOT`)
- Added launch script template (`llama-qwen36-35b.sh`) with variable section
- Updated STATUS.md with benchmark findings, GPU status, and findings section

## Benchmark Results

| Metric | Result |
| --- | --- |
| Output throughput (200 tok, avg) | **40.12 tok/s** |
| Output throughput range | 34.96 – 42.74 tok/s |
| MTP draft acceptance rate | **86.5%** (237/274) |
| Mean draft length | **1.86 tokens** |
| Graphs reused | **29,892** |

## Environment

- GPU: 2x Intel Arc B70 (Battlemage G31, PCIe 4.0 x8), 32 GB each
- CPU: AMD Ryzen 9 9950X
- OS: Ubuntu 26.04 LTS, kernel 7.0.0-28-generic
- Driver: xe
- Runtime: llama.cpp fb92d8f18, IntelLLVM 2026.1.0, SYCL backend
- Model: Qwen3.6-35B-A3B (35B total, 3B active MoE), Q8_0
- Speculative decoding: draft-MTP n-max=3
- Reasoning: enabled, 2048-token budget

## Evidence Level

`community-reported` — measured against live service, not yet tested in reference lab.