### PR TITLE
community: 2× B70 result packets — Q8-vs-Q4, B60-vs-B70, MTP net-loss (+AMD cross-arch)

### DIFF
--- a/community/bosd-trx50-2xb70-b60-vs-b70/README.md
+++ b/community/bosd-trx50-2xb70-b60-vs-b70/README.md
@@ -1,0 +1,23 @@
+# Arc Pro B60 vs B70 — single-card head-to-head
+
+**Contributor:** bosd · **Evidence:** B70 column `B70-tested`; **B60 column `community-reported`** (reference lab has no B60 — see [`STATUS.md`](STATUS.md)).
+Full write-up: **https://github.com/bosd/trx50-arc-b70-benchmarks/blob/master/results/b60-vs-b70.md**
+
+The returned-from-RMA Sparkle **B60 (G21, 24 GB)** dropped into the TRX50 alongside a **B70 (G31, 32 GB)**, same models, single card each. `llama-bench -p 512 -n 128`; W = GPU-only (`xe` card energy counter).
+
+| Model | backend | B60 pp512 | B60 tg128 | B60 W | B70 pp512 | B70 tg128 | B70 W |
+|---|---|---|---|---|---|---|---|
+| Qwen3-4B-Q4 | SYCL | 2236 | **101.8** | 81 | 3280 | 115.7 | 144 |
+| Qwen3-4B-Q4 | Vulkan | 1698 | 55.4 | 72 | 2390 | 79.9 | 138 |
+| Qwen3.6-35B-A3B-Q4_0 | Vulkan | 908 | 37.3 | 60 | 1250 | 48.0 | 96 |
+| Qwen3.6-35B-A3B-Q4_0 | SYCL | — | — | — | 980 | 71.8 | 77 |
+
+## Takeaways
+
+- **Generation: B60 ≈ 78–88% of a B70** (88% on the SYCL production path).
+- **Prompt processing: B60 ≈ 68–73%** — the B70's extra Xe cores show on compute-bound prefill.
+- **Power: B60 draws ~56–63% of a B70** → **1.2–1.6× more tokens/joule**.
+- **VRAM: 24 GB (21.5 usable) vs 32 GB** — B60 fits a 20 GB MoE fine but has 8 GB less headroom.
+- **B60 POSTs** (G21 has mature DP+HDMI GOP); the B70 (G31) gives no pre-OS video on this board, so the B60's slot can double as console **and** compute.
+
+**Verdict:** the B60 is the **efficiency + console** card; the B70 is the **VRAM + prompt-throughput** card. Don't put a B60 in a `-sm layer` tensor-split with B70s (bottlenecks them; the 24/32 GB mismatch wastes the B70's VRAM). For a VRAM-bound big-model mission, expand with **uniform B70s**; the B60's efficiency edge pays off best on an always-on box.

--- a/community/bosd-trx50-2xb70-b60-vs-b70/STATUS.md
+++ b/community/bosd-trx50-2xb70-b60-vs-b70/STATUS.md
@@ -1,0 +1,68 @@
+# Arc Pro B60 vs B70 — single-card head-to-head (SYCL + Vulkan)
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `B70-tested` for the B70 column; **B60 column is `community-reported`** (reference lab has no B60) |
+| Patch review status | n/a — benchmark result, no source patch |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no (B60 cannot be verified in the reference lab) |
+
+## Provenance
+
+- Contributor: **bosd** (`github.com/bosd`)
+- Source PR or URL: this PR; full data in `bosd/trx50-arc-b70-benchmarks`
+- Commits: llama.cpp **SYCL** + **Vulkan** builds (oneAPI 2026.0 / Mesa Anv 26.0.7); exact upstream commit `unknown`
+- Right-to-submit statement present: yes — own measurements
+- Third-party material and attribution: none
+
+## Claim
+
+A single Arc Pro **B60 (G21, 24 GB)** runs at **~78–88% of a B70's generation speed** and **~68–73% of its prompt-processing**, while drawing **~56–63% of the power** → **1.2–1.6× more tokens/joule**; it also POSTs (G21 GOP) where the B70 (G31) does not.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | 1× **Arc Pro B60** (Battlemage G21, `8086:e211`, 24 GB / ~21.5 usable) vs 1× **Arc Pro B70** (G31, `8086:e223`, 32 GB), same host, single card each |
+| OS / kernel | Fedora Server 44, kernel **7.0.10** |
+| GPU driver (`i915`/`xe`) and version | **`xe`** |
+| compute-runtime / level-zero | NEO **26.18.38308.1** (SYCL); Mesa **26.0.7** (Vulkan/Anv) |
+| Engine / image and exact version | llama.cpp `llama-bench`, **SYCL** (oneAPI 2026.0) and **Vulkan** (Mesa Anv); commit `unknown` |
+| Model repo and revision | Qwen3-4B (Q4), Qwen3.6-35B-A3B (Q4_0) |
+| Quantization (weights / KV / activations) | weights Q4 / Q4_0; KV f16; no activation quant |
+| Command and environment variables | `llama-bench -p 512 -n 128`; per-backend defaults |
+| Prompt / output / context lengths, concurrency | pp512 / tg128; concurrency 1 |
+| Cache and speculation policy | cold, defaults; no speculation |
+| Metric definition, repeats, dispersion, TTFT | pp512 & tg128 t/s (llama-bench defaults); W = GPU-only (`xe` card energy counter, single card); TTFT n/a |
+| Logs / JSON / durable links | https://github.com/bosd/trx50-arc-b70-benchmarks/blob/master/results/b60-vs-b70.md |
+
+## Reference Lab Environment
+
+Nothing executed in the reference lab. **The B60 is not present in the reference lab, so the B60 column is inherently `community-reported`** and cannot be promoted.
+
+## What Was Actually Run Here
+
+Nothing in the reference lab. Both columns measured on the contributor's TRX50 (B60 and B70 in the same host, one card at a time).
+
+## Findings
+
+- **Generation:** B60 ≈ **78–88%** of a B70 (88% on the SYCL production path).
+- **Prompt processing:** B60 ≈ **68–73%** — the B70's extra Xe cores show on compute-bound prefill.
+- **Power:** B60 draws **~56–63%** of a B70 (60–81 W vs 96–144 W) → **1.2–1.6× tokens/joule**.
+- **POST/GOP:** the B60 (G21) produces POST video and can double as a console GPU; the B70 (G31) produces **no** pre-OS video on this platform — a practical B60 advantage for headless-build bring-up.
+- **Do not tensor-split B60+B70:** the 24/32 GB mismatch wastes the B70's VRAM and the slower B60 bottlenecks the pair; keep the B60 standalone.
+
+## Known Issues
+
+None found — result-only submission.
+
+## Open Questions For The Contributor
+
+Nothing needed for correctness; the B60 column simply cannot reach `B70-verified` without a B60 in the reference lab. Useful add: the SYCL row for Qwen3.6-35B-A3B on the B60 (only Vulkan captured for that model on B60).
+
+## Disposition
+
+Stays `community/`; the B60 column is `community-reported` by definition (no B60 in the reference lab). Recorded as reference data for anyone weighing B60 vs B70 for an Intel Arc inference build. CONTRIBUTING explicitly welcomes B50/B60/B65 work.

--- a/community/bosd-trx50-2xb70-mtp-net-loss/README.md
+++ b/community/bosd-trx50-2xb70-mtp-net-loss/README.md
@@ -1,0 +1,36 @@
+# MTP speculative decoding on the B70 — a net loss for single-stream decode
+
+**Contributor:** bosd · **Evidence:** `B70-tested` (contributor B70; AMD rows are dominick253's — see [`STATUS.md`](STATUS.md)).
+Full write-up: **https://github.com/bosd/trx50-arc-b70-benchmarks/blob/master/results/mtp-spec-decode-b70.md**
+
+Model: **Qwen3.6-35B-A3B UD-Q4_K_M** from [`unsloth/Qwen3.6-35B-A3B-MTP-GGUF`](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF) (MTP variant — carries `blk.40.nextn.*`; the base repo drops it). **Single B70**, `llama-server` (upstream `dee2a84`, oneAPI 2026.0, SYCL), `n_predict=512`, temp 0, `--spec-draft-n-max 3`. Wall power via Shelly.
+
+## Result
+
+| Flash-attn | MTP-off tok/s | MTP-on tok/s | MTP effect | draft acceptance |
+|---|---|---|---|---|
+| off (`-fa 0`) | **72.4** | 68.6 | **−5%** | 71% (348/487), mean len 3.13 |
+| on (`-fa 1`)  | **72.6** | 65.1 | **−10%** | 66% (339/515), mean len 2.97 |
+
+MTP engages correctly (~70% acceptance, mean draft len ~3) — but **MTP-on is consistently slower**, and flash-attn makes it worse.
+
+## Why MTP loses here (MoE + bandwidth-bound)
+
+Single-stream decode on the B70 is memory-bandwidth-bound. Speculative decoding trades compute for a batched verification pass — a win only if verifying K draft tokens is ~as cheap as one. On a **3B-active MoE**, a batch of 3–4 draft tokens routes to **more experts**, so the verification reads **more weight bandwidth**, cancelling the batching benefit — and the MTP draft head adds forward-pass overhead. Net −5 to −10%. Q4/1-GPU is the best case; Q8_K_XL or 2-GPU is more bandwidth-bound.
+
+## Context — supplies the MTP-off baseline PR #14 lacked
+
+[PR #14](https://github.com/steveseguin/b70-optimization-lab/pull/14) (dominick253) reported ~40 tok/s *with* MTP (Q8_K_XL, 2× B70, kernel 7.0.0), 86.5% acceptance, but **no MTP-off control**. High acceptance ≠ speedup. dominick253 then re-ran his own config and measured **MTP-off ≈ 45 vs MTP-on ≈ 40** — a net loss on Q8/2-GPU too, matching this Q4/1-GPU result.
+
+## Cross-arch: MTP *helps* on AMD, *hurts* on Intel — it's the backend, not the hardware
+
+Same model on **2× AMD Radeon 7800 XT (ROCm)** (credit: dominick253):
+
+| Rig | backend | MTP-off | MTP-on | effect |
+|---|---|---|---|---|
+| Intel Arc B70 | SYCL | 72 | 68 | **−5%** |
+| AMD 7800 XT ×2 | ROCm/HIP | ~70 | ~100 | **+43%** |
+
+The **MTP-off baselines are ~identical** (72 vs ~70) — raw decode is the same — but the **MTP path** is +43% on ROCm and −5% on SYCL. So it's the **llama.cpp SYCL batched draft-verification path being immature**, not B70 memory bandwidth.
+
+**Takeaway:** don't enable MTP for single-stream MoE serving on B70 *today*; it costs throughput. It's not a hardware dead-end — re-test after SYCL kernel/oneAPI updates. Upstream: [#23533](https://github.com/ggml-org/llama.cpp/issues/23533) (overhead shrinking build-over-build), [#23797](https://github.com/ggml-org/llama.cpp/issues/23797) (multi-GPU). ⚠️ `dee2a84` is a known-good build (avoid the #24795 MTP-load regression in b9702/b9717).

--- a/community/bosd-trx50-2xb70-mtp-net-loss/STATUS.md
+++ b/community/bosd-trx50-2xb70-mtp-net-loss/STATUS.md
@@ -1,0 +1,75 @@
+# MTP speculative decoding on B70 — net loss for single-stream MoE decode
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `B70-tested` (on contributor's B70, **not** the reference lab → not `B70-verified`) |
+| Patch review status | n/a — benchmark result, no source patch |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no until re-run in the reference lab |
+
+## Provenance
+
+- Contributor: **bosd** (`github.com/bosd`)
+- Source PR or URL: consolidates findings from [PR #14](https://github.com/steveseguin/b70-optimization-lab/pull/14); full data in `bosd/trx50-arc-b70-benchmarks`
+- Commits: upstream llama.cpp **`dee2a84`** (MTP-capable SYCL build, oneAPI 2026.0)
+- Right-to-submit statement present: yes — own measurements
+- Third-party material and attribution: **AMD 7800 XT cross-arch numbers and the Q8_K_XL/2× B70 MTP-on figure are dominick253's** (PR #14), reproduced here with credit
+
+## Claim
+
+With MTP genuinely engaged (~70% draft acceptance), **MTP-on is 5–10% *slower* than MTP-off** for single-stream decode of a 3B-active MoE on the B70 — and the same model shows **+43% on 2× AMD 7800 XT (ROCm)**, so the deficit is the **SYCL backend's batched-verification path, not B70 hardware**.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | 1× **Arc Pro B70** (Battlemage G31, `8086:e223`, 32 GB), TRX50 / Threadripper 9960X |
+| OS / kernel | Fedora Server 44, kernel **7.0.10** |
+| GPU driver (`i915`/`xe`) and version | **`xe`** |
+| compute-runtime / level-zero | NEO **26.18.38308.1** |
+| Engine / image and exact version | upstream **llama.cpp `dee2a84`** `llama-server`, **SYCL**, oneAPI **2026.0** |
+| Model repo and revision | **`unsloth/Qwen3.6-35B-A3B-MTP-GGUF`** UD-Q4_K_M (the **MTP variant** — carries `blk.40.nextn.*`; the base `-GGUF` repo drops it) |
+| Quantization (weights / KV / activations) | weights UD-Q4_K_M; KV f16; no activation quant |
+| Command and environment variables | `llama-server` `--spec-type draft-mtp --spec-draft-n-max 3`, `n_predict=512`, temp 0; `-fa 0` and `-fa 1`; `GGML_SYCL_DISABLE_OPT=1`; single GPU |
+| Prompt / output / context lengths, concurrency | n_predict 512; **concurrency 1** (single-stream) |
+| Cache and speculation policy | cold; **MTP draft head, `--spec-draft-n-max 3`** (vs MTP-off control) |
+| Metric definition, repeats, dispersion, TTFT | decode tok/s (server telemetry) MTP-off vs MTP-on; draft acceptance % + mean draft length reported; `t/J = tok/s ÷ wall W` (Shelly) |
+| Logs / JSON / durable links | https://github.com/bosd/trx50-arc-b70-benchmarks/blob/master/results/mtp-spec-decode-b70.md (+ `bench-mtp-1gpu.sh`) |
+
+## Reference Lab Environment
+
+Nothing executed in the reference lab — contributor submission on the contributor's B70.
+
+## What Was Actually Run Here
+
+Nothing in the reference lab. The Intel B70 rows are the contributor's measurements; the AMD 7800 XT rows and the Q8_K_XL/2-GPU MTP-on figure are **dominick253's** (PR #14), included for the cross-arch comparison with credit.
+
+## Findings
+
+**Confirmed (contributor B70, Q4/1-GPU):**
+
+| Flash-attn | MTP-off tok/s | MTP-on tok/s | effect | acceptance |
+|---|---|---|---|---|
+| off (`-fa 0`) | **72.4** | 68.6 | **−5%** | 71%, mean len 3.13 |
+| on (`-fa 1`) | **72.6** | 65.1 | **−10%** | 66%, mean len 2.97 |
+
+- MTP engages correctly (~70% acceptance) but **loses**: a 3B-active MoE's batched draft-verification routes to **more experts** → more weight-bandwidth on bandwidth-bound decode, cancelling the batching win; the draft head adds overhead. This Q4/1-GPU config is MTP's best case here (Q8/2-GPU is more bandwidth-bound).
+- **Supplies the MTP-off baseline that PR #14 lacked.** High acceptance ≠ speedup.
+- **Cross-arch (same model, credit dominick253):** Intel B70/SYCL **−5%** vs AMD 7800 XT×2/ROCm **+43%**, with **matching MTP-off baselines (~72 vs ~70)** — so the divergence is the SYCL backend, not the hardware.
+
+**Hypothesis (not yet reproduced here):** MTP should flip positive on B70 once the SYCL MoE/spec-decode kernels mature. Tracking [ggml-org/llama.cpp#23533](https://github.com/ggml-org/llama.cpp/issues/23533) (SYCL MTP no-speedup — overhead shrinking build-over-build: −21%/−34% on b9292 → −5% on dee2a84) and [#23797](https://github.com/ggml-org/llama.cpp/issues/23797) (SYCL multi-GPU tensor-split). ⚠️ #24795 is a *newer* MTP-load regression (b9702/b9717) — `dee2a84` is a known-good build.
+
+## Known Issues
+
+None found — result-only submission.
+
+## Open Questions For The Contributor
+
+To raise to `B70-verified`: reference-lab re-run of `bench-mtp-1gpu.sh` (Qwen3.6-35B-A3B-MTP-GGUF UD-Q4_K_M, single B70) confirming MTP-on < MTP-off on the reference kernel/runtime.
+
+## Disposition
+
+Stays `community/` as `B70-tested`. Actionable now as a **negative result**: don't enable MTP for single-stream MoE serving on B70 today; re-test after SYCL backend/oneAPI bumps (the overhead is trending toward break-even).

--- a/community/bosd-trx50-2xb70-q8-vs-q4/README.md
+++ b/community/bosd-trx50-2xb70-q8-vs-q4/README.md
@@ -1,0 +1,37 @@
+# Q8_0 vs Q4_K_M on the B70 — and what it bounds for FP8
+
+**Contributor:** bosd · **Hardware:** 2× Arc Pro B70 (G31, 32 GB), TRX50 / Threadripper 9960X · **Evidence:** `B70-tested` (contributor hardware — see [`STATUS.md`](STATUS.md)).
+Full write-up + raw JSON: **https://github.com/bosd/trx50-arc-b70-benchmarks/blob/master/results/q8-vs-q4-b70.md**
+
+Firmware: BIOS 14.10 · GuC 70.65.0 · kernel 7.0.10 · Mesa 26.0.7. `llama-bench -p 512 -n 128`, SYCL (XMX), Shelly wall power; `t/J(wall) = tg128 ÷ avg W`. GPU-W is the `xe` card energy counter (noisy over the short window → treat wall-W as authoritative).
+
+Motivation: "does the B70 have native FP8?" — no. Battlemage Xe2 **XMX = INT2/4/8, FP16, BF16, TF32; no FP8**. vLLM `--quantization fp8` on B70 is weight-only 8-bit (selects `XPUFP8ScaledMMLinearKernel`, disables `RMSNorm+quant`/`Activation+quant` fusions — "not supported on XPU"). So the honest FP8 proxy is **Q8_0**: same 8 bits, same bandwidth cost.
+
+## Qwen3-30B-A3B (MoE, 3B active)
+
+| Quant | GPUs | Size GiB | pp512 t/s | tg128 t/s | wall W | t/J(wall) |
+|---|---|---|---|---|---|---|
+| Q4_K_M | 1 | 17.3 | 1227 | **79.2** | 292 | **0.271** |
+| Q4_K_M | 2 | 17.3 | 1179 | 77.5 | 327 | 0.237 |
+| Q8_0 | 2 | 30.2 | 890 | **41.2** | 311 | **0.132** |
+
+*(Q8_0 30.2 GiB + KV won't fit one 32 GB card → 2-GPU only.)*
+
+## Hermes-4-14B (dense, qwen3)
+
+| Quant | GPUs | Size GiB | pp512 t/s | tg128 t/s | wall W | t/J(wall) |
+|---|---|---|---|---|---|---|
+| Q4_K_M | 1 | 8.4 | 1393 | **47.5** | 368 | **0.129** |
+| Q4_K_M | 2 | 8.4 | 1349 | 47.5 | 422 | 0.113 |
+| Q8_0 | 1 | 14.6 | 1464 | **29.8** | 385 | **0.077** |
+| Q8_0 | 2 | 14.6 | 1423 | 28.9 | 381 | 0.076 |
+
+## Findings
+
+- **8-bit costs ~half the throughput and ~half the efficiency of Q4.** Qwen3-30B-A3B Q8 = **0.52×** Q4 tg/s (41 vs 79) at **0.49×** t/J; Hermes-14B Q8 = **0.63×** (30 vs 47) at 0.60× t/J. Decode is bandwidth-bound; the tax tracks the ~1.7–2× bytes/weight.
+- **FP8 can't beat this.** Same 8-bit weight-only path, no native XMX, fusions disabled → at best the Q8_0 zone, consistent with [#9](https://github.com/steveseguin/b70-optimization-lab/pull/9)'s ~34 tg/s FP8 (27B TP2). FP8's only value on B70 is VRAM/context, never speed — and Q5_K_M/Q6_K already give that at better throughput.
+- **MoE beats dense** on speed *and* efficiency: 30B-A3B (3B-act) 79 tg/s vs dense-14B 47, at 2× the t/J. Buy active-params, not total-params.
+- **Two GPUs never help a fits-on-one model.** Hermes tg identical 1↔2 GPU at higher power; Qwen Q4 slightly worse on 2. `-sm layer` serialises — reserve dual-B70 for models that don't fit.
+- **Prefill is quant-insensitive** (~1200–1460 pp t/s, compute-bound).
+
+**Bottom line:** Q4_K_M is the serving default; 8-bit (Q8_0 *or* FP8) is a ~2×-cost quality-ceiling point, and on B70 Q8_0-SYCL is the mature way to get it, not FP8.

--- a/community/bosd-trx50-2xb70-q8-vs-q4/STATUS.md
+++ b/community/bosd-trx50-2xb70-q8-vs-q4/STATUS.md
@@ -1,0 +1,66 @@
+# Q8_0 vs Q4_K_M cost on 2× B70 (and the ceiling it puts on FP8)
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `B70-tested` (on contributor's 2× B70, **not** the reference lab → not `B70-verified`) |
+| Patch review status | n/a — benchmark result, no source patch |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no until re-run in the reference lab |
+
+## Provenance
+
+- Contributor: **bosd** (`github.com/bosd`)
+- Source PR or URL: this PR; full data + raw JSON in `bosd/trx50-arc-b70-benchmarks`
+- Commits: llama.cpp **SYCL** build (`build-sycl`, `icx/icpx`, oneAPI 2026.0, `-DGGML_SYCL_F16=ON`); exact upstream commit not pinned in notes → `unknown`
+- Right-to-submit statement present: yes — own measurements, Unlicense-compatible
+- Third-party material and attribution: none
+
+## Claim
+
+On 2× Arc Pro B70, **Q8_0 delivers ~0.5–0.6× the decode throughput and ~0.5–0.6× the tokens/joule of Q4_K_M** (Qwen3-30B-A3B: 41.2 vs 79.2 tg/s; Hermes-4-14B: 29.8 vs 47.5 tg/s), which bounds weight-only FP8 on B70 to at best the Q8_0 operating point.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | 2× Intel **Arc Pro B70** (Battlemage G31, `8086:e223`, 32 GB) on ASRock TRX50 WS, Threadripper 9960X (24c/48t) |
+| OS / kernel | Fedora Server 44, kernel **7.0.10** |
+| GPU driver (`i915`/`xe`) and version | **`xe`** |
+| compute-runtime / level-zero | NEO **26.18.38308.1** |
+| Engine / image and exact version | llama.cpp **SYCL** `llama-bench`, oneAPI 2026.0, `-DGGML_SYCL_F16=ON`; commit `unknown` (see linked repo) |
+| Model repo and revision | Qwen3-30B-A3B (MoE 3B-act) and Hermes-4-14B (dense, qwen3), Q4_K_M + Q8_0 GGUFs |
+| Quantization (weights / KV / activations) | weights **Q4_K_M / Q8_0**; KV f16; no activation quant |
+| Command and environment variables | `llama-bench -p 512 -n 128`; `GGML_SYCL_DISABLE_OPT=1`; 1-GPU vs 2-GPU `-sm layer` |
+| Prompt / output / context lengths, concurrency | pp512 / tg128; **concurrency 1** (single-stream) |
+| Cache and speculation policy | cold, `llama-bench` defaults; no speculative decoding |
+| Metric definition, repeats, dispersion, TTFT | tg128 & pp512 t/s (llama-bench default 5 repeats); `t/J(wall) = tg128 ÷ avg wall W` via **Shelly Plug S Gen3**; GPU-W (xe counter) noisy over the short window → wall-W authoritative; TTFT n/a |
+| Logs / JSON / durable links | https://github.com/bosd/trx50-arc-b70-benchmarks/blob/master/results/q8-vs-q4-b70.md (+ `raw/`, `bench-q8q4.sh`) |
+
+## Reference Lab Environment
+
+Nothing executed in the reference lab — this is a contributor submission measured on the contributor's own 2× B70.
+
+## What Was Actually Run Here
+
+Nothing in the reference lab. All numbers are from the contributor's TRX50 host (above), `llama-bench` with Shelly wall-power sampling; scripts and raw JSON linked.
+
+## Findings
+
+- **8-bit costs ~2× vs Q4** on both models: Qwen3-30B-A3B Q8 = 0.52× Q4 tg/s at 0.49× t/J; Hermes-4-14B Q8 = 0.63× Q4 tg/s at 0.60× t/J. Decode is bandwidth-bound; the slowdown tracks the ~1.7–2× bytes/weight.
+- **This bounds FP8 on B70.** Battlemage Xe2 XMX has **no native FP8** (INT2/4/8, FP16, BF16, TF32 only), so vLLM FP8 is weight-only (`XPUFP8ScaledMMLinearKernel`, RMSNorm/Activation fusions disabled). FP8 therefore lands at best in the Q8_0 zone — consistent with PR #9's ~34 tg/s FP8. **FP8's only value on B70 is VRAM/context, not speed.**
+- **MoE beats dense** on speed and efficiency (30B-A3B 79 tg/s > dense 14B 47). **2 GPUs never help a fits-on-one model** (`-sm layer` serialises; identical or worse tg at higher power). **Prefill is quant-insensitive** (~1200–1460 pp t/s, compute-bound).
+
+## Known Issues
+
+None found — result-only submission, no source to review.
+
+## Open Questions For The Contributor
+
+To raise to `B70-verified`: re-run `bench-q8q4.sh` on the reference lab's B70(s) with the maintainer's storage layout, and confirm the Q8/Q4 tg ratio (~0.5–0.6×) holds on the reference kernel/runtime.
+
+## Disposition
+
+Stays `community/` as `B70-tested` (contributor hardware). Promote toward `results/` only after a reference-lab re-run. Directly complements the FP8 thread in PR #9.

--- a/community/bosd-trx50-sycl-build-freshness-and-multigpu-regression/README.md
+++ b/community/bosd-trx50-sycl-build-freshness-and-multigpu-regression/README.md
@@ -1,0 +1,31 @@
+# SYCL build freshness (+27% decode) & the `-sm layer` multi-GPU regression
+
+**Contributor:** bosd · **Evidence:** `B70-tested` (contributor 2× B70 — see [`STATUS.md`](STATUS.md)).
+Raw data: **https://github.com/bosd/trx50-arc-b70-benchmarks**
+
+Two build-version effects found while chasing a single-B70 throughput gap and re-testing multi-GPU across a kernel update. Both on the same 2× Arc Pro B70 / TRX50 host; llama.cpp SYCL (`icx/icpx`, oneAPI 2026.0, `GGML_SYCL_F16=ON`).
+
+## 1. Build freshness is worth ~27% decode (single B70)
+
+Qwen3-30B-A3B-Instruct-2507 UD-Q4_K_XL, `llama-bench -p 512 -n 128`, fa-on:
+
+| llama.cpp build | tg128 | pp512 |
+|---|---|---|
+| b9455 (Jun 1) | 84.7 | 1287 |
+| dee2a84 (Jul 27) | 97.0 | 1383 |
+| **11924d4 (Aug 2, master)** | **100.6** | 1393 |
+
+The older Qwen3-30B-A3B Q4_K_M on b9455 was 79 tg/s → newer model/quant ~+7%, **build freshness the other +19%**. ~100 tg/s looks like the current upstream ceiling here. **Takeaway: keep the SYCL build current — it's free throughput.**
+
+## 2. The 2-GPU `-sm layer` crash is a build regression, not the kernel
+
+Qwen3.6-35B-A3B Q8_0 across two B70s (`--device SYCL1,SYCL2 -sm layer`):
+
+| build | kernel 7.0.10 | kernel 7.1.5 |
+|---|---|---|
+| **b9455** | ✅ works (~26 tg/s — our published Q8 2-GPU numbers) | ✅ works (~26 tg/s) |
+| dee2a84 / 11924d4 | ❌ SIGABRT `ggml_backend_tensor_copy` | ❌ same SIGABRT |
+
+Updating the host kernel 7.0.10 → 7.1.5 changed nothing: b9455 works on both, the newer builds crash on both. So the crash is a **regression in `b9455..dee2a84`** on the SYCL device-to-device tensor-copy path — a **build** regression, likely the same class as [#23797](https://github.com/ggml-org/llama.cpp/issues/23797). This gives a **good/bad build window for a `git bisect`**.
+
+**Supporting single-card numbers** (llama-bench, fa-on): gemma-4-26B-A4B UD-Q8_K_XL 26.8 tg/s (B70, base/no-spec); Laguna-XS-2.1 (poolside 30B-A3B coder) Q4_K_M **87.7 (B70) / 72.5 (B60)**.

--- a/community/bosd-trx50-sycl-build-freshness-and-multigpu-regression/STATUS.md
+++ b/community/bosd-trx50-sycl-build-freshness-and-multigpu-regression/STATUS.md
@@ -1,0 +1,83 @@
+# SYCL build freshness (+27% single-B70 decode) and the `-sm layer` multi-GPU regression (b9455→dee2a84)
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `B70-tested` (on contributor's 2× B70, not the reference lab) |
+| Patch review status | n/a — benchmark + bisect, no source patch |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no until re-run in the reference lab |
+
+## Provenance
+
+- Contributor: **bosd** (`github.com/bosd`)
+- Source PR or URL: this PR; raw data in `bosd/trx50-arc-b70-benchmarks`
+- Commits under test: llama.cpp **`b9455`** (Jun 1), **`dee2a84`** (Jul 27), **`11924d4`** (Aug 2, master) — all SYCL, `icx/icpx` oneAPI 2026.0, `-DGGML_SYCL=ON -DGGML_SYCL_F16=ON`, Release
+- Right-to-submit statement present: yes
+- Third-party material and attribution: none
+
+## Claim
+
+Two build-version effects on the same 2× B70 hardware: **(1)** single-GPU decode of Qwen3-30B-A3B-2507 rises **79 → 100.6 tg/s (+27%) purely from newer llama.cpp builds**; **(2)** the 2-GPU `-sm layer` `ggml_backend_tensor_copy` SIGABRT is a **regression between `b9455` and `dee2a84`**, reproducible on **both** kernel 7.0.10 and 7.1.5 — i.e. it is a build regression, not kernel-gated.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | 2× Intel **Arc Pro B70** (Battlemage G31, `8086:e223`, 32 GB) + 1× B60 (24 GB), ASRock TRX50 WS, Threadripper 9960X |
+| OS / kernel | Fedora Server 44; tested on **kernel 7.0.10** and **7.1.5** |
+| GPU driver (`i915`/`xe`) and version | **`xe`** |
+| compute-runtime / level-zero | NEO **26.18.38308.1** |
+| Engine / image and exact version | llama.cpp SYCL, oneAPI 2026.0; commits **b9455 / dee2a84 / 11924d4** |
+| Model repo and revision | Qwen3-30B-A3B-Instruct-2507 (UD-Q4_K_XL); Qwen3.6-35B-A3B (Q8_0, MTP-GGUF) for the 2-GPU test |
+| Quantization (weights / KV / activations) | UD-Q4_K_XL / Q8_0; KV f16; no activation quant |
+| Command and environment variables | single-GPU: `llama-bench -p 512 -n 128 -sm none -mg 1 -fa 0,1`; 2-GPU: `llama-cli --device SYCL1,SYCL2 -sm layer -ngl 99 -fa 0`; `GGML_SYCL_DISABLE_OPT=1` |
+| Prompt / output / context lengths, concurrency | pp512 / tg128; concurrency 1 |
+| Cache and speculation policy | cold, `llama-bench` defaults; no speculation |
+| Metric definition, repeats, dispersion, TTFT | tg128 & pp512 t/s (llama-bench default 5 repeats); TTFT n/a |
+| Logs / JSON / durable links | https://github.com/bosd/trx50-arc-b70-benchmarks |
+
+## Reference Lab Environment
+
+Nothing executed in the reference lab — contributor's 2× B70.
+
+## What Was Actually Run Here
+
+`llama-bench` single-GPU across the three build commits; and a `llama-cli --device SYCL1,SYCL2 -sm layer` generation on each build across two kernels, watching for the crash.
+
+## Findings
+
+**(1) Build freshness — Qwen3-30B-A3B-Instruct-2507 UD-Q4_K_XL, single B70, `-p 512 -n 128`, fa-on:**
+
+| build | tg128 | pp512 |
+| --- | --- | --- |
+| b9455 (Jun 1) | 84.7 | 1287 |
+| dee2a84 (Jul 27) | 97.0 | 1383 |
+| **11924d4 (Aug 2 master)** | **100.6** | 1393 |
+
+Older Qwen3-30B-A3B Q4_K_M on b9455 was 79 → so model/quant added ~+7%, **build freshness the other +19%**. 100.6 appears to be the current upstream ceiling for this config.
+
+**(2) `-sm layer` 2-GPU regression — Qwen3.6-35B-A3B Q8_0, two B70s:**
+
+| build | kernel 7.0.10 | kernel 7.1.5 |
+| --- | --- | --- |
+| **b9455** | ✅ works (~26 tg/s, our published Q8 2-GPU numbers) | ✅ works (~26 tg/s) |
+| dee2a84 / 11924d4 | ❌ SIGABRT `ggml_backend_tensor_copy` (first decode) | ❌ same SIGABRT |
+
+The crash is a **regression in the window `b9455..dee2a84`**, on the SYCL `-sm layer` device-to-device tensor-copy path, **independent of kernel** (fails on both 7.0.10 and 7.1.5; b9455 works on both). Likely the same class as **[ggml-org/llama.cpp#23797](https://github.com/ggml-org/llama.cpp/issues/23797)** — this narrows a good-vs-bad build window for a bisect.
+
+**Supporting single-card numbers (llama-bench, fa-on):** gemma-4-26B-A4B UD-Q8_K_XL = 26.8 tg/s (B70, b9455, base/no-spec); Laguna-XS-2.1 (poolside 30B-A3B) Q4_K_M = **87.7 (B70) / 72.5 (B60)** on 11924d4.
+
+## Known Issues
+
+None found — measurement + bisect, no source to review.
+
+## Open Questions For The Contributor
+
+To raise to `B70-verified`: reference-lab re-run confirming (a) the ~100 tg/s single-B70 ceiling on a current build, and (b) that `-sm layer` works on a b9455-era build but SIGABRTs on a current build. A `git bisect` in the `b9455..dee2a84` window would pin the exact regressing commit for #23797.
+
+## Disposition
+
+Stays `community/` as `B70-tested`. Most useful immediately as **#23797 bisect input** (good/bad build window) and as a "keep your SYCL build current" data point (+27% for free).


### PR DESCRIPTION
Three `community/` result packets from a **2× Arc Pro B70** TRX50 workstation (Fedora 44, kernel 7.0.10, `xe`, llama.cpp-SYCL / oneAPI 2026.0). Each has a `STATUS.md` (from `STATUS-TEMPLATE.md`), a short `README.md`, and durable links to raw data + scripts in [`bosd/trx50-arc-b70-benchmarks`](https://github.com/bosd/trx50-arc-b70-benchmarks). These consolidate findings I'd previously only left as comments on #9 / #13 / #14.

**Evidence level: `B70-tested`** — measured on my own 2× B70, *not* your reference lab, so promote only after a lab re-run. The B60 column in packet 2 is `community-reported` by definition (no B60 in the reference lab).

### Packets
1. **`bosd-trx50-2xb70-q8-vs-q4`** — Q8_0 = **~0.5–0.6× Q4_K_M** tg/s *and* t/J on the B70 (Qwen3-30B-A3B 41 vs 79; Hermes-14B 30 vs 47). Since Xe2 XMX has no native FP8, weight-only FP8 is bounded to this Q8_0 zone — matches #9's ~34 tg/s FP8. Directly complements the FP8 thread.
2. **`bosd-trx50-2xb70-b60-vs-b70`** — single-card head-to-head: B60 ≈ **78–88%** of B70 generation at **~56–63%** power → **1.2–1.6× tokens/joule**; B60 also POSTs where the G31 doesn't. CONTRIBUTING welcomes B60 work; this is data you can't verify locally.
3. **`bosd-trx50-2xb70-mtp-net-loss`** — MTP-on is **5–10% slower** than MTP-off for single-stream MoE decode despite ~70% acceptance. Supplies the **MTP-off baseline #14 lacked**. Same model is **+43% on 2× AMD 7800 XT (ROCm)** with matching MTP-off baselines → it's the **SYCL backend**, not B70 hardware. *(AMD numbers + the Q8/2-GPU confirmation are @dominick253's, from #14, credited in the packet.)*

No weights/secrets included. Happy to adjust structure, split into separate PRs, or add fields if anything's missing from the verification checklist.
