### PR TITLE
field-reports/bosd: mixed B60+B70 split measurement + single-B70 batched throughput

### DIFF
--- a/community/field-reports/bosd/trx50-2xb70/b60-vs-b70.md
+++ b/community/field-reports/bosd/trx50-2xb70/b60-vs-b70.md
@@ -29,6 +29,22 @@ Pinned contributor write-up:
 
 Power is reported as the per-card `xe` energy counter rather than wall power.
 
+## Reported mixed B60 + B70 layer split
+
+A separate run supplies a mixed-split measurement absent from the single-card
+table above. Llama-3.3-Nemotron-Super-49B (dense, Q4_K_M, 28 GiB) across a
+B60 + B70 pair with llama.cpp `-sm layer`:
+
+| Config | tg128 |
+| --- | --- |
+| 49B dense, B60 + B70 mixed `-sm layer` | 13.4 tok/s |
+
+The contributor reports the pair runs at roughly B60-class speed: the slower,
+smaller card sets the pace and the 24/32 GB asymmetry leaves the B70's extra
+VRAM unused. Interpretation is the contributor's; a uniform 2× B70 control for
+the same model was not run on this host, so this is one measured mixed-split
+point rather than a controlled A/B against a matched pair.
+
 ## Maintainer review
 
 For the three rows with both GPUs measured:

--- a/community/field-reports/bosd/trx50-2xb70/sycl-build-and-layer-split.md
+++ b/community/field-reports/bosd/trx50-2xb70/sycl-build-and-layer-split.md
@@ -52,3 +52,26 @@ the regressing commit or exclude other build/runtime differences.
 The narrow useful output is a community-supplied candidate window from
 `b9455`/`8e6fff84` to `dee2a84`/`dee2a846` for investigation alongside
 [`ggml-org/llama.cpp#23797`](https://github.com/ggml-org/llama.cpp/issues/23797).
+
+## Reported batched throughput at concurrency
+
+Separate from the single-stream and two-GPU results above, the contributor ran
+`llama-batched-bench` on one B70 to measure aggregate throughput versus parallel
+request count. Qwen3-30B-A3B-Instruct-2507 UD-Q4_K_XL, `-npp 128 -ntg 128 -fa 1`,
+build `11924d4`:
+
+| Parallel (npl) | Generation tok/s (aggregate) | Total tok/s (incl prompt) |
+| --- | --- | --- |
+| 1 | 65.7 | 115.8 |
+| 4 | 110.7 | 199.8 |
+| 16 | 202.5 | 354.1 |
+| 32 | 299.8 | 495.2 |
+| 50 | 382.7 | 601.5 |
+
+The contributor offers this as one single-B70 data point against community
+reports of roughly 370 tok/s (peaks near 550) at fifty-way concurrency: here
+382.7 generation / 601.5 total tok/s on plain llama.cpp continuous batching, for
+a 3B-active MoE. It is not a controlled reproduction of any specific third-party
+report — model revision and engine differ, and a dense model or vLLM-XPU would
+shift the prompt/generation mix — but the batched-throughput ceiling on one card
+is in that range. Prompt processing held near 1400 tok/s across the sweep.


### PR DESCRIPTION
Follow-up to the merged field report (thanks for adopting + reorganizing it). Two additions to `community/field-reports/bosd/trx50-2xb70/`, in the same reported/measured style:

1. **`b60-vs-b70.md` — mixed B60+B70 layer split, now measured.** Your maintainer review noted the mixed-split recommendation "was not measured in this table." A separate run supplies it: **Llama-3.3-Nemotron-Super-49B (dense, Q4_K_M) across a B60+B70 `-sm layer` pair = 13.4 tok/s** — the pair runs at ~B60-class speed (slower card sets the pace; 24/32 GB asymmetry wastes the B70 VRAM). No matched 2× B70 control was run, so it's one measured point, not a controlled A/B — flagged as such.
2. **`sycl-build-and-layer-split.md` — single-B70 batched throughput.** `llama-batched-bench`, Qwen3-30B-A3B-2507 on one B70: **382.7 gen / 601.5 total tok/s at 50-way concurrency** (plain llama.cpp continuous batching, 3B-active MoE). Offered as an independent data point for community ~370-550 tok/s concurrency reports; different model/engine than any specific third-party claim, noted.

Same evidence level (contributor 2× B70, not the reference lab). Happy to adjust wording or split further.
