### PR TITLE
docs: record USB recovery and verified Qwen storage

### DIFF
--- a/CURRENT.md
+++ b/CURRENT.md
@@ -1,6 +1,6 @@
 # Current Workspace State
 
-Last reviewed: **2026-07-27**
+Last reviewed: **2026-08-08**
 
 ## Authority And Update Rule
 
@@ -81,9 +81,12 @@ both units were stopped before DeepSeek testing and remain stopped.
 The authorized 2026-07-15 host reboot recovered all four B70s: discovery,
 per-device allocation/compute, runtime status, and a four-rank exact XCCL gate
 pass, all four external links report Gen4 x16, and ASPM is `default`. The
-external `/mnt/usb-models` volume did not automount, but the active K160 model
-is on `/mnt/fast-ai` and the record launcher maps oneCCL from the DeepSeek
-virtual environment first.
+external `/mnt/usb-models` volume does not automount. It was recovered from an
+NTFS mirror mismatch and mounted read/write on 2026-08-08; its inventory and
+maintenance warning are recorded in
+[`docs/reference-lab-storage.md`](docs/reference-lab-storage.md). The active
+K160 model is on `/mnt/fast-ai`, and the record launcher maps oneCCL from the
+DeepSeek virtual environment first.
 
 The unauthenticated LAN front door is intentional for this private network. Do
 not silently add authentication or change its exposure policy.

--- a/docs/local-ops.md
+++ b/docs/local-ops.md
@@ -65,7 +65,7 @@ storage and archived benchmark artifacts:
 /mnt/usb-models
 ```
 
-Device identity observed at setup:
+Device identity observed at setup and revalidated on 2026-08-08:
 
 - block device: `/dev/sda2`;
 - filesystem: `ntfs3`;
@@ -76,11 +76,24 @@ Device identity observed at setup:
   - `/mnt/usb-models/bench-results`;
   - `/mnt/usb-models/models`.
 
+The volume does not auto-mount. On 2026-08-08, apparent missing models were an
+unmounted-drive symptom, followed by an NTFS `$MFT`/`$MFTMirr` mismatch. The
+tree was inventoried read-only before repair, SMART reported no media errors,
+and `ntfsfix` restored read/write mounting. See
+[`reference-lab-storage.md`](reference-lab-storage.md) and the drive-local
+`.storage-health/README.md` before filesystem maintenance. A Windows
+`chkdsk /f` plus two reboots remains required at the next safe maintenance
+window.
+
 Use the internal NVMe cache for active benchmark hot paths unless disk pressure
 or model count makes that impractical. Use the USB drive for alternate model
 variants, overflow downloads, and archived large artifacts. Do not commit model
 weights, USB paths full of artifacts, or generated cache contents to Git; record
 only the model identity, local path, checksum if useful, and result summaries.
+Use `/mnt/usb-models/llm-cache/hf` as `HF_HOME` for new large Hugging Face
+downloads and `/mnt/usb-models/models/<model-family>/` for pinned standalone
+GGUFs. Preserve the older `/mnt/usb-models/hf-cache` until it has been audited;
+do not combine the two cache trees mechanically.
 
 For Laguna S 2.1, the stricter policy established on 2026-07-23 overrides the
 general overflow rule: the external Corsair `ntfs3` volume is backup-only.

--- a/docs/local-ops.md
+++ b/docs/local-ops.md
@@ -68,7 +68,8 @@ storage and archived benchmark artifacts:
 Device identity observed at setup and revalidated on 2026-08-08:
 
 - block device: `/dev/sda2`;
-- filesystem: `ntfs3`;
+- filesystem: NTFS (normally mounted through `ntfs-3g`, reported as
+  `fuseblk`; kernel `ntfs3` was used only for the read-only recovery mount);
 - label: `CorsairExternal`;
 - mount path: `/mnt/usb-models`;
 - created folders:

--- a/docs/reference-lab-storage.md
+++ b/docs/reference-lab-storage.md
@@ -94,6 +94,21 @@ been reconciled into `llm-cache/hf/`. Do not merge or delete cache trees by
 filename alone. The drive-local `/mnt/usb-models/MODEL-STORAGE.md` records the
 same convention for operators working outside this repository.
 
+Verified or repaired on 2026-08-08:
+
+| Model | Location | Verification |
+| --- | --- | --- |
+| Qwen3.6-27B MTP Q4_K_M | `models/qwen36-27b-mtp-gguf/Qwen3.6-27B-Q4_K_M.gguf` | 17,106,773,120 bytes; published SHA-256 match |
+| Qwen3.6-35B-A3B-FP8 | `llm-cache/hf/hub/models--Qwen--Qwen3.6-35B-A3B-FP8` | pinned `95a723d0...`; 56/56 remote-aware checksum pass |
+| Qwen3.6-27B BF16 backup | `llm-models/Qwen-Qwen3.6-27B-6a9e13bd6` | 55.59 GB; full source checksum and 15/15 safetensors header pass |
+| Qwen3.6-35B-A3B BF16 backup | `llm-models/Qwen-Qwen3.6-35B-A3B-995ad96e` | 71.93 GB; repaired, quarantined old mismatches, full source checksum and 26/26 header pass |
+
+Stable aliases under `/mnt/fast-ai/llm-models/` are
+`qwen3.6-27b-mtp-gguf`, `qwen3.6-35b-a3b-fp8-qwen`,
+`qwen3.6-27b-bf16-qwen`, and `qwen3.6-35b-a3b-bf16-qwen`. The first two
+require the USB mount; the BF16 aliases point to the internal sources, whose
+verified backups are on USB.
+
 ## Old Paths Still Work
 
 Each relocated model left a symlink behind at its original NVMe path:

--- a/docs/reference-lab-storage.md
+++ b/docs/reference-lab-storage.md
@@ -13,7 +13,7 @@ where the weights happen to live.
 **For the maintainer:** this is the map of what sits where, and which storage
 has to be mounted before a lane will run.
 
-Last verified: 2026-07-25.
+Last verified: 2026-08-08.
 
 ## Internal NVMe
 
@@ -37,6 +37,20 @@ which had reached 98% full.
 
 `/dev/sda2`, 3.6 TB NTFS, volume label `CorsairExternal`, mounted at
 `/mnt/usb-models`.
+
+On 2026-08-08 the drive was still physically present but unmounted. An NTFS
+`$MFT`/`$MFTMirr` record-3 mismatch prevented `ntfs-3g` from mounting it. The
+model tree was first inventoried through a read-only kernel `ntfs3` mount, SMART
+reported no media/data-integrity errors, and `ntfsfix` then repaired the mirror
+record and reset the NTFS journal. The drive is mounted read/write again with
+about 1.8 TB free. The pre-repair inventory and key-model checksums are under
+`/mnt/fast-ai/storage-recovery/`; the drive-local recovery record is
+`/mnt/usb-models/.storage-health/README.md`.
+
+`ntfsfix` is not a replacement for Windows filesystem repair. At the next safe
+maintenance window, cleanly unmount the drive, attach it to Windows, run
+`chkdsk /f`, and reboot Windows twice before considering the NTFS metadata
+fully checked.
 
 **This drive does not auto-mount.** If it is not mounted, every path below
 fails with a "no such file or directory" error that looks like missing data
@@ -66,6 +80,19 @@ Already resident before that move: `qwen3.6-27b-fp8-vrfai`,
 `gemma4-26b-a4b-it-eagle3-gguf`, `gemma4-26b-a4b-it-qat-gguf`,
 `gemma4-e4b-it-gguf`. The drive also holds an `hf-cache/` tree with further
 Qwen3.6-27B quantizations.
+
+Use the following top-level conventions for new material:
+
+- `llm-cache/hf/` is the canonical Hugging Face cache;
+- `llm-models/` holds complete directly runnable model directories;
+- `models/` holds standalone GGUF files and source-specific groupings;
+- `bench-results/` and `llm-optimization-artifacts/` hold evidence, not model
+  weights.
+
+The older `hf-cache/` tree is intentionally preserved until its snapshots have
+been reconciled into `llm-cache/hf/`. Do not merge or delete cache trees by
+filename alone. The drive-local `/mnt/usb-models/MODEL-STORAGE.md` records the
+same convention for operators working outside this repository.
 
 ## Old Paths Still Work
 

--- a/notes/2026-08-08-corsair-usb-recovery-and-model-restoration.md
+++ b/notes/2026-08-08-corsair-usb-recovery-and-model-restoration.md
@@ -1,0 +1,46 @@
+# Corsair USB recovery and model restoration
+
+Date: 2026-08-08
+
+## Why the models appeared missing
+
+The 4 TB `CorsairExternal` USB drive was physically present as `/dev/sda2` but
+was not mounted. Its NTFS `$MFTMirr` record 3 did not match `$MFT`, so the normal
+`ntfs-3g` mount failed. The historical model directories had not disappeared.
+
+## Fail-safe recovery
+
+1. Mounted the volume read-only with kernel `ntfs3` and inventoried the model
+   tree before making filesystem changes.
+2. Saved the 183,052-entry inventory at
+   `/mnt/fast-ai/storage-recovery/corsair-external-model-tree-pre-repair-20260808.tsv`.
+   SHA-256:
+   `98f90fdfd1e6ea4de30ba85bd812ede278830821a654cd4109796c954e8ecf8d`.
+3. Hashed the important resident Qwen GGUFs into
+   `/mnt/fast-ai/storage-recovery/corsair-external-key-model-hashes-pre-repair-20260808.sha256`.
+4. Checked the NVMe device through the ASMedia bridge. SMART passed with zero
+   reported media/data-integrity errors and zero error-log entries.
+5. Unmounted the read-only filesystem, ran `ntfsfix`, and mounted it read/write
+   with `ntfs-3g`. A write-and-sync check passed. About 1.8 TB was free.
+
+Windows `chkdsk /f` followed by two Windows reboots is still required at the
+next safe maintenance window. `ntfsfix` repaired the immediate Linux-mount
+blocker but is not a complete NTFS consistency check.
+
+## Storage convention
+
+The canonical large-download cache is `/mnt/usb-models/llm-cache/hf`.
+Standalone GGUFs belong under `/mnt/usb-models/models/<model-family>/`, and
+complete direct model directories belong under `/mnt/usb-models/llm-models/`.
+The older `/mnt/usb-models/hf-cache` is preserved pending reconciliation.
+
+The external SMB host `DESKTOP-ALIENWA` was reachable at `10.0.0.9`, but guest
+access was denied and no local SMB credential was available. It was not needed
+because the recovered USB had sufficient capacity. No credential was guessed
+or copied from an unrelated service.
+
+## Host changes
+
+Installed `smartmontools`, `cifs-utils`, and `smbclient` for storage diagnosis
+and future authenticated backup work. No model or benchmark service was
+started during recovery.

--- a/notes/2026-08-08-corsair-usb-recovery-and-model-restoration.md
+++ b/notes/2026-08-08-corsair-usb-recovery-and-model-restoration.md
@@ -44,3 +44,34 @@ or copied from an unrelated service.
 Installed `smartmontools`, `cifs-utils`, and `smbclient` for storage diagnosis
 and future authenticated backup work. No model or benchmark service was
 started during recovery.
+
+## BF16 backup repair
+
+The historical USB copy of `Qwen-Qwen3.6-35B-A3B-995ad96e` had all 26 shard
+names but 13 files were truncated. A verified append restored 27.0 GB. A full
+content comparison then found three additional same-size mismatches in shards
+1, 5, and 6. Those bad copies and their hashes were preserved under the model's
+`.quarantine/20260808-content-mismatch/` directory before clean source copies
+were installed. The final full `rsync -nrc` comparison against the 71.93 GB
+internal source emitted no differences.
+
+## Restored contributor models
+
+The official `unsloth/Qwen3.6-27B-MTP-GGUF` Q4_K_M file was downloaded at
+pinned repository commit `5cb35eb3dcbf52dbce5f87dbc64df6aaffadcace` to
+`/mnt/usb-models/models/qwen36-27b-mtp-gguf/Qwen3.6-27B-Q4_K_M.gguf`.
+The completed size is `17,106,773,120` bytes and its SHA-256 is
+`a7cbd3ecc0e3f9b333edee61ae66bc87ed713c5d49587a8355814722ed329e0f`,
+matching the published artifact.
+
+The complete `Qwen/Qwen3.6-27B` BF16 snapshot
+`6a9e13bd6fc8f0983b9b99948120bc37f49c13e9` was also backed up from the
+internal Hugging Face cache to
+`/mnt/usb-models/llm-models/Qwen-Qwen3.6-27B-6a9e13bd6/`. Cache symlinks were
+dereferenced so the 55.59 GB backup is self-contained. A full `rsync -nrcL`
+comparison emitted no differences across all 15 weight shards and support
+files.
+
+Safetensors header parsing also passed for both BF16 backups: 26 shards and
+1,045 tensor entries for 35B-A3B, and 15 shards and 1,199 tensor entries for
+27B.

--- a/notes/2026-08-08-corsair-usb-recovery-and-model-restoration.md
+++ b/notes/2026-08-08-corsair-usb-recovery-and-model-restoration.md
@@ -75,3 +75,22 @@ files.
 Safetensors header parsing also passed for both BF16 backups: 26 shards and
 1,045 tensor entries for 35B-A3B, and 15 shards and 1,199 tensor entries for
 27B.
+
+The exact `Qwen/Qwen3.6-35B-A3B-FP8` snapshot was downloaded to the canonical
+USB Hugging Face cache at pinned revision
+`95a723d08a9490559dae23d0cff1d9466213d989`. A post-download dry-run required
+0 files and 0 bytes. `hf cache verify --fail-on-missing-files` checked all 56
+remote files. The snapshot contains 40 layer shards, 42 indexed safetensors,
+no missing indexed file, and 64,196 tensor entries; its total size is
+`37,493,015,668` bytes. Config metadata identifies FP8 `e4m3` weights with
+dynamic activation scaling.
+
+A 56-entry independent SHA-256 manifest is stored at
+`/mnt/fast-ai/storage-recovery/qwen36-35b-a3b-fp8-95a723d08a9490559dae23d0cff1d9466213d989.sha256`
+and copied to USB `.storage-health/`. Both manifest copies hash to
+`cc0d1f15345146beb453d10a103968ede1f2db1de43b3cfcba35dcef12d991ae`.
+
+Stable aliases were added under `/mnt/fast-ai/llm-models/` for the exact GGUF,
+exact FP8 cache repository, and the two internal BF16 sources. The USB-backed
+GGUF and FP8 aliases intentionally fail when the non-automounted drive is not
+present rather than falling back to a different model.


### PR DESCRIPTION
## Summary
- document the 2026-08-08 Corsair NTFS recovery and required Windows chkdsk follow-up
- record the canonical USB model/cache layout and stable aliases
- record exact Qwen Q4_K_M and FP8 revisions, sizes, checksums, and validation gates
- record repaired and checksum-verified 27B/35B BF16 backups

## Validation
- git diff --check
- Q4_K_M published SHA-256 match
- FP8 pinned dry-run: 0 files / 0 bytes
- FP8 remote-aware cache verification: 56/56
- FP8 independent SHA-256 recheck: 56/56
- BF16 full source checksum comparisons and safetensors header gates
- USB remained read/write with no I/O/reset errors during sustained writes

No model service or benchmark was started.