### PR TITLE
Record clean post-community reboot state

### DIFF
--- a/CURRENT.md
+++ b/CURRENT.md
@@ -21,6 +21,17 @@ was closed on 2026-07-13. The last configured role was the temporary Gemma 4
 in [`docs/gemma4-26b-q8-service-runbook.md`](docs/gemma4-26b-q8-service-runbook.md).
 Confirm the endpoint and process state before relying on this observation.
 
+The 2026-08-08 community-validation maintenance window ended with a clean host
+reboot at 17:05 local. All four B70s enumerate and pass per-device XPU
+allocation/matrix compute. All four external root/peer paths are Gen4 x16, all
+four root-port target fields are back at `0004`, and all relevant AER totals are
+zero. The five tracked Gemma/MiniMax/model-slot units are disabled and inactive;
+no model container, worker, or inference listener is running. The external USB
+model volume was remounted read/write at `/mnt/usb-models`, and the stable Qwen
+aliases resolve. The community B2 runtime is not loaded in Docker; its verified
+recoverable archive remains on USB. The maintenance evidence is linked from
+[`community/dominick253-qwen36-35b-fp8-b2-tp2/validation/2026-08-08-pcie-link-sensitivity.md`](community/dominick253-qwen36-35b-fp8-b2-tp2/validation/2026-08-08-pcie-link-sensitivity.md).
+
 No DeepSeek service is currently running. The promoted DSpark7 sharded target-
 argmax record service was stopped cleanly after three strict suites and the
 final exact canary. Its evidence is

--- a/community/dominick253-qwen36-35b-fp8-b2-tp2/validation/2026-08-08-pcie-link-sensitivity.md
+++ b/community/dominick253-qwen36-35b-fp8-b2-tp2/validation/2026-08-08-pcie-link-sensitivity.md
@@ -69,11 +69,17 @@ compute passed. After the A2 model start, both root-port target-speed fields
 read `0003`. A post-teardown attempt to restore `0004` persisted for two
 seconds, then both fields returned to `0003` again without retraining the live
 links; the component responsible was not identified. No further register
-writes were attempted. The final
-durable state is 16.0 GT/s x16 at both root and peer ends, root target fields
-`0003`, all four relevant root/peer AER correctable, nonfatal, and fatal totals
-at zero, and no inference container, worker, or listener. The final-state file
-in the external manifest records this distinction.
+writes were attempted in that boot. The pre-reboot state remained 16.0 GT/s
+x16 at both root and peer ends, with root target fields `0003`, all relevant
+AER totals at zero, and no inference container, worker, or listener.
+
+A clean host reboot then restored all four B70 root-port target fields to their
+normal `0004` values. All four root/peer paths negotiated 16.0 GT/s x16, all
+AER totals remained zero, and a real allocation/matrix-compute check passed on
+all four B70s. Model services remained disabled and inactive. The USB model
+volume was remounted read/write and its Qwen aliases, FP8 snapshot, GGUF, and
+runtime archive were checked. The pre-reboot, post-reboot, and compute files in
+the external manifest preserve both states.
 
 ## Throughput observations
 
@@ -128,12 +134,12 @@ Raw artifacts are outside Git under:
 
 `/mnt/fast-ai/llm-optimization-artifacts/community-dominick253/qwen36-35b-fp8-b2-tp2/`
 
-The focused 17-entry manifest is
+The focused 20-entry manifest is
 `20260808-pcie-bandwidth-manifest.sha256`, whose SHA-256 is
-`5544e0316ec5f9ba6fb2a5363212951d84f04aa094b08a6e2cf80ccbbdef6780`.
+`182f182198a895e1a21262ab57ac7bc3bc2bdaea169436e185034daeb237fc92`.
 It covers benchmark JSON, the zero-valued counter series, container identity,
-link/AER state, saved registers, the post-A2 final host state, and both
-all-reduce rows.
+link/AER state, saved registers, the post-A2 state, the clean reboot gate, and
+both all-reduce rows.
 
 The contributor's faster rate remains valid only as contributor-host evidence.
 The current data close PCIe link bandwidth as the leading explanation; they do

--- a/docs/reference-lab-storage.md
+++ b/docs/reference-lab-storage.md
@@ -60,6 +60,11 @@ rather than a missing drive. Mount it first:
 sudo mount -t ntfs-3g -o rw,uid=1000,gid=1000,umask=022 /dev/sda2 /mnt/usb-models
 ```
 
+The 2026-08-08 17:05 maintenance reboot confirmed this behavior. The drive was
+remounted read/write with the command above; the four stable Qwen aliases,
+selected FP8 snapshot/config, 27B GGUF size, and archived B2 runtime size were
+then rechecked before the next model lane.
+
 Note that `mount -o remount,rw` does **not** work on this filesystem; ntfs-3g
 silently keeps the old mode and writes fail with a misleading `ENOENT`.
 Unmount and mount fresh instead.


### PR DESCRIPTION
## Summary

- records the clean reboot that restored all four B70 root target fields to 0004
- records Gen4 x16 on all four external paths, zero AER totals, and four-device XPU compute
- records disabled/inactive model services and the restored USB model mount
- extends the external PCIe evidence manifest from 17 to 20 verified entries
- updates CURRENT.md as the live-state authority

## Validation

- 20/20 external manifest entries verify
- all four B70s enumerate and pass real matrix compute
- all four external root/peer paths are Gen4 x16
- all root targets are 0004 and all relevant AER totals are zero
- five tracked model services are disabled/inactive
- USB Qwen aliases, FP8 config, GGUF size, and B2 runtime archive size checked
- local Markdown links and git diff check pass