### PR TITLE
Optimize Qwen3.6 27B Q8 TP2 target-only decode

### DIFF
--- a/notes/2026-08-14-qwen36-q8-tp2-40tps-pass1.md
+++ b/notes/2026-08-14-qwen36-q8-tp2-40tps-pass1.md
@@ -38,3 +38,27 @@ The short `n16` result is only a recovery check, not a headline benchmark. Raw l
 Further measurements will use low-intrusion `xpu-smi dump` sampling during ordinary unprofiled runs. Candidate changes must pass matched reversed-order A/B tests and exact output/quality gates before promotion.
 
 Already-rejected experiments will not be recycled as new work. These include root-barrier elision, Q8 scale broadcast, Q8 cache, VDR2/VDR8, the earlier column-split/block-remap attempt, and broad subgroup/workgroup sweeps. The next useful question is whether the remaining gap is predominantly HBM efficiency, cross-bridge collective latency, or host submission overhead.
+
+## Ordinary-run telemetry
+
+An uninstrumented `p64/n512/r1` run reached `35.862770 tok/s`. During its decode window both cards held their full `2,800 MHz` graphics clock. Average card power was about `181.86 W` and `188.58 W`, comfortably below the `275 W` limit. This rules out thermal, clock, and board-power throttling as the immediate limiter. The installed `xpu-smi` build returned `N/A` for HBM, EU, and PCIe throughput counters, so those unavailable fields are not interpreted.
+
+## Fused-kernel subgroup bracket
+
+The accepted binary was screened at 4, 8, 16, and 32 MMVQ subgroups using `p64/n128/r3`; the default 8-subgroup arm was repeated last:
+
+| Subgroups | Decode tok/s |
+| ---: | ---: |
+| 8, first control | 35.740543 |
+| 4 | 35.748434 |
+| 16 | 35.747355 |
+| 32 | 35.692427 |
+| 8, repeated control | 35.688574 |
+
+The entire bracket fits inside the observed drift. No subgroup setting is promoted.
+
+## Safe graph census and first candidate
+
+A count-only `p0/n1` census—without device timestamps or profiling barriers—confirmed `128` allreduces per token. All `128` reached the fused allreduce+residual+RMS+multiply path. The remaining Q8 matrix-vector shapes were the expected per-rank `3072x5120` and `8704x5120` families plus the `5120x124160` output head.
+
+The first source candidate is an opt-in dual-peer RMS reduction in the isolated `/mnt/fast-ai/src/llama.cpp-q8-tp2-40tps` tree. The incumbent path runs one root-GPU reduction kernel, then releases one RMS/Q8 kernel on each card. The candidate removes the root launch: each card independently reads the other 20 KiB partial and performs the ordered `p0+p1`, residual add, RMS, multiply, and Q8 handoff locally. It is disabled by default behind `GGML_SYCL_COMM_DUAL_PEER_RMS=1` and will be discarded unless matched throughput and exact-output gates pass.

--- a/notes/2026-08-14-qwen36-q8-tp2-40tps-pass1.md
+++ b/notes/2026-08-14-qwen36-q8-tp2-40tps-pass1.md
@@ -1,0 +1,40 @@
+# Qwen3.6 27B Q8 TP2 target-only optimization: pass 1
+
+Date: 2026-08-14  
+Host: 2x ASRock Intel Arc Pro B70, 32 GiB per card  
+Scope: conventional target-only decode; no MTP, DFlash, or other speculation
+
+## Starting point
+
+The accepted reproduction snapshot is commit `ce51350b8` and reports:
+
+- 35.699225 tok/s conventional endpoint median
+- 36.059823 tok/s legacy-compatible endpoint median
+- about 36.6 tok/s in longer direct `llama-bench` repeats
+- 42.5 tok/s approximate aggregate HBM roofline for the 28.596 GB Q8 model
+
+The optimization work is isolated on branch `agent/qwen36-q8-tp2-40tps`. The accepted source/build remains the recovery reference while candidates use separate source and build paths.
+
+## Hardware topology
+
+`xpu-smi topology -m` reports `SYS` between GPU 0 and GPU 1. The cards share the same CPU affinity but traverse different PCIe host bridges. This makes per-token TP collective latency a first-class constraint; branding and cooling do not change that interconnect.
+
+## Profiler rejection and recovery
+
+The llama.cpp built-in `GGML_SYCL_PROFILE=1` path was tried once at `p64/n16`. It inserts device-wide timing barriers and is not production-equivalent. On this host it caused Level Zero `UR_RESULT_ERROR_DEVICE_LOST`, CAT/fault messages, and engine resets on both cards. It must not be retried.
+
+Both devices returned to `Device State: normal` immediately after the reset. A normal, unprofiled target-only `p64/n16/r1` smoke then passed at:
+
+- prompt processing: 384.738573 tok/s
+- token generation: 35.395890 tok/s
+
+The short `n16` result is only a recovery check, not a headline benchmark. Raw logs are retained outside Git in:
+
+- `/mnt/fast-ai/bench-results/qwen36-q8-asrock-b70-20260814-40tps/profile-current-p64-n16.log`
+- `/mnt/fast-ai/bench-results/qwen36-q8-asrock-b70-20260814-40tps/post-reset-smoke-p64-n16.log`
+
+## Current direction
+
+Further measurements will use low-intrusion `xpu-smi dump` sampling during ordinary unprofiled runs. Candidate changes must pass matched reversed-order A/B tests and exact output/quality gates before promotion.
+
+Already-rejected experiments will not be recycled as new work. These include root-barrier elision, Q8 scale broadcast, Q8 cache, VDR2/VDR8, the earlier column-split/block-remap attempt, and broad subgroup/workgroup sweeps. The next useful question is whether the remaining gap is predominantly HBM efficiency, cross-bridge collective latency, or host submission overhead.


### PR DESCRIPTION
Isolated workstream toward 40 tok/s conventional target-only Qwen3.6 27B Q8 TP2 decode on two ASRock B70 GPUs. No MTP, DFlash, or other speculation. Small evidence checkpoints will be pushed regularly so concurrent work can follow and avoid duplication.