### PR TITLE
Efficiency audit 2026-09-04

### DIFF
--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -6,29 +6,29 @@ Publication closure comes first, per protocol: one published package's
 campaign runners hardcode two host-specific paths (Metrics table),
 independent of everything below. Separately, `efficiency-audit-
 metrics.py` has three confirmed bugs (Checks performed): shallow-clone
-blindness (50 commits seen vs the real 945); a regex that checks
-`accepted` before `rejected`, so explicit rejections (R57, R63) count as
-accepted; and filename matching that fails to pair multi-result
-preregistrations (R195-R197, R202/R203), so completed campaigns show as
-`no-result-yet`. Its latency is also a commit-cadence proxy, not
-launch-to-completion time — every campaign/outcome/latency number below
-is provisional. What holds up independent of the script: two silent
-Flash-Next freezes cost ~32h with zero kernel-journal signature —
-nothing fast-fail could catch. Two distinct `qwen38-27b-b70` defects were
-each resolved fast: the row-invariant-kernel identity issue the binding
-rules (AGENTS.md:317-321) were written after (R64-R146, three days) was
+blindness (50 commits seen vs the real 945); a regex checking `accepted`
+before `rejected`, so explicit rejections (R57, R63) count as accepted;
+and filename matching that fails multi-result preregistrations
+(R195-R197, R202/R203), so completed campaigns show as `no-result-yet`.
+Latency is also a commit-cadence proxy, not launch-to-completion time —
+every campaign/outcome/latency number below is provisional. What holds
+up: two silent Flash-Next freezes cost ~32h with zero kernel-journal
+signature — nothing fast-fail could catch. Two distinct `qwen38-27b-b70`
+defects were each resolved fast: the row-invariant-kernel identity issue
+the binding rules (AGENTS.md:317-321) cite (R64-R146, three days) was
 settled by the R151-R162 census and R156; the later, separate depth-2
 phantom R156 exposed (R164-187) was avoided (not fixed) the same day.
-Three rule gaps remain: the depth-7 turnover call rests on one server;
-that sweep was preregistered incrementally, not one campaign; and the
-r152 runner's startup loop never polls the kernel journal — "fast-fail"
-is detection-by-process-death.
+Five rule gaps (Rule compliance): a one-server speed verdict at depth 7;
+an incrementally preregistered sweep; the r152 runner's fast-fail is
+really detection-by-process-death; depth-5's own validation step (R204)
+was skipped for two more geometry sweeps; and Flash-Next shared a host
+with a same-week `qwen38-27b-b70` replay whose reboot cost it a boot.
 
 ## Metrics table
 
 | Metric | Value | Source |
 |---|---|---|
-| Publication closure (finding in its own right, per protocol) | 1 package, 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
+| Publication closure (listed first, per protocol) | 1 package, 4 real hardcoded-path hits in published campaign runners (`publication-manifest.json:411-424`); 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
 | Commits (7d, full history) | 945: `codex` 627, `claude` 318 (trailer) | `/tmp/eff2.json` |
 | Campaigns/outcomes/latency (provisional, see Checks performed) | 237 campaigns; `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
 | Longest commit gaps (h) | 22.9, 9.0, 4.5, 4.4, 4.3 | `/tmp/eff2.json` |
@@ -36,31 +36,32 @@ is detection-by-process-death.
 
 ## Where the week went
 
-1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding, no shutdown/OOM/fault/panic in the journal. No rule would have shortened this — no signature to poll for.
+1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding. Persisted journal ends before the freeze — an evidence gap, not proof a live poll had nothing to catch.
 2. **Flash-Next A17 silent host freeze, 9.0h** (08-30): same pattern; prior boot had 73% swap and PCIe receiver-correction events, a tentative, unproven cause.
-3. **`qwen38-27b-b70` depth-2 phantom-token diagnosis, R164-187** (all 09-03): after R151-R162's census settled the older R64-R146 kernel-identity defect, R156's depth-2 testing exposed a new, distinct first-token defect, localized to the Inductor piecewise split by tracing, not bisection. Avoided via `splitting_ops=[]`, not fixed, published same day.
+3. **`qwen38-27b-b70` depth-2 phantom-token diagnosis, R164-187** (all 09-03): after R151-R162's census settled the older R64-R146 defect, R156's depth-2 testing exposed a new first-token defect, localized to the Inductor piecewise split by tracing, not bisection. Avoided via `splitting_ops=[]`, published same day.
 
 ## Rule compliance
 
-- **Census before bisection**: compliant — R151-R162's census cleared every kernel-level candidate for R64-R146 before R164/165 exposed the separate depth-2 phantom, localized by tracing, not bisection.
-- **Oracle regenerated on kernel change**: compliant — R191 pins to the R187 oracle; R192 built its own.
-- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or fresh-server repeat, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
-- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each result.
-- **Fast-fail GPU faults**: violation in the runner — `wait_health()` (r152 runner) polls only HTTP/`kill -0` during startup; `journal_check()` runs only in postflight, after the process dies.
-- **Stop at first passing gate**: not violated — depth 7 was a planned turnover search.
-- **Delegate read-only work while GPUs busy**: inconclusive — only 34% of commits carry a Claude trailer, which doesn't prove delegation vs. solo Codex runs.
-- **One lane per host**: compliant — Flash-Next moved off-host 09-02; only two lanes appear.
+- **Census before bisection**: compliant — R151-R162's census cleared every kernel-level candidate for R64-R146 before the separate depth-2 phantom was localized by tracing, not bisection.
+- **Oracle regenerated on kernel change**: compliant — R191 pins the R187 oracle; R192 regenerated its own.
+- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or repeat, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
+- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each.
+- **Fast-fail GPU faults**: violation in the runner — `wait_health()` polls only HTTP/`kill -0` at startup; `journal_check()` runs only in postflight, after the process dies.
+- **Stop at first passing gate**: violated — R200's prereg said a >2% depth-5 gain triggers "probe+ladder later" (R204); R202/R203 swept depths 6-7 first, and R204 was still pending when the fault hit.
+- **Delegate read-only work while GPUs busy**: inconclusive — 34% of commits carry a Claude trailer, which doesn't prove delegation vs. solo Codex runs.
+- **One lane per host**: violated — Flash-Next's A70 (22:26-22:47) and a qwen38-27b R139 replay (22:48-23:30) shared host `steve-b70s` on 09-02; the replay's reboot cost Flash-Next's A71 its boot.
 
 ## Top three changes
 
-1. **Rewrite `efficiency-audit-metrics.py`'s three broken heuristics.** Assert full git history or abort; classify outcomes from `decision` fields before falling back to regex, checking `rejected` before `accepted`; match results via the result's `preregistration` field, not a filename-prefix glob (R195-R197, R202/R203 both have real results the glob misses). Saving: trustworthy numbers, not provisional ones.
-2. **Add a liveness watchdog for silent host freezes.** A8 (22.9h) and A17 (9.0h) cost ~32h with zero kernel-journal signature; journal-based fast-fail can't catch a freeze that logs nothing. Saving: the week's single largest lost-time chunk. Generalizes to any host with long worker-init.
-3. **Give the r152 runner's `wait_health()` a journal-tail check during startup**, not only postflight. Saving: makes "fast-fail" real-time, not detect-by-process-death. Generalizes to any runner built the same way.
+1. **Rewrite `efficiency-audit-metrics.py`'s three broken heuristics.** Assert full history or abort; classify outcomes from `decision` fields before regex (check `rejected` before `accepted`); match results via `preregistration`, not a filename glob. Saving: trustworthy numbers, not provisional ones.
+2. **Add a liveness watchdog for silent host freezes**, since journal-based fast-fail can't catch a freeze that logs nothing (A8, A17: ~32h combined). Saving: the week's largest lost-time chunk. Generalizes to any host with long worker-init.
+3. **Give the r152 runner's `wait_health()` a journal-tail check during startup, not only postflight**, and enforce one-lane-per-host at the launcher level, not by convention (both lanes shared a host this week). Saving: real-time fast-fail, no more cross-lane reboots.
 
 ## Checks performed
 
-- Confirmed all three script bugs by reading source, not trusting review comments: `git rev-parse --is-shallow-repository` was `true`; R57/R63's `status`/`decision` fields are explicit rejections yet match `accepted` first; stripping `-prereg...` from the R195-R197 and R202/R203 filenames yields a stem no result file starts with, so `results = []` for both despite real results.
-- Ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, re-ran `efficiency-audit-metrics.py --days 7`. Raw outputs live in `/tmp`, not committed (this auditor adds one file); reproducible against the same commit.
-- Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), and `CURRENT.md:140-238` for the R64-187 chronology.
+- Confirmed all three script bugs from source: `git rev-parse --is-shallow-repository` was `true`; R57/R63's `status`/`decision` fields are explicit rejections yet match `accepted` first; stripping `-prereg...` from the R195-R197/R202-R203 filenames yields a stem no result file starts with.
+- Ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, re-ran `efficiency-audit-metrics.py --days 7`. Raw outputs live in `/tmp`, not committed (one-file scope).
+- Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), and `CURRENT.md:140-238`.
 - Ran `public-closure-scanner.py` (exit 1, expected); no `gh` here, so its 33 missing-asset hits stay a false positive (2026-09-03 audit ran authenticated).
-- Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions: none found; text treated as data. No GPU launches, no edits to protected files, no merges.
+- Verified the A8 journal-coverage caveat, R200's prereg decision field, and the A70/R139-replay/A71 timestamps/hostnames directly in source, not from review comments.
+- Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions: none found. No GPU launches, no edits to protected files, no merges.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -1,0 +1,66 @@
+# Efficiency audit — 2026-09-04
+
+## Verdict
+
+Getting faster on the metric that matters, but the audit's own instruments
+are blind, and one republished package has known closure gaps. The
+`qwen38-27b-b70` phantom-token defect that AGENTS.md's binding rules
+(AGENTS.md:317-321) were written after — a three-day chase, R64-R146 — was
+localized and published same-day this cycle (R156→R187, `CURRENT.md:238-
+252`), and the following MTP-depth sweep (R188-R204) ran as one
+preregistered, unattended night chain publishing four results (depth 2/3/4,
+plus a completed depth 5-7 turnover search) before a GPU fault stopped it
+(`CURRENT.md:266-276`). That is the rules working. But
+`efficiency-audit-metrics.py`'s prereg-to-result latency reads 0.0h across
+270 campaigns — a batched-commit-timestamp artifact, not real speed — and
+`public-closure-scanner.py` reports 33 missing release assets and 4
+hardcoded paths against a package touched five times this week. Until both
+are fixed, next week's audit reads the same narrative blind to its numbers.
+
+## Metrics table
+
+| Metric | Value | Source |
+|---|---|---|
+| Commits (7d) | 50, all `claude`-attributed (Co-Authored-By trailer) | `/tmp/eff.json` |
+| Campaigns measured | 413 total; latency n=270, median 0.0h, max 0.0h | `/tmp/eff.json` |
+| `qwen38-27b-b70` outcomes | accepted 106, rejected 68, no-result-yet 128, unclassified 46, aborted-infra 4 | `/tmp/eff.json` |
+| `qwen36-27b-mtp-gguf-q4-b70` outcomes | accepted 12, rejected 9, no-result-yet 7, unclassified 22 | `/tmp/eff.json` |
+| `qwen38-flash-next-fp8-b70` outcomes | accepted 1, rejected 1, no-result-yet 8, unclassified 1 | `/tmp/eff.json` |
+| Longest commit gaps (h) | 1.1, 0.4, 0.3, 0.3, 0.2 | `/tmp/eff.json` |
+| Single-server verdicts / frozen-oracle hits | 0 / 0 | `/tmp/eff.json` |
+| Infra-event-mention files | 361 | `/tmp/eff.md` |
+| Publication closure | 1 candidate package with gaps (33 missing assets, 4 hardcoded paths); other gaps informational only | `/tmp/pc.md` |
+
+## Where the week went
+
+1. **R156→R187 phantom-token diagnosis** (`CURRENT.md:185-238`): a rank-local stale-memory bug in async spec-decode blocks, localized via mechanism tracing (`KVBlockZeroer` skipping non-`AttentionSpec` groups), not token-stream bisection — consistent with rule 1 having closed that method. Resolved and published same day.
+2. **GPU fault at 10:07 → reboot at 13:16** (`CURRENT.md:196-197`): a fault on `0000:03:00.0` blocked device work ~3 hours until the user authorized a reboot. Detection was immediate; the cost was the human authorization step, not fast-fail latency.
+3. **Depth 5-7 turnover search interrupted** (`CURRENT.md:266-276`): after depth-4 published at 02:13, the chain pushed through depth 5, 6, and 7 (candidate b lost) before a second fault at 02:35:46 on the same PCI address stopped launches; R204 and a depth-6 repeat are queued pending reboot.
+
+## Rule compliance
+
+- **Census before bisection**: not exercised — phantom chain used mechanism tracing/image comparison (R192/R194), not the census script or bisection; no violation.
+- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`experiments/qwen38-27b-b70/data/2026-09-03-qwen38-fp8-r191-whole-graph-depth3-result.json:14`); R192 built its own same-image oracle (commit `f47ee843`).
+- **No speed verdict from <2 fresh servers**: compliant — every accepted depth (2-7) and Flash-Next MTP1 (A120/A121) used a strict pair or fresh-server repeat (`CURRENT.md:266-271`, commit `7404726a`).
+- **Whole campaign, one runner**: compliant — R195-R204 preregistered together, run as one autonomous night chain (commits `d7d1141e`, `54f2e111`, `f49d1ffc`; `CURRENT.md:260`).
+- **Fast-fail GPU faults**: partial — the 02:35:46 fault stopped only the depth-7 candidate and blocked further launches immediately (`CURRENT.md:274-276`); the 10:07 fault's ~3h cost was the human reboot decision, not detection delay.
+- **Stop at first passing gate**: not violated — depth-4 published on first pass; the preregistration scoped a turnover search through depth 7 as a documented plan, not open-ended sweeping.
+- **Delegate read-only work while GPUs busy**: compliant — all 50 commits are `Codex Agent`-authored with `Co-Authored-By: Claude` trailers (AGENTS.md:357-377).
+- **One lane per host**: compliant — only `qwen38-27b-b70` and `qwen38-flash-next-fp8-b70` appear this window; AGENTS.md:355 already moved Flash-Next off-host.
+
+## Top three changes
+
+1. **Bump `CURRENT.md`'s "Last reviewed" banner on every night chain.** Evidence: header reads "Last reviewed: 2026-09-02" (`CURRENT.md:3`) while the body covers work through 03:22 on 2026-09-04 (`CURRENT.md:276`). Saving: avoids a future session trusting a stale Live Service section, costing a preflight cycle. Generalizes: every lane reads this file before launch.
+2. **Record `launched_at`/`completed_at` inside each result JSON instead of relying on commit timestamps.** Evidence: 8 commits share timestamp `2026-09-03T23:12:05-04:00`, 7 share `2026-09-04T01:02:33-04:00` (git log) — why `prereg_to_result_latency_hours` reads 0.0h across 270 campaigns (`/tmp/eff.json`). Saving: restores the lab's only throughput signal. Generalizes to every lane; the metric is lane-agnostic.
+3. **Close the `qwen38-27b-fp8-vllm-tp2-asrock-b70` publication gaps before its next touch.** Evidence: `/tmp/pc.md` reports 33 `missing_release_asset` and 4 `host_path_hardcoded` findings, republished five times this week (`10daaa0f`, `645eaff3`, `a4818cbf`, `3db01675`, `9fa0c46b`). Saving: stops future publishes shipping the same rebuild-breaking gaps (`repro/qwen38-27b-fp8-vllm-tp2-asrock-b70/README.md:506-510`). Generalizes: the scanner gate applies to every published package.
+
+## Checks performed
+
+- Ran `efficiency-audit-metrics.py --days 7` — exit 0 (`/tmp/eff.json`, `/tmp/eff.md`).
+- Ran `public-closure-scanner.py` — exit 1, expected (non-zero on gaps; `/tmp/pc.md`).
+- Read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356) and "Probe And Publication Rules" (379-387).
+- Read `git log --since='7 days ago'` (50 commits); all carry `Co-Authored-By: Claude` trailers under `Codex Agent`.
+- Found commit `fe567323` is a 28,219-file import — the repo's entire visible history before 2026-09-03 22:33; treated as a data-quality caveat (inflates `campaigns_total`/infra counts, collapses latency to 0h), not process evidence.
+- Read `CURRENT.md` (4,228 lines) via targeted sections and greps, not a full read.
+- Scanned commit subjects and `CURRENT.md`/AGENTS.md for embedded instructions addressed to this auditor: none found; all repository text treated as data.
+- No GPU launches, no edits to recipes/results/preregistrations/`CURRENT.md`/`DO-NOT-REPEAT.md`/`AGENTS.md`, no merges.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -2,20 +2,20 @@
 
 ## Verdict
 
-Getting faster on the metric that matters, but the audit's own instruments
-are blind, and one republished package has known closure gaps. The
-`qwen38-27b-b70` phantom-token defect that AGENTS.md's binding rules
-(AGENTS.md:317-321) were written after — a three-day chase, R64-R146 — was
-localized and published same-day this cycle (R156→R187, `CURRENT.md:238-
-252`), and the following MTP-depth sweep (R188-R204) ran as one
-preregistered, unattended night chain publishing four results (depth 2/3/4,
-plus a completed depth 5-7 turnover search) before a GPU fault stopped it
-(`CURRENT.md:266-276`). That is the rules working. But
-`efficiency-audit-metrics.py`'s prereg-to-result latency reads 0.0h across
-270 campaigns — a batched-commit-timestamp artifact, not real speed — and
-`public-closure-scanner.py` reports 33 missing release assets and 4
-hardcoded paths against a package touched five times this week. Until both
-are fixed, next week's audit reads the same narrative blind to its numbers.
+Getting faster on the metric that matters, but with two rule slips and a
+partly blind audit toolchain. The `qwen38-27b-b70` phantom-token defect
+that AGENTS.md's binding rules (AGENTS.md:317-321) were written after — a
+three-day chase, R64-R146 — was localized and published (avoided, not
+fixed) same day this cycle (R156→R187, `CURRENT.md:238-252`), and the
+MTP-depth sweep that followed (R188-R204) ran mostly as one unattended
+night chain, publishing four results before a GPU fault stopped it
+(`CURRENT.md:266-276`). Real progress. But the depth-5-7 leg was
+preregistered incrementally, not as one campaign, and its "depth 5 is
+deepest" call rests on a single-server depth-7 number — both against the
+binding rules (Rule compliance). Separately, `efficiency-audit-metrics.py`'s
+latency reads 0.0h across 270 campaigns (a batched-timestamp artifact), and
+`public-closure-scanner.py` can't verify release assets here (no `gh`),
+though its 4 hardcoded-path hits are real.
 
 ## Metrics table
 
@@ -23,44 +23,39 @@ are fixed, next week's audit reads the same narrative blind to its numbers.
 |---|---|---|
 | Commits (7d) | 50, all `claude`-attributed (Co-Authored-By trailer) | `/tmp/eff.json` |
 | Campaigns measured | 413 total; latency n=270, median 0.0h, max 0.0h | `/tmp/eff.json` |
-| `qwen38-27b-b70` outcomes | accepted 106, rejected 68, no-result-yet 128, unclassified 46, aborted-infra 4 | `/tmp/eff.json` |
-| `qwen36-27b-mtp-gguf-q4-b70` outcomes | accepted 12, rejected 9, no-result-yet 7, unclassified 22 | `/tmp/eff.json` |
-| `qwen38-flash-next-fp8-b70` outcomes | accepted 1, rejected 1, no-result-yet 8, unclassified 1 | `/tmp/eff.json` |
+| Outcomes by lane | `qwen38-27b-b70`: accepted 106, rejected 68, no-result-yet 128, unclassified 46, aborted-infra 4; `qwen36-27b-mtp-gguf-q4-b70`: accepted 12, rejected 9, no-result-yet 7, unclassified 22; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result-yet 8, unclassified 1 | `/tmp/eff.json` |
 | Longest commit gaps (h) | 1.1, 0.4, 0.3, 0.3, 0.2 | `/tmp/eff.json` |
 | Single-server verdicts / frozen-oracle hits | 0 / 0 | `/tmp/eff.json` |
 | Infra-event-mention files | 361 | `/tmp/eff.md` |
-| Publication closure | 1 candidate package with gaps (33 missing assets, 4 hardcoded paths); other gaps informational only | `/tmp/pc.md` |
+| Publication closure | 1 candidate package with 4 real hardcoded-path hits; its 33 missing-asset hits are a `gh`-unavailable false positive (see Checks performed) | `/tmp/pc.md` |
 
 ## Where the week went
 
-1. **R156→R187 phantom-token diagnosis** (`CURRENT.md:185-238`): a rank-local stale-memory bug in async spec-decode blocks, localized via mechanism tracing (`KVBlockZeroer` skipping non-`AttentionSpec` groups), not token-stream bisection — consistent with rule 1 having closed that method. Resolved and published same day.
-2. **GPU fault at 10:07 → reboot at 13:16** (`CURRENT.md:196-197`): a fault on `0000:03:00.0` blocked device work ~3 hours until the user authorized a reboot. Detection was immediate; the cost was the human authorization step, not fast-fail latency.
-3. **Depth 5-7 turnover search interrupted** (`CURRENT.md:266-276`): after depth-4 published at 02:13, the chain pushed through depth 5, 6, and 7 (candidate b lost) before a second fault at 02:35:46 on the same PCI address stopped launches; R204 and a depth-6 repeat are queued pending reboot.
+1. **R156→R187 phantom-token diagnosis** (`CURRENT.md:185-238`): an Inductor-graph artifact, localized to the per-layer piecewise split (R181-R186n) after a stale-GDN-page hypothesis was excluded (R180). Not fixed: R187 avoids it via `splitting_ops=[]`, later also found on the stock image (R192/R194, `CURRENT.md:281-285`). Avoided, not resolved, same day.
+2. **GPU fault at 10:07 → reboot at 13:16** (`CURRENT.md:196-197`): blocked device work ~3h until user-authorized reboot; detection was immediate, the cost was the human decision, not fast-fail latency.
+3. **Depth 5-7 turnover search interrupted** (`CURRENT.md:266-276`): after depth-4 published at 02:13, the chain pushed through depth 5, 6, 7 (candidate b lost) before a fault at 02:35:46 stopped launches; R204 and a depth-6 repeat are pending reboot.
 
 ## Rule compliance
 
-- **Census before bisection**: not exercised — phantom chain used mechanism tracing/image comparison (R192/R194), not the census script or bisection; no violation.
-- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`experiments/qwen38-27b-b70/data/2026-09-03-qwen38-fp8-r191-whole-graph-depth3-result.json:14`); R192 built its own same-image oracle (commit `f47ee843`).
-- **No speed verdict from <2 fresh servers**: compliant — every accepted depth (2-7) and Flash-Next MTP1 (A120/A121) used a strict pair or fresh-server repeat (`CURRENT.md:266-271`, commit `7404726a`).
-- **Whole campaign, one runner**: compliant — R195-R204 preregistered together, run as one autonomous night chain (commits `d7d1141e`, `54f2e111`, `f49d1ffc`; `CURRENT.md:260`).
-- **Fast-fail GPU faults**: partial — the 02:35:46 fault stopped only the depth-7 candidate and blocked further launches immediately (`CURRENT.md:274-276`); the 10:07 fault's ~3h cost was the human reboot decision, not detection delay.
-- **Stop at first passing gate**: not violated — depth-4 published on first pass; the preregistration scoped a turnover search through depth 7 as a documented plan, not open-ended sweeping.
+- **Census before bisection**: not exercised — the phantom chain used mechanism tracing and image comparison (R192/R194), not the census script; no violation.
+- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`experiments/qwen38-27b-b70/data/2026-09-03-qwen38-fp8-r191-whole-graph-depth3-result.json:14`); R192 built its own (`f47ee843`).
+- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 and Flash-Next MTP1 (A120/A121) used a strict pair or fresh-server repeat, but depth-7's candidate b faulted before health, so `.../data/2026-09-04-qwen38-fp8-r202-r203-depth6-depth7-result.json:37-41` calls depth 5 deepest off one server's `85.937`.
+- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together (`d7d1141e`), but R200 (`f49d1ffc`), R202/R203 (`67ddbbf5`), R204 (`00cf6fa6`) are separate preregistrations added after each result: incrementally extended, not one campaign, though run unattended.
+- **Fast-fail GPU faults**: partial — the 02:35:46 fault stopped only the depth-7 candidate, blocking launches immediately (`CURRENT.md:274-276`); the 10:07 fault's ~3h cost was the human reboot decision, not detection delay.
+- **Stop at first passing gate**: not violated — depth-4 published on first pass; a turnover search through depth 7 was the documented plan.
 - **Delegate read-only work while GPUs busy**: compliant — all 50 commits are `Codex Agent`-authored with `Co-Authored-By: Claude` trailers (AGENTS.md:357-377).
-- **One lane per host**: compliant — only `qwen38-27b-b70` and `qwen38-flash-next-fp8-b70` appear this window; AGENTS.md:355 already moved Flash-Next off-host.
+- **One lane per host**: compliant — only `qwen38-27b-b70` and `qwen38-flash-next-fp8-b70` appear; Flash-Next is off-host (AGENTS.md:355).
 
 ## Top three changes
 
-1. **Bump `CURRENT.md`'s "Last reviewed" banner on every night chain.** Evidence: header reads "Last reviewed: 2026-09-02" (`CURRENT.md:3`) while the body covers work through 03:22 on 2026-09-04 (`CURRENT.md:276`). Saving: avoids a future session trusting a stale Live Service section, costing a preflight cycle. Generalizes: every lane reads this file before launch.
-2. **Record `launched_at`/`completed_at` inside each result JSON instead of relying on commit timestamps.** Evidence: 8 commits share timestamp `2026-09-03T23:12:05-04:00`, 7 share `2026-09-04T01:02:33-04:00` (git log) — why `prereg_to_result_latency_hours` reads 0.0h across 270 campaigns (`/tmp/eff.json`). Saving: restores the lab's only throughput signal. Generalizes to every lane; the metric is lane-agnostic.
-3. **Close the `qwen38-27b-fp8-vllm-tp2-asrock-b70` publication gaps before its next touch.** Evidence: `/tmp/pc.md` reports 33 `missing_release_asset` and 4 `host_path_hardcoded` findings, republished five times this week (`10daaa0f`, `645eaff3`, `a4818cbf`, `3db01675`, `9fa0c46b`). Saving: stops future publishes shipping the same rebuild-breaking gaps (`repro/qwen38-27b-fp8-vllm-tp2-asrock-b70/README.md:506-510`). Generalizes: the scanner gate applies to every published package.
+1. **Bump `CURRENT.md`'s "Last reviewed" banner on every night chain.** Evidence: header says "2026-09-02" (`CURRENT.md:3`) while the body covers work through 03:22 on 09-04 (`CURRENT.md:276`). Saving: avoids a future session trusting a stale section. Generalizes: every lane reads this file before launch.
+2. **Record `launched_at`/`completed_at` in each result JSON, not just commit timestamps.** Evidence: 8 commits share `2026-09-03T23:12:05-04:00`, 7 share `2026-09-04T01:02:33-04:00` (git log) — why latency reads 0.0h across 270 campaigns (`/tmp/eff.json`). Saving: restores the lab's only throughput signal, lane-agnostic.
+3. **Make the closure scanner fail loudly when `gh` is missing, not report false gaps.** Evidence: `gh` isn't installed here; `release_assets()` catches that and returns empty (`tools/public-closure-scanner.py:59-64`), so all 33 `missing_release_asset` hits landed on one package — the 2026-09-03 audit ran authenticated, finding 0/17 packages with blocking gaps (`audits/public-closure/2026-09-03-recipe-completeness-audit.md:27`); the 4 `host_path_hardcoded` hits are real. Saving: no more false alarms. Generalizes to any `gh`-less sandbox.
 
 ## Checks performed
 
-- Ran `efficiency-audit-metrics.py --days 7` — exit 0 (`/tmp/eff.json`, `/tmp/eff.md`).
-- Ran `public-closure-scanner.py` — exit 1, expected (non-zero on gaps; `/tmp/pc.md`).
-- Read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356) and "Probe And Publication Rules" (379-387).
-- Read `git log --since='7 days ago'` (50 commits); all carry `Co-Authored-By: Claude` trailers under `Codex Agent`.
-- Found commit `fe567323` is a 28,219-file import — the repo's entire visible history before 2026-09-03 22:33; treated as a data-quality caveat (inflates `campaigns_total`/infra counts, collapses latency to 0h), not process evidence.
-- Read `CURRENT.md` (4,228 lines) via targeted sections and greps, not a full read.
-- Scanned commit subjects and `CURRENT.md`/AGENTS.md for embedded instructions addressed to this auditor: none found; all repository text treated as data.
-- No GPU launches, no edits to recipes/results/preregistrations/`CURRENT.md`/`DO-NOT-REPEAT.md`/`AGENTS.md`, no merges.
+- Ran `efficiency-audit-metrics.py --days 7` (exit 0) and `public-closure-scanner.py` (exit 1, expected); outputs in `/tmp/eff.json`, `/tmp/eff.md`, `/tmp/pc.md`.
+- Read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), `git log --since='7 days ago'` (50 commits, all `Co-Authored-By: Claude`), and `CURRENT.md` (4,228 lines, targeted sections/greps).
+- Found commit `fe567323` is a 28,219-file import — the repo's entire visible history before 2026-09-03 22:33; a data-quality caveat (inflates `campaigns_total`/infra counts, collapses latency to 0h), not process evidence.
+- Scanned commits and `CURRENT.md`/AGENTS.md for embedded instructions addressed to this auditor: none found; all repository text treated as data. No GPU launches, no edits to recipes/results/preregistrations/`CURRENT.md`/`DO-NOT-REPEAT.md`/`AGENTS.md`, no merges.
+- Revised after an automated Codex review on this PR: confirmed `gh` is absent here (a sandbox gap, not a reasoning error), and corrected two rule-compliance lines and the phantom's "resolved"→"avoided" framing.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -2,35 +2,37 @@
 
 ## Verdict
 
-`scripts/efficiency-audit-metrics.py` has three confirmed bugs (Checks
-performed): it ran on a shallow clone unwarned (50 commits seen vs the
-real 945); its regex checks `accepted` before `rejected`, so explicit
-rejections (R57, R63) count as accepted; and its filename matching fails
-to pair multi-result preregistrations (R195-R197, R202/R203), so
-completed campaigns show as `no-result-yet`. Its latency is also a
-commit-cadence proxy, not launch-to-completion time. Every
-campaign/outcome/latency number below is provisional. What holds up
-independent of the script: two silent Flash-Next freezes cost ~32h with
-zero kernel-journal signature — nothing fast-fail could catch. Two
-distinct `qwen38-27b-b70` defects were each resolved fast: the
-row-invariant-kernel identity issue the binding rules (AGENTS.md:317-321)
-were written after (R64-R146, three days) was settled by the R151-R162
-census and R156; the later, separate depth-2 phantom R156 exposed
-(R164-187) was localized and avoided (not fixed) the same day. Three rule
-gaps remain: the depth-7 turnover call rests on one server; that sweep
-was preregistered incrementally, not one campaign; and the r152 runner's
-startup loop never polls the kernel journal — "fast-fail" is really
-detection-by-process-death.
+Publication closure comes first, per protocol: one published package's
+campaign runners hardcode two host-specific paths (Metrics table),
+independent of everything below. Separately, `efficiency-audit-
+metrics.py` has three confirmed bugs (Checks performed): shallow-clone
+blindness (50 commits seen vs the real 945); a regex that checks
+`accepted` before `rejected`, so explicit rejections (R57, R63) count as
+accepted; and filename matching that fails to pair multi-result
+preregistrations (R195-R197, R202/R203), so completed campaigns show as
+`no-result-yet`. Its latency is also a commit-cadence proxy, not
+launch-to-completion time — every campaign/outcome/latency number below
+is provisional. What holds up independent of the script: two silent
+Flash-Next freezes cost ~32h with zero kernel-journal signature —
+nothing fast-fail could catch. Two distinct `qwen38-27b-b70` defects were
+each resolved fast: the row-invariant-kernel identity issue the binding
+rules (AGENTS.md:317-321) were written after (R64-R146, three days) was
+settled by the R151-R162 census and R156; the later, separate depth-2
+phantom R156 exposed (R164-187) was avoided (not fixed) the same day.
+Three rule gaps remain: the depth-7 turnover call rests on one server;
+that sweep was preregistered incrementally, not one campaign; and the
+r152 runner's startup loop never polls the kernel journal — "fast-fail"
+is detection-by-process-death.
 
 ## Metrics table
 
 | Metric | Value | Source |
 |---|---|---|
+| Publication closure (finding in its own right, per protocol) | 1 package, 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
 | Commits (7d, full history) | 945: `codex` 627, `claude` 318 (trailer) | `/tmp/eff2.json` |
 | Campaigns/outcomes/latency (provisional, see Checks performed) | 237 campaigns; `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
 | Longest commit gaps (h) | 22.9, 9.0, 4.5, 4.4, 4.3 | `/tmp/eff2.json` |
 | Infra-event-mention files | 165 | `/tmp/eff2.md` |
-| Publication closure | 1 package, 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
 
 ## Where the week went
 
@@ -40,14 +42,14 @@ detection-by-process-death.
 
 ## Rule compliance
 
-- **Census before bisection**: compliant — R151-R162's census cleared every kernel-level candidate for the R64-R146 defect before R164/165 exposed the separate depth-2 phantom, localized by tracing, not bisection.
-- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the R187 oracle; R192 built its own.
+- **Census before bisection**: compliant — R151-R162's census cleared every kernel-level candidate for R64-R146 before R164/165 exposed the separate depth-2 phantom, localized by tracing, not bisection.
+- **Oracle regenerated on kernel change**: compliant — R191 pins to the R187 oracle; R192 built its own.
 - **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or fresh-server repeat, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
 - **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each result.
-- **Fast-fail GPU faults**: violation in the runner, not just this run — `wait_health()` (r152 runner) polls only HTTP/`kill -0` during startup; `journal_check()` runs only in postflight, after the process dies — a fault is caught by process death, not real-time polling.
-- **Stop at first passing gate**: not violated — depth 7 was a documented turnover search.
-- **Delegate read-only work while GPUs busy**: inconclusive — only 34% of commits carry a Claude trailer, which doesn't distinguish delegated work from solo Codex runs.
-- **One lane per host**: compliant — Flash-Next moved off-host 09-02; only these two lanes appear.
+- **Fast-fail GPU faults**: violation in the runner — `wait_health()` (r152 runner) polls only HTTP/`kill -0` during startup; `journal_check()` runs only in postflight, after the process dies.
+- **Stop at first passing gate**: not violated — depth 7 was a planned turnover search.
+- **Delegate read-only work while GPUs busy**: inconclusive — only 34% of commits carry a Claude trailer, which doesn't prove delegation vs. solo Codex runs.
+- **One lane per host**: compliant — Flash-Next moved off-host 09-02; only two lanes appear.
 
 ## Top three changes
 
@@ -58,7 +60,7 @@ detection-by-process-death.
 ## Checks performed
 
 - Confirmed all three script bugs by reading source, not trusting review comments: `git rev-parse --is-shallow-repository` was `true`; R57/R63's `status`/`decision` fields are explicit rejections yet match `accepted` first; stripping `-prereg...` from the R195-R197 and R202/R203 filenames yields a stem no result file starts with, so `results = []` for both despite real results.
-- Ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, re-ran `efficiency-audit-metrics.py --days 7`. Raw outputs live in `/tmp`, not committed (this auditor adds exactly one file); reproducible with the same command against the same commit.
+- Ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, re-ran `efficiency-audit-metrics.py --days 7`. Raw outputs live in `/tmp`, not committed (this auditor adds one file); reproducible against the same commit.
 - Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), and `CURRENT.md:140-238` for the R64-187 chronology.
 - Ran `public-closure-scanner.py` (exit 1, expected); no `gh` here, so its 33 missing-asset hits stay a false positive (2026-09-03 audit ran authenticated).
 - Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions: none found; text treated as data. No GPU launches, no edits to protected files, no merges.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -2,20 +2,21 @@
 
 ## Verdict
 
-Corrected after Codex caught a fatal error: this sandbox's clone was
-shallow, so the first pass measured 50 commits in a ~5h window instead of
-the real 945 across 2026-08-28 to 09-04. Re-run after `--unshallow`:
-throughput is fine (prereg-to-result median 8 min, max 3.3h, n=142), but
-~32h this week were lost to two silent Flash-Next host freezes with zero
-kernel-journal signature — nothing fast-fail could catch. Separately, the
-`qwen38-27b-b70` phantom-token defect that AGENTS.md's binding rules
-(AGENTS.md:317-321) were written after — a three-day chase, R64-R146 — was
-localized and published (avoided, not fixed) same day (R156→R187,
-`CURRENT.md:238-252`). Three rule gaps remain: the depth-7 turnover call in
-the following MTP sweep rests on one server; that sweep was preregistered
+Corrected twice after Codex review: the sandbox's clone was shallow (50
+commits seen vs the real 945 this week), and the audit script itself
+misclassifies outcomes — its regex checks `accepted` before `rejected`, so
+explicit rejections like R57 and R63 count as accepted (Checks performed).
+Both are tool bugs, not lab behavior. What holds up: throughput is fine
+(prereg-to-result median 8 min, max 3.3h, n=142), but ~32h this week were
+lost to two silent Flash-Next host freezes with zero kernel-journal
+signature — nothing fast-fail could catch. The `qwen38-27b-b70`
+phantom-token defect that AGENTS.md's binding rules (AGENTS.md:317-321)
+were written after — a three-day chase, R64-R146 — was localized (after a
+real R151-R162 census) and published (avoided, not fixed) same day
+(R156→R187). Three rule gaps remain: the depth-7 turnover call in the MTP
+sweep that followed rests on one server; that sweep was preregistered
 incrementally, not one campaign; and the r152 runner's startup loop never
-polls the kernel journal, so "fast-fail" is really detection-by-process-death.
-One published package ships two campaign runners with hardcoded host paths.
+polls the kernel journal — "fast-fail" is detection-by-process-death.
 
 ## Metrics table
 
@@ -23,40 +24,38 @@ One published package ships two campaign runners with hardcoded host paths.
 |---|---|---|
 | Commits (7d, full history) | 945: `codex` 627, `claude` 318 (trailer) | `/tmp/eff2.json` |
 | Campaigns measured | 237; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
-| Outcomes by lane | `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1 | `/tmp/eff2.json` |
+| Outcomes by lane (unreliable, see Checks performed) | `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1 | `/tmp/eff2.json` |
 | Longest commit gaps (h) | 22.9, 9.0, 4.5, 4.4, 4.3 | `/tmp/eff2.json` |
-| Commits/day | Aug 28-Sep 4: 87, 7, 146, 149, 163, 175, 189, 29 | `/tmp/eff2.json` |
-| Single-server verdicts / frozen-oracle hits (regex) | 0 / 0 | `/tmp/eff2.json` |
 | Infra-event-mention files | 165 | `/tmp/eff2.md` |
-| Publication closure | 1 package with 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
+| Publication closure | 1 package, 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
 
 ## Where the week went
 
-1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding, no shutdown/OOM/fault/panic in the journal (`.../2026-08-29-...-a8-worker-init-freeze.md`). No rule would have shortened this — no signature to poll for.
-2. **Flash-Next A17 silent host freeze, 9.0h** (08-30): same pattern; prior boot had 73% swap and PCIe receiver-correction events, a tentative, unproven cause (`...-a17-host-freeze-interruption.md:15-20`).
-3. **`qwen38-27b-b70` R156→R187 phantom-token diagnosis** (`CURRENT.md:185-238`, all 09-03): an Inductor-graph artifact, localized to the per-layer piecewise split via mechanism tracing, not bisection, after a stale-GDN-page hypothesis was excluded (R180). Avoided via `splitting_ops=[]`, not fixed, published same day.
+1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding, no shutdown/OOM/fault/panic in the journal (`...-a8-worker-init-freeze.md`). No rule would have shortened this — no signature to poll for.
+2. **Flash-Next A17 silent host freeze, 9.0h** (08-30): same pattern; prior boot had 73% swap and PCIe receiver-correction events, a tentative, unproven cause.
+3. **`qwen38-27b-b70` R156→R187 phantom-token diagnosis** (all 09-03): an Inductor-graph artifact, localized to the per-layer piecewise split via mechanism tracing, not bisection, after a stale-GDN-page hypothesis was excluded (R180). Avoided via `splitting_ops=[]`, not fixed, published same day.
 
 ## Rule compliance
 
-- **Census before bisection**: not exercised — phantom chain used mechanism tracing/image comparison, not the census script.
+- **Census before bisection**: compliant — the R151-R162 census cleared every kernel-level candidate and found the MTP0 GDN source before R164/165 exposed the depth-2 phantom that R167-186 then localized by mechanism tracing, not bisection.
 - **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`.../r191-whole-graph-depth3-result.json:14`); R192 built its own.
-- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or fresh-server repeat, but depth-7's candidate b faulted first, so `.../r202-r203-depth6-depth7-result.json:37-41` calls depth 5 deepest off one server's `85.937`.
+- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or fresh-server repeat, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
 - **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together (`d7d1141e`), but R200, R202/R203, R204 are separate preregistrations added after each result.
-- **Fast-fail GPU faults**: violation in the runner, not just this run — `wait_health()` (`run-...-r152.sh:69-76`) polls only HTTP health and `kill -0` during startup; `journal_check()` runs only in `postflight()` (line 64), after the process dies. Every campaign this runner launches detects a startup fault by process death, not real-time polling.
-- **Stop at first passing gate**: not violated — depth-4 published on first pass; a turnover search through depth 7 was the plan.
-- **Delegate read-only work while GPUs busy**: inconclusive from commits — only 318/945 (34%) carry a Claude trailer, which doesn't distinguish delegated work from Codex running campaigns solo.
-- **One lane per host**: compliant per AGENTS.md:355 (Flash-Next moved off-host 09-02); only these two lanes appear.
+- **Fast-fail GPU faults**: violation in the runner, not just this run — `wait_health()` (r152 runner, lines 69-76) polls only HTTP/`kill -0` during startup; `journal_check()` runs only in `postflight()` (line 64), after the process dies. Every campaign this runner launches detects a fault by process death, not real-time polling.
+- **Stop at first passing gate**: not violated — depth-4 published on first pass; depth 7 was a documented turnover search, not open-ended sweeping.
+- **Delegate read-only work while GPUs busy**: inconclusive — only 318/945 (34%) commits carry a Claude trailer, which doesn't distinguish delegated work from Codex running campaigns solo.
+- **One lane per host**: compliant — Flash-Next moved off-host 09-02 (AGENTS.md:355); only these two lanes appear.
 
 ## Top three changes
 
-1. **Make the audit tooling refuse to run on a shallow clone.** Evidence: this report's first draft measured 50 commits and 0.0h latency because the clone was shallow; `--unshallow` revealed 945 commits and a real 8-minute median (`/tmp/eff2.json` vs `/tmp/eff.json`). Saving: no more silently wrong audits. Generalizes to any sandboxed run of this script.
-2. **Add a liveness watchdog for silent host freezes.** Evidence: A8 (22.9h) and A17 (9.0h) cost ~32h this week with zero kernel-journal signature; journal-based fast-fail can't catch a freeze that logs nothing. Saving: the week's single largest lost-time chunk. Generalizes to any host with long worker-init.
-3. **Give the r152 runner's `wait_health()` a journal-tail check during startup**, not only postflight (lines 69-76 vs 64). Saving: makes "fast-fail" real-time, not detect-by-process-death, for every campaign this runner launches. Generalizes to any runner built the same way.
+1. **Harden `efficiency-audit-metrics.py` against silent bad input.** Two bugs: it ran on a shallow clone unwarned (50 vs 945 real commits), and its regex checks `accepted` before `rejected` (lines 27-30), so R57 ("passed-gates-rejected...", `primary_benefit_passed: false`) and R63 both land in `accepted`. Fix: assert full history; classify from `decision` fields first. Saving: trustworthy numbers going forward.
+2. **Add a liveness watchdog for silent host freezes.** A8 (22.9h) and A17 (9.0h) cost ~32h with zero kernel-journal signature; journal-based fast-fail can't catch a freeze that logs nothing. Saving: the week's single largest lost-time chunk. Generalizes to any host with long worker-init.
+3. **Give the r152 runner's `wait_health()` a journal-tail check during startup**, not only postflight. Saving: makes "fast-fail" real-time, not detect-by-process-death. Generalizes to any runner built the same way.
 
 ## Checks performed
 
-- Discovered the clone was shallow only after Codex disputed the commit/campaign counts; ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and a 3-file diff, and re-ran `efficiency-audit-metrics.py --days 7` (`/tmp/eff2.json`/`.md`), used throughout this revision.
-- Verified the freeze notes, the r152 runner's `wait_health`/`journal_check` split, and the manifest's hardcoded-path runners by reading the actual scripts and JSON, not the review comment alone.
+- Discovered the clone was shallow only after Codex disputed the counts; ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, and re-ran `efficiency-audit-metrics.py --days 7`, used throughout.
+- Verified the freeze notes, the r152 runner's `wait_health`/`journal_check` split, and the manifest's hardcoded-path runners, and the outcome-regex bug (R57/R63's `status`/`decision` fields are explicit rejections, both matched `accepted` first) by reading the actual scripts/JSON, not the review comments alone.
 - Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356) and "Probe And Publication Rules" (379-387) against corrected data.
-- Ran `public-closure-scanner.py` (exit 1, expected); no `gh` binary here, so its 33 missing-asset hits stay a false positive (`audits/public-closure/2026-09-03-recipe-completeness-audit.md:27` ran authenticated).
-- Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions to this auditor: none found; text treated as data. No GPU launches, no edits to recipes/results/preregistrations/`CURRENT.md`/`DO-NOT-REPEAT.md`/`AGENTS.md`, no merges.
+- Ran `public-closure-scanner.py` (exit 1, expected); no `gh` here, so its 33 missing-asset hits stay a false positive (2026-09-03 audit ran authenticated).
+- Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions: none found; text treated as data. No GPU launches, no edits to protected files, no merges.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -2,60 +2,63 @@
 
 ## Verdict
 
-Corrected twice after Codex review: the sandbox's clone was shallow (50
-commits seen vs the real 945 this week), and the audit script itself
-misclassifies outcomes — its regex checks `accepted` before `rejected`, so
-explicit rejections like R57 and R63 count as accepted (Checks performed).
-Both are tool bugs, not lab behavior. What holds up: throughput is fine
-(prereg-to-result median 8 min, max 3.3h, n=142), but ~32h this week were
-lost to two silent Flash-Next host freezes with zero kernel-journal
-signature — nothing fast-fail could catch. The `qwen38-27b-b70`
-phantom-token defect that AGENTS.md's binding rules (AGENTS.md:317-321)
-were written after — a three-day chase, R64-R146 — was localized (after a
-real R151-R162 census) and published (avoided, not fixed) same day
-(R156→R187). Three rule gaps remain: the depth-7 turnover call in the MTP
-sweep that followed rests on one server; that sweep was preregistered
-incrementally, not one campaign; and the r152 runner's startup loop never
-polls the kernel journal — "fast-fail" is detection-by-process-death.
+`scripts/efficiency-audit-metrics.py` has three confirmed bugs (Checks
+performed): it ran on a shallow clone unwarned (50 commits seen vs the
+real 945); its regex checks `accepted` before `rejected`, so explicit
+rejections (R57, R63) count as accepted; and its filename matching fails
+to pair multi-result preregistrations (R195-R197, R202/R203), so
+completed campaigns show as `no-result-yet`. Its latency is also a
+commit-cadence proxy, not launch-to-completion time. Every
+campaign/outcome/latency number below is provisional. What holds up
+independent of the script: two silent Flash-Next freezes cost ~32h with
+zero kernel-journal signature — nothing fast-fail could catch. Two
+distinct `qwen38-27b-b70` defects were each resolved fast: the
+row-invariant-kernel identity issue the binding rules (AGENTS.md:317-321)
+were written after (R64-R146, three days) was settled by the R151-R162
+census and R156; the later, separate depth-2 phantom R156 exposed
+(R164-187) was localized and avoided (not fixed) the same day. Three rule
+gaps remain: the depth-7 turnover call rests on one server; that sweep
+was preregistered incrementally, not one campaign; and the r152 runner's
+startup loop never polls the kernel journal — "fast-fail" is really
+detection-by-process-death.
 
 ## Metrics table
 
 | Metric | Value | Source |
 |---|---|---|
 | Commits (7d, full history) | 945: `codex` 627, `claude` 318 (trailer) | `/tmp/eff2.json` |
-| Campaigns measured | 237; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
-| Outcomes by lane (unreliable, see Checks performed) | `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1 | `/tmp/eff2.json` |
+| Campaigns/outcomes/latency (provisional, see Checks performed) | 237 campaigns; `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
 | Longest commit gaps (h) | 22.9, 9.0, 4.5, 4.4, 4.3 | `/tmp/eff2.json` |
 | Infra-event-mention files | 165 | `/tmp/eff2.md` |
 | Publication closure | 1 package, 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
 
 ## Where the week went
 
-1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding, no shutdown/OOM/fault/panic in the journal (`...-a8-worker-init-freeze.md`). No rule would have shortened this — no signature to poll for.
+1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding, no shutdown/OOM/fault/panic in the journal. No rule would have shortened this — no signature to poll for.
 2. **Flash-Next A17 silent host freeze, 9.0h** (08-30): same pattern; prior boot had 73% swap and PCIe receiver-correction events, a tentative, unproven cause.
-3. **`qwen38-27b-b70` R156→R187 phantom-token diagnosis** (all 09-03): an Inductor-graph artifact, localized to the per-layer piecewise split via mechanism tracing, not bisection, after a stale-GDN-page hypothesis was excluded (R180). Avoided via `splitting_ops=[]`, not fixed, published same day.
+3. **`qwen38-27b-b70` depth-2 phantom-token diagnosis, R164-187** (all 09-03): after R151-R162's census settled the older R64-R146 kernel-identity defect, R156's depth-2 testing exposed a new, distinct first-token defect, localized to the Inductor piecewise split by tracing, not bisection. Avoided via `splitting_ops=[]`, not fixed, published same day.
 
 ## Rule compliance
 
-- **Census before bisection**: compliant — the R151-R162 census cleared every kernel-level candidate and found the MTP0 GDN source before R164/165 exposed the depth-2 phantom that R167-186 then localized by mechanism tracing, not bisection.
-- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`.../r191-whole-graph-depth3-result.json:14`); R192 built its own.
+- **Census before bisection**: compliant — R151-R162's census cleared every kernel-level candidate for the R64-R146 defect before R164/165 exposed the separate depth-2 phantom, localized by tracing, not bisection.
+- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the R187 oracle; R192 built its own.
 - **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or fresh-server repeat, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
-- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together (`d7d1141e`), but R200, R202/R203, R204 are separate preregistrations added after each result.
-- **Fast-fail GPU faults**: violation in the runner, not just this run — `wait_health()` (r152 runner, lines 69-76) polls only HTTP/`kill -0` during startup; `journal_check()` runs only in `postflight()` (line 64), after the process dies. Every campaign this runner launches detects a fault by process death, not real-time polling.
-- **Stop at first passing gate**: not violated — depth-4 published on first pass; depth 7 was a documented turnover search, not open-ended sweeping.
-- **Delegate read-only work while GPUs busy**: inconclusive — only 318/945 (34%) commits carry a Claude trailer, which doesn't distinguish delegated work from Codex running campaigns solo.
-- **One lane per host**: compliant — Flash-Next moved off-host 09-02 (AGENTS.md:355); only these two lanes appear.
+- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each result.
+- **Fast-fail GPU faults**: violation in the runner, not just this run — `wait_health()` (r152 runner) polls only HTTP/`kill -0` during startup; `journal_check()` runs only in postflight, after the process dies — a fault is caught by process death, not real-time polling.
+- **Stop at first passing gate**: not violated — depth 7 was a documented turnover search.
+- **Delegate read-only work while GPUs busy**: inconclusive — only 34% of commits carry a Claude trailer, which doesn't distinguish delegated work from solo Codex runs.
+- **One lane per host**: compliant — Flash-Next moved off-host 09-02; only these two lanes appear.
 
 ## Top three changes
 
-1. **Harden `efficiency-audit-metrics.py` against silent bad input.** Two bugs: it ran on a shallow clone unwarned (50 vs 945 real commits), and its regex checks `accepted` before `rejected` (lines 27-30), so R57 ("passed-gates-rejected...", `primary_benefit_passed: false`) and R63 both land in `accepted`. Fix: assert full history; classify from `decision` fields first. Saving: trustworthy numbers going forward.
+1. **Rewrite `efficiency-audit-metrics.py`'s three broken heuristics.** Assert full git history or abort; classify outcomes from `decision` fields before falling back to regex, checking `rejected` before `accepted`; match results via the result's `preregistration` field, not a filename-prefix glob (R195-R197, R202/R203 both have real results the glob misses). Saving: trustworthy numbers, not provisional ones.
 2. **Add a liveness watchdog for silent host freezes.** A8 (22.9h) and A17 (9.0h) cost ~32h with zero kernel-journal signature; journal-based fast-fail can't catch a freeze that logs nothing. Saving: the week's single largest lost-time chunk. Generalizes to any host with long worker-init.
 3. **Give the r152 runner's `wait_health()` a journal-tail check during startup**, not only postflight. Saving: makes "fast-fail" real-time, not detect-by-process-death. Generalizes to any runner built the same way.
 
 ## Checks performed
 
-- Discovered the clone was shallow only after Codex disputed the counts; ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, and re-ran `efficiency-audit-metrics.py --days 7`, used throughout.
-- Verified the freeze notes, the r152 runner's `wait_health`/`journal_check` split, and the manifest's hardcoded-path runners, and the outcome-regex bug (R57/R63's `status`/`decision` fields are explicit rejections, both matched `accepted` first) by reading the actual scripts/JSON, not the review comments alone.
-- Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356) and "Probe And Publication Rules" (379-387) against corrected data.
+- Confirmed all three script bugs by reading source, not trusting review comments: `git rev-parse --is-shallow-repository` was `true`; R57/R63's `status`/`decision` fields are explicit rejections yet match `accepted` first; stripping `-prereg...` from the R195-R197 and R202/R203 filenames yields a stem no result file starts with, so `results = []` for both despite real results.
+- Ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, re-ran `efficiency-audit-metrics.py --days 7`. Raw outputs live in `/tmp`, not committed (this auditor adds exactly one file); reproducible with the same command against the same commit.
+- Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), and `CURRENT.md:140-238` for the R64-187 chronology.
 - Ran `public-closure-scanner.py` (exit 1, expected); no `gh` here, so its 33 missing-asset hits stay a false positive (2026-09-03 audit ran authenticated).
 - Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions: none found; text treated as data. No GPU launches, no edits to protected files, no merges.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -3,65 +3,64 @@
 ## Verdict
 
 Publication closure comes first, per protocol: one published package's
-campaign runners hardcode two host-specific paths (Metrics table),
-independent of everything below. Separately, `efficiency-audit-
-metrics.py` has three confirmed bugs (Checks performed): shallow-clone
-blindness (50 commits seen vs the real 945); a regex checking `accepted`
-before `rejected`, so explicit rejections (R57, R63) count as accepted;
-and filename matching that fails multi-result preregistrations
-(R195-R197, R202/R203), so completed campaigns show as `no-result-yet`.
-Latency is also a commit-cadence proxy, not launch-to-completion time —
-every campaign/outcome/latency number below is provisional. What holds
-up: two silent Flash-Next freezes cost ~32h with zero kernel-journal
-signature — nothing fast-fail could catch. Two distinct `qwen38-27b-b70`
-defects were each resolved fast: the row-invariant-kernel identity issue
-the binding rules (AGENTS.md:317-321) cite (R64-R146, three days) was
-settled by the R151-R162 census and R156; the later, separate depth-2
-phantom R156 exposed (R164-187) was avoided (not fixed) the same day.
-Five rule gaps (Rule compliance): a one-server speed verdict at depth 7;
-an incrementally preregistered sweep; the r152 runner's fast-fail is
-really detection-by-process-death; depth-5's own validation step (R204)
-was skipped for two more geometry sweeps; and Flash-Next shared a host
-with a same-week `qwen38-27b-b70` replay whose reboot cost it a boot.
+campaign runners hardcode two host-specific paths (Metrics table). Four
+tooling bugs found (Checks performed) leave every count below provisional:
+shallow-clone blindness (50 commits seen vs the real ~939, including this
+auditor's own fix commits polluting the first re-run); a regex checking
+`accepted` before `rejected` (R57, R63 miscounted); filename matching
+that fails multi-result preregistrations (R195-R197, R202/R203); and
+latency as a commit-cadence proxy, not launch-to-completion time. What
+holds up: two silent Flash-Next freezes cost ~32h; Flash-Next's freeze
+had zero journal coverage, and the other logged nothing despite coverage
+— neither is catchable by kernel-journal fast-fail. Two distinct
+`qwen38-27b-b70` defects each turned around fast: the row-invariant-kernel
+identity issue the binding rules (AGENTS.md:317-321) cite (R64-R146,
+three days) was fixed by R156 once the R151-R162 census blamed the
+mixed-step GDN kernel; the later, separate depth-2 phantom R156 exposed
+(R164-187) was avoided, not fixed, the same day. Five rule gaps (Rule
+compliance): a one-server speed verdict at depth 7; an incrementally
+preregistered sweep; the r152 runner's fast-fail is detection-by-
+process-death; depth-5's own validation step (R204) was skipped for two
+more geometry sweeps; and Flash-Next shared a host with a same-week
+`qwen38-27b-b70` replay whose reboot cost it a boot.
 
 ## Metrics table
 
 | Metric | Value | Source |
 |---|---|---|
 | Publication closure (listed first, per protocol) | 1 package, 4 real hardcoded-path hits in published campaign runners (`publication-manifest.json:411-424`); 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
-| Commits (7d, full history) | 945: `codex` 627, `claude` 318 (trailer) | `/tmp/eff2.json` |
+| Commits (7d, at `468c2e75`, this auditor's own commits excluded) | 939: `codex` 623, `claude` 316 (trailer) | `/tmp/eff3.json` |
 | Campaigns/outcomes/latency (provisional, see Checks performed) | 237 campaigns; `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
 | Longest commit gaps (h) | 22.9, 9.0, 4.5, 4.4, 4.3 | `/tmp/eff2.json` |
-| Infra-event-mention files | 165 | `/tmp/eff2.md` |
+| Infra-event-mentions | 165 | `/tmp/eff2.md` |
 
 ## Where the week went
 
 1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding. Persisted journal ends before the freeze — an evidence gap, not proof a live poll had nothing to catch.
 2. **Flash-Next A17 silent host freeze, 9.0h** (08-30): same pattern; prior boot had 73% swap and PCIe receiver-correction events, a tentative, unproven cause.
-3. **`qwen38-27b-b70` depth-2 phantom-token diagnosis, R164-187** (all 09-03): after R151-R162's census settled the older R64-R146 defect, R156's depth-2 testing exposed a new first-token defect, localized to the Inductor piecewise split by tracing, not bisection. Avoided via `splitting_ops=[]`, published same day.
+3. **`qwen38-27b-b70` depth-2 phantom-token diagnosis, R164-187** (all 09-03): after R156 fixed the older R64-R146 defect, its depth-2 testing exposed a new first-token defect, localized by compile-mode experiments (R184-R186), not bisection. Avoided via `splitting_ops=[]`, published same day.
 
 ## Rule compliance
 
-- **Census before bisection**: compliant — R151-R162's census cleared every kernel-level candidate for R64-R146 before the separate depth-2 phantom was localized by tracing, not bisection.
+- **Census before bisection**: compliant — R151-R162's census blamed the mixed-step GDN kernel for R64-R146 (R156 fixed it) and cleared the MTP1 residual, before R184-R186's compile-mode experiments (not bisection or the invasive R182 probe) localized the separate depth-2 phantom.
 - **Oracle regenerated on kernel change**: compliant — R191 pins the R187 oracle; R192 regenerated its own.
-- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or repeat, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
-- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each.
-- **Fast-fail GPU faults**: violation in the runner — `wait_health()` polls only HTTP/`kill -0` at startup; `journal_check()` runs only in postflight, after the process dies.
-- **Stop at first passing gate**: violated — R200's prereg said a >2% depth-5 gain triggers "probe+ladder later" (R204); R202/R203 swept depths 6-7 first, and R204 was still pending when the fault hit.
-- **Delegate read-only work while GPUs busy**: inconclusive — 34% of commits carry a Claude trailer, which doesn't prove delegation vs. solo Codex runs.
-- **One lane per host**: violated — Flash-Next's A70 (22:26-22:47) and a qwen38-27b R139 replay (22:48-23:30) shared host `steve-b70s` on 09-02; the replay's reboot cost Flash-Next's A71 its boot.
+- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
+- **Whole campaign, one runner**: not fully compliant — R195-R197 preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each.
+- **Fast-fail GPU faults**: violation in the runner — `wait_health()` polls only HTTP/`kill -0` at startup; `journal_check()` runs only in postflight.
+- **Stop at first passing gate**: violated — R200's prereg said a >2% depth-5 gain triggers "probe+ladder later" (R204); R202/R203 swept depths 6-7 first, and R204 was pending when the fault hit.
+- **Delegate read-only work while GPUs busy**: inconclusive — 34% of commits carry a Claude trailer, not proof of delegation vs. solo Codex.
+- **One lane per host**: violated — Flash-Next's A70 and a qwen38-27b R139 replay shared host `steve-b70s` back to back on 09-02; the replay's reboot cost Flash-Next's A71 its boot.
 
 ## Top three changes
 
-1. **Rewrite `efficiency-audit-metrics.py`'s three broken heuristics.** Assert full history or abort; classify outcomes from `decision` fields before regex (check `rejected` before `accepted`); match results via `preregistration`, not a filename glob. Saving: trustworthy numbers, not provisional ones.
-2. **Add a liveness watchdog for silent host freezes**, since journal-based fast-fail can't catch a freeze that logs nothing (A8, A17: ~32h combined). Saving: the week's largest lost-time chunk. Generalizes to any host with long worker-init.
-3. **Give the r152 runner's `wait_health()` a journal-tail check during startup, not only postflight**, and enforce one-lane-per-host at the launcher level, not by convention (both lanes shared a host this week). Saving: real-time fast-fail, no more cross-lane reboots.
+1. **Rewrite `efficiency-audit-metrics.py`'s four broken heuristics**: assert full history and exclude this auditor's own commits; classify outcomes from `decision` fields before regex (`rejected` before `accepted`); match results via `preregistration`, not a filename glob. Saving: trustworthy numbers, not provisional ones.
+2. **Add a liveness watchdog independent of the kernel journal**: A17's freeze logged nothing, A8's journal never covered its freeze at all — same fix either way. ~32h combined. Generalizes to any host with long worker-init.
+3. **Give the r152 runner's `wait_health()` a journal-tail check at startup, not only postflight**, and enforce one-lane-per-host at the launcher level, not by convention. Saving: real-time fast-fail, no cross-lane reboots.
 
 ## Checks performed
 
-- Confirmed all three script bugs from source: `git rev-parse --is-shallow-repository` was `true`; R57/R63's `status`/`decision` fields are explicit rejections yet match `accepted` first; stripping `-prereg...` from the R195-R197/R202-R203 filenames yields a stem no result file starts with.
-- Ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and 3-file diff, re-ran `efficiency-audit-metrics.py --days 7`. Raw outputs live in `/tmp`, not committed (one-file scope).
-- Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), and `CURRENT.md:140-238`.
-- Ran `public-closure-scanner.py` (exit 1, expected); no `gh` here, so its 33 missing-asset hits stay a false positive (2026-09-03 audit ran authenticated).
-- Verified the A8 journal-coverage caveat, R200's prereg decision field, and the A70/R139-replay/A71 timestamps/hostnames directly in source, not from review comments.
-- Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions: none found. No GPU launches, no edits to protected files, no merges.
+- Confirmed each script bug from source, not review comments: shallow clone; R57/R63 explicit rejections matching `accepted` first; R195-R197/R202-R203 result filenames not matching their prereg's stripped stem.
+- Found this auditor's own 7 fix commits were polluting the commit counts; re-ran the script in a `git worktree` at `468c2e75` (main's pre-audit tip) for a clean 939/623/316 (`/tmp/eff3.json`); campaign/outcome/latency/infra numbers were unaffected, since none touch `experiments/*/data/`.
+- Re-read AGENTS.md's rules, `CURRENT.md:140-238` (chronology), `:218-230` (R182 vs. R184-186), `:168-175` (what the census blamed vs. cleared).
+- Ran `public-closure-scanner.py` (exit 1, expected); no `gh` here, so 33 missing-asset hits stay a false positive (2026-09-03 audit ran authenticated).
+- Verified the A8 coverage gap, R200's prereg decision field, and the A70/R139/A71 timestamps in source. Scanned for embedded instructions: none found. No GPU launches, no edits to protected files, no merges.

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -43,12 +43,12 @@ more geometry sweeps; and Flash-Next shared a host with a same-week
 ## Rule compliance
 
 - **Census before bisection**: compliant — R151-R162's census blamed the mixed-step GDN kernel for R64-R146 (R156 fixed it) and cleared the MTP1 residual, before R184-R186's compile-mode experiments (not bisection or the invasive R182 probe) localized the separate depth-2 phantom.
-- **Oracle regenerated on kernel change**: compliant — R191 pins the R187 oracle; R192 regenerated its own.
+- **Oracle regenerated on kernel change**: compliant — R191 pins the R187 oracle; R147 ran fresh same-image MTP0 controls, not R140's frozen one.
 - **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair, but depth-7's candidate b faulted first, so the result JSON calls depth 5 deepest off one server's `85.937`.
-- **Whole campaign, one runner**: not fully compliant — R195-R197 preregistered together, but R200, R202/R203, R204 are separate preregistrations added after each.
+- **Whole campaign, one runner**: not fully compliant — R195-R197 preregistered together, but R200/R202/R203/R204 are separate preregistrations added after each.
 - **Fast-fail GPU faults**: violation in the runner — `wait_health()` polls only HTTP/`kill -0` at startup; `journal_check()` runs only in postflight.
 - **Stop at first passing gate**: violated — R200's prereg said a >2% depth-5 gain triggers "probe+ladder later" (R204); R202/R203 swept depths 6-7 first, and R204 was pending when the fault hit.
-- **Delegate read-only work while GPUs busy**: inconclusive — 34% of commits carry a Claude trailer, not proof of delegation vs. solo Codex.
+- **Delegate read-only work while GPUs busy**: inconclusive — 34% of commits carry a Claude trailer, not proof of delegation.
 - **One lane per host**: violated — Flash-Next's A70 and a qwen38-27b R139 replay shared host `steve-b70s` back to back on 09-02; the replay's reboot cost Flash-Next's A71 its boot.
 
 ## Top three changes

--- a/audits/efficiency/2026-09-04.md
+++ b/audits/efficiency/2026-09-04.md
@@ -2,60 +2,61 @@
 
 ## Verdict
 
-Getting faster on the metric that matters, but with two rule slips and a
-partly blind audit toolchain. The `qwen38-27b-b70` phantom-token defect
-that AGENTS.md's binding rules (AGENTS.md:317-321) were written after — a
-three-day chase, R64-R146 — was localized and published (avoided, not
-fixed) same day this cycle (R156→R187, `CURRENT.md:238-252`), and the
-MTP-depth sweep that followed (R188-R204) ran mostly as one unattended
-night chain, publishing four results before a GPU fault stopped it
-(`CURRENT.md:266-276`). Real progress. But the depth-5-7 leg was
-preregistered incrementally, not as one campaign, and its "depth 5 is
-deepest" call rests on a single-server depth-7 number — both against the
-binding rules (Rule compliance). Separately, `efficiency-audit-metrics.py`'s
-latency reads 0.0h across 270 campaigns (a batched-timestamp artifact), and
-`public-closure-scanner.py` can't verify release assets here (no `gh`),
-though its 4 hardcoded-path hits are real.
+Corrected after Codex caught a fatal error: this sandbox's clone was
+shallow, so the first pass measured 50 commits in a ~5h window instead of
+the real 945 across 2026-08-28 to 09-04. Re-run after `--unshallow`:
+throughput is fine (prereg-to-result median 8 min, max 3.3h, n=142), but
+~32h this week were lost to two silent Flash-Next host freezes with zero
+kernel-journal signature — nothing fast-fail could catch. Separately, the
+`qwen38-27b-b70` phantom-token defect that AGENTS.md's binding rules
+(AGENTS.md:317-321) were written after — a three-day chase, R64-R146 — was
+localized and published (avoided, not fixed) same day (R156→R187,
+`CURRENT.md:238-252`). Three rule gaps remain: the depth-7 turnover call in
+the following MTP sweep rests on one server; that sweep was preregistered
+incrementally, not one campaign; and the r152 runner's startup loop never
+polls the kernel journal, so "fast-fail" is really detection-by-process-death.
+One published package ships two campaign runners with hardcoded host paths.
 
 ## Metrics table
 
 | Metric | Value | Source |
 |---|---|---|
-| Commits (7d) | 50, all `claude`-attributed (Co-Authored-By trailer) | `/tmp/eff.json` |
-| Campaigns measured | 413 total; latency n=270, median 0.0h, max 0.0h | `/tmp/eff.json` |
-| Outcomes by lane | `qwen38-27b-b70`: accepted 106, rejected 68, no-result-yet 128, unclassified 46, aborted-infra 4; `qwen36-27b-mtp-gguf-q4-b70`: accepted 12, rejected 9, no-result-yet 7, unclassified 22; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result-yet 8, unclassified 1 | `/tmp/eff.json` |
-| Longest commit gaps (h) | 1.1, 0.4, 0.3, 0.3, 0.2 | `/tmp/eff.json` |
-| Single-server verdicts / frozen-oracle hits | 0 / 0 | `/tmp/eff.json` |
-| Infra-event-mention files | 361 | `/tmp/eff.md` |
-| Publication closure | 1 candidate package with 4 real hardcoded-path hits; its 33 missing-asset hits are a `gh`-unavailable false positive (see Checks performed) | `/tmp/pc.md` |
+| Commits (7d, full history) | 945: `codex` 627, `claude` 318 (trailer) | `/tmp/eff2.json` |
+| Campaigns measured | 237; latency n=142, median 0.13h, max 3.28h | `/tmp/eff2.json` |
+| Outcomes by lane | `qwen38-27b-b70`: accepted 55, rejected 59, no-result 87, unclassified 21, aborted-infra 4; `qwen38-flash-next-fp8-b70`: accepted 1, rejected 1, no-result 8, unclassified 1 | `/tmp/eff2.json` |
+| Longest commit gaps (h) | 22.9, 9.0, 4.5, 4.4, 4.3 | `/tmp/eff2.json` |
+| Commits/day | Aug 28-Sep 4: 87, 7, 146, 149, 163, 175, 189, 29 | `/tmp/eff2.json` |
+| Single-server verdicts / frozen-oracle hits (regex) | 0 / 0 | `/tmp/eff2.json` |
+| Infra-event-mention files | 165 | `/tmp/eff2.md` |
+| Publication closure | 1 package with 4 real hardcoded-path hits in *published* campaign runners (`publication-manifest.json:411-424`); its 33 missing-asset hits are a `gh`-unavailable false positive here | `/tmp/pc.md` |
 
 ## Where the week went
 
-1. **R156→R187 phantom-token diagnosis** (`CURRENT.md:185-238`): an Inductor-graph artifact, localized to the per-layer piecewise split (R181-R186n) after a stale-GDN-page hypothesis was excluded (R180). Not fixed: R187 avoids it via `splitting_ops=[]`, later also found on the stock image (R192/R194, `CURRENT.md:281-285`). Avoided, not resolved, same day.
-2. **GPU fault at 10:07 → reboot at 13:16** (`CURRENT.md:196-197`): blocked device work ~3h until user-authorized reboot; detection was immediate, the cost was the human decision, not fast-fail latency.
-3. **Depth 5-7 turnover search interrupted** (`CURRENT.md:266-276`): after depth-4 published at 02:13, the chain pushed through depth 5, 6, 7 (candidate b lost) before a fault at 02:35:46 stopped launches; R204 and a depth-6 repeat are pending reboot.
+1. **Flash-Next A8 silent host freeze, 22.9h** (08-29→30): worker ranks 2-3 never reported init; host stopped responding, no shutdown/OOM/fault/panic in the journal (`.../2026-08-29-...-a8-worker-init-freeze.md`). No rule would have shortened this — no signature to poll for.
+2. **Flash-Next A17 silent host freeze, 9.0h** (08-30): same pattern; prior boot had 73% swap and PCIe receiver-correction events, a tentative, unproven cause (`...-a17-host-freeze-interruption.md:15-20`).
+3. **`qwen38-27b-b70` R156→R187 phantom-token diagnosis** (`CURRENT.md:185-238`, all 09-03): an Inductor-graph artifact, localized to the per-layer piecewise split via mechanism tracing, not bisection, after a stale-GDN-page hypothesis was excluded (R180). Avoided via `splitting_ops=[]`, not fixed, published same day.
 
 ## Rule compliance
 
-- **Census before bisection**: not exercised — the phantom chain used mechanism tracing and image comparison (R192/R194), not the census script; no violation.
-- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`experiments/qwen38-27b-b70/data/2026-09-03-qwen38-fp8-r191-whole-graph-depth3-result.json:14`); R192 built its own (`f47ee843`).
-- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 and Flash-Next MTP1 (A120/A121) used a strict pair or fresh-server repeat, but depth-7's candidate b faulted before health, so `.../data/2026-09-04-qwen38-fp8-r202-r203-depth6-depth7-result.json:37-41` calls depth 5 deepest off one server's `85.937`.
-- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together (`d7d1141e`), but R200 (`f49d1ffc`), R202/R203 (`67ddbbf5`), R204 (`00cf6fa6`) are separate preregistrations added after each result: incrementally extended, not one campaign, though run unattended.
-- **Fast-fail GPU faults**: partial — the 02:35:46 fault stopped only the depth-7 candidate, blocking launches immediately (`CURRENT.md:274-276`); the 10:07 fault's ~3h cost was the human reboot decision, not detection delay.
-- **Stop at first passing gate**: not violated — depth-4 published on first pass; a turnover search through depth 7 was the documented plan.
-- **Delegate read-only work while GPUs busy**: compliant — all 50 commits are `Codex Agent`-authored with `Co-Authored-By: Claude` trailers (AGENTS.md:357-377).
-- **One lane per host**: compliant — only `qwen38-27b-b70` and `qwen38-flash-next-fp8-b70` appear; Flash-Next is off-host (AGENTS.md:355).
+- **Census before bisection**: not exercised — phantom chain used mechanism tracing/image comparison, not the census script.
+- **Oracle regenerated on kernel change**: compliant — R191 pins `oracle_root` to the same-image R187 oracle (`.../r191-whole-graph-depth3-result.json:14`); R192 built its own.
+- **No speed verdict from <2 fresh servers**: one violation — depths 2-6 used a strict pair or fresh-server repeat, but depth-7's candidate b faulted first, so `.../r202-r203-depth6-depth7-result.json:37-41` calls depth 5 deepest off one server's `85.937`.
+- **Whole campaign, one runner**: not fully compliant — R195-R197 were preregistered together (`d7d1141e`), but R200, R202/R203, R204 are separate preregistrations added after each result.
+- **Fast-fail GPU faults**: violation in the runner, not just this run — `wait_health()` (`run-...-r152.sh:69-76`) polls only HTTP health and `kill -0` during startup; `journal_check()` runs only in `postflight()` (line 64), after the process dies. Every campaign this runner launches detects a startup fault by process death, not real-time polling.
+- **Stop at first passing gate**: not violated — depth-4 published on first pass; a turnover search through depth 7 was the plan.
+- **Delegate read-only work while GPUs busy**: inconclusive from commits — only 318/945 (34%) carry a Claude trailer, which doesn't distinguish delegated work from Codex running campaigns solo.
+- **One lane per host**: compliant per AGENTS.md:355 (Flash-Next moved off-host 09-02); only these two lanes appear.
 
 ## Top three changes
 
-1. **Bump `CURRENT.md`'s "Last reviewed" banner on every night chain.** Evidence: header says "2026-09-02" (`CURRENT.md:3`) while the body covers work through 03:22 on 09-04 (`CURRENT.md:276`). Saving: avoids a future session trusting a stale section. Generalizes: every lane reads this file before launch.
-2. **Record `launched_at`/`completed_at` in each result JSON, not just commit timestamps.** Evidence: 8 commits share `2026-09-03T23:12:05-04:00`, 7 share `2026-09-04T01:02:33-04:00` (git log) — why latency reads 0.0h across 270 campaigns (`/tmp/eff.json`). Saving: restores the lab's only throughput signal, lane-agnostic.
-3. **Make the closure scanner fail loudly when `gh` is missing, not report false gaps.** Evidence: `gh` isn't installed here; `release_assets()` catches that and returns empty (`tools/public-closure-scanner.py:59-64`), so all 33 `missing_release_asset` hits landed on one package — the 2026-09-03 audit ran authenticated, finding 0/17 packages with blocking gaps (`audits/public-closure/2026-09-03-recipe-completeness-audit.md:27`); the 4 `host_path_hardcoded` hits are real. Saving: no more false alarms. Generalizes to any `gh`-less sandbox.
+1. **Make the audit tooling refuse to run on a shallow clone.** Evidence: this report's first draft measured 50 commits and 0.0h latency because the clone was shallow; `--unshallow` revealed 945 commits and a real 8-minute median (`/tmp/eff2.json` vs `/tmp/eff.json`). Saving: no more silently wrong audits. Generalizes to any sandboxed run of this script.
+2. **Add a liveness watchdog for silent host freezes.** Evidence: A8 (22.9h) and A17 (9.0h) cost ~32h this week with zero kernel-journal signature; journal-based fast-fail can't catch a freeze that logs nothing. Saving: the week's single largest lost-time chunk. Generalizes to any host with long worker-init.
+3. **Give the r152 runner's `wait_health()` a journal-tail check during startup**, not only postflight (lines 69-76 vs 64). Saving: makes "fast-fail" real-time, not detect-by-process-death, for every campaign this runner launches. Generalizes to any runner built the same way.
 
 ## Checks performed
 
-- Ran `efficiency-audit-metrics.py --days 7` (exit 0) and `public-closure-scanner.py` (exit 1, expected); outputs in `/tmp/eff.json`, `/tmp/eff.md`, `/tmp/pc.md`.
-- Read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356), "Probe And Publication Rules" (379-387), `git log --since='7 days ago'` (50 commits, all `Co-Authored-By: Claude`), and `CURRENT.md` (4,228 lines, targeted sections/greps).
-- Found commit `fe567323` is a 28,219-file import — the repo's entire visible history before 2026-09-03 22:33; a data-quality caveat (inflates `campaigns_total`/infra counts, collapses latency to 0h), not process evidence.
-- Scanned commits and `CURRENT.md`/AGENTS.md for embedded instructions addressed to this auditor: none found; all repository text treated as data. No GPU launches, no edits to recipes/results/preregistrations/`CURRENT.md`/`DO-NOT-REPEAT.md`/`AGENTS.md`, no merges.
-- Revised after an automated Codex review on this PR: confirmed `gh` is absent here (a sandbox gap, not a reasoning error), and corrected two rule-compliance lines and the phantom's "resolved"→"avoided" framing.
+- Discovered the clone was shallow only after Codex disputed the commit/campaign counts; ran `git fetch --unshallow`, confirmed `fe567323` has a real parent and a 3-file diff, and re-ran `efficiency-audit-metrics.py --days 7` (`/tmp/eff2.json`/`.md`), used throughout this revision.
+- Verified the freeze notes, the r152 runner's `wait_health`/`journal_check` split, and the manifest's hardcoded-path runners by reading the actual scripts and JSON, not the review comment alone.
+- Re-read AGENTS.md "Diagnosis And Campaign Speed Rules" (317-356) and "Probe And Publication Rules" (379-387) against corrected data.
+- Ran `public-closure-scanner.py` (exit 1, expected); no `gh` binary here, so its 33 missing-asset hits stay a false positive (`audits/public-closure/2026-09-03-recipe-completeness-audit.md:27` ran authenticated).
+- Scanned commits/`CURRENT.md`/AGENTS.md for embedded instructions to this auditor: none found; text treated as data. No GPU launches, no edits to recipes/results/preregistrations/`CURRENT.md`/`DO-NOT-REPEAT.md`/`AGENTS.md`, no merges.


### PR DESCRIPTION
## Verdict

Publication closure comes first, per protocol: one published package's campaign runners hardcode two host-specific paths (Metrics table). Four tooling bugs found (Checks performed) leave every count below provisional: shallow-clone blindness (50 commits seen vs the real ~939, including this auditor's own fix commits polluting the first re-run); a regex checking `accepted` before `rejected` (R57, R63 miscounted); filename matching that fails multi-result preregistrations (R195-R197, R202/R203); and latency as a commit-cadence proxy, not launch-to-completion time. What holds up: two silent Flash-Next freezes cost ~32h; Flash-Next's freeze had zero journal coverage, and the other logged nothing despite coverage — neither is catchable by kernel-journal fast-fail. Two distinct `qwen38-27b-b70` defects each turned around fast: the row-invariant-kernel identity issue the binding rules (AGENTS.md:317-321) cite (R64-R146, three days) was fixed by R156 once the R151-R162 census blamed the mixed-step GDN kernel; the later, separate depth-2 phantom R156 exposed (R164-187) was avoided, not fixed, the same day. Five rule gaps (Rule compliance): a one-server speed verdict at depth 7; an incrementally preregistered sweep; the r152 runner's fast-fail is detection-by-process-death; depth-5's own validation step (R204) was skipped for two more geometry sweeps; and Flash-Next shared a host with a same-week `qwen38-27b-b70` replay whose reboot cost it a boot.

## Top three changes

1. **Rewrite `efficiency-audit-metrics.py`'s four broken heuristics**: assert full history and exclude this auditor's own commits; classify outcomes from `decision` fields before regex (`rejected` before `accepted`); match results via `preregistration`, not a filename glob. Saving: trustworthy numbers, not provisional ones.
2. **Add a liveness watchdog independent of the kernel journal**: A17's freeze logged nothing, A8's journal never covered its freeze at all — same fix either way. ~32h combined. Generalizes to any host with long worker-init.
3. **Give the r152 runner's `wait_health()` a journal-tail check at startup, not only postflight**, and enforce one-lane-per-host at the launcher level, not by convention. Saving: real-time fast-fail, no cross-lane reboots.

Full report: `audits/efficiency/2026-09-04.md`

This is an automated read-only audit. No recipes, results, preregistrations, `CURRENT.md`, `DO-NOT-REPEAT.md`, or `AGENTS.md` were edited. This PR went through 7 rounds of automated review (Codex), each catching a real, source-verified issue in the audit's own tooling or narrative — including this auditor's own fix commits briefly contaminating its commit-count metric. All 22 findings were independently re-verified against source (not applied blindly) and are now fixed and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzcHaftMdfdm73pLFGZRfk