### PR TITLE
Efficiency audit 2026-09-06

### DIFF
--- a/audits/efficiency/2026-09-06.md
+++ b/audits/efficiency/2026-09-06.md
@@ -2,110 +2,112 @@
 
 ## Verdict
 
-The lab is fast this window, but the window is not what it looks like: the
-entire git history reachable by `--since='7 days ago'` spans one boot-to-boot
-session, `ff455c41` (2026-09-05T23:05:06-04:00, a 28,938-file import commit)
-through `5216bb4b` (2026-09-06T05:42:17-04:00) — about 6.6 hours, not seven
-days. In that window the INT4 lane went from a 91.0 tok/s graph-capture
-headline (R247) to a 112.36 tok/s published headline (R257) and kept
-optimizing overnight (R261-R278), while fast-fail preflight correctly
-aborted three GPU faults instead of burning health-timeout minutes. The drag
-is repeated single-arm, human-narrated commits (R220-R247) where the
-campaign's own "matrix" runner pattern (`r222`/`r227`/`r239`) went unused,
-and a DO-NOT-REPEAT entry that reads as host-wide is now contradicted by
-this window's own result.
+**Correction (see Checks performed): the first version of this report ran
+against a shallow clone and misjudged the window's shape.** The real window
+is 2026-08-30 to 2026-09-06, 1157 commits, across two active lanes:
+`qwen38-27b-b70` (official FP8/INT4) and `qwen38-flash-next-fp8-b70` (MoE
+placement/offload). Both show the same shape: reach a passing, lossless
+candidate, then keep sweeping one to two more days before publishing.
+Flash-Next's MTP0 line was approved 09-04 11:04 (`8319e0964`), but kept
+running attribution/placement work (A114-A205) through two more publishes
+on 09-06. INT4's R247 passed its lossless gate at 91.0 tok/s on 09-05
+22:21 and kept sweeping through R278. Fast-fail preflight worked all
+week; one DO-NOT-REPEAT entry underclaims a lever a sibling lane now uses
+productively.
 
 ## Metrics table
 
 | Metric | Value | Source |
 |---|---|---|
-| Commits (author: 100% Codex, Claude co-author) | 50 | `/tmp/eff.json` |
-| Campaigns total | 416 | `/tmp/eff.json` |
-| qwen38-27b-b70 outcomes | no-result 131, accepted 106, rejected 68, unclassified 46, aborted-infra 4 | `/tmp/eff.json` |
-| qwen36-27b-mtp-gguf-q4-b70 outcomes | accepted 12, rejected 9, unclassified 22, no-result 7 | `/tmp/eff.json` |
-| qwen38-flash-next-fp8-b70 outcomes | accepted 1, rejected 1, unclassified 1, no-result 8 | `/tmp/eff.json` |
-| Prereg-to-result latency (see Checks) | median/max 0.0h, n=270 | `/tmp/eff.json` |
-| Infra-event file mentions (see Checks) | 364 | `/tmp/eff.json` |
-| Single-server speed verdicts flagged | 0 | `/tmp/eff.json` |
-| Frozen-oracle gate violations flagged | 0 | `/tmp/eff.json` |
+| Commits (codex/claude) | 1158 (521/637) | `/tmp/eff2.json` |
+| Campaigns total | 237 | `/tmp/eff2.json` |
+| qwen38-27b-b70 outcomes | no-result 89, accepted 53, rejected 59, unclassified 21, aborted-infra 4 | `/tmp/eff2.json` |
+| qwen38-flash-next-fp8-b70 outcomes | accepted 1, rejected 1, unclassified 1, no-result 8 | `/tmp/eff2.json` |
+| Prereg-to-result latency | median 0.13h, max 3.28h, n=140 | `/tmp/eff2.json` |
+| Infra-event file mentions (see Checks) | 155 | `/tmp/eff2.json` |
+| Single-server speed verdicts flagged | 0 | `/tmp/eff2.json` |
+| Frozen-oracle gate violations flagged | 0 | `/tmp/eff2.json` |
 
 ## Where the week went
 
-All visible commits belong to one lane pair on one host: `qwen38-27b-b70`
-(FP8 and INT4 sub-lanes). Three stretches stand out:
+1. **Flash-Next A91-A205 (09-03 through 09-06).** A multi-day attribution
+   chain (day summaries `12d7fc378`, `64388d803`, `d2ed88424`, `fdf60dfd7`,
+   `a43bf5f06`) worked step attribution, collective-knobs, split-K, and
+   cold-expert placement one arm at a time, past its own first accepted
+   result (09-04) into two more publishes on 09-06.
+2. **INT4 R220-R247 (09-05 daytime).** A fixed-K W4A16 port (R220-R228)
+   closed most of the c32/c64 residual; eleven further arms (R229-R247)
+   chased the remaining GDN-composition residual one at a time, ending
+   "closed for today" unresolved (`CURRENT.md` lines 424-470).
+3. **Two GPU faults on 0000:03:00.0 within ~12h (01:43, 13:07:50, 09-05)**,
+   both during weight staging, caught by preflight before launch
+   (`CURRENT.md` line 428: "a host reliability item for the user");
+   recovery from the second took about an hour.
 
-1. **R220-R247 (2026-09-05 daytime), row-invariance + graph search.** A
-   fixed-K W4A16 kernel port (R220-R228) closed most of the c32/c64
-   residual; eleven further arms (R229-R247) then chased the remaining
-   GDN-composition residual one at a time, ending "closed for today"
-   unresolved (`CURRENT.md` lines 424-470). Rule 4 would have shortened
-   the round trips.
-2. **Two GPU faults on 0000:03:00.0 within ~12h (01:43 and 13:07:50)**, both
-   during weight staging, both caught by preflight before launch
-   (`CURRENT.md` line 428: "a host reliability item for the user"); recovery
-   from the second took about an hour ("Fresh boot 14:12, third today").
-3. **R261-R278 (2026-09-06 overnight)**, the pass that hit a single-user
-   speed floor (112.70/112.96 tok/s, V2 runner) then two more xe faults
-   (04:47 on 03:00.0, 05:34 on e3:00.0), each deferred to `@reboot`
-   autolaunch (`5216bb4b`).
-
-Distance to publication for INT4: recipe, package, README, and manifest are
-already updated through R257 (`1ad989d9ad78`), image pushed to GHCR; the
-one remaining gate is that the image is private ("the user must flip
-visibility", line 457).
+Distance to publication: Flash-Next has two LocalMaxxing-approved lines
+(09-06). INT4's recipe/package/README/manifest are updated through R257
+(`1ad989d9ad78`) and the image is on GHCR; the one remaining gate is that
+the image is private (`CURRENT.md` line 457, "the user must flip
+visibility").
 
 ## Rule compliance
 
-- **Census before bisection** — compliant: R210 ARK/woqgemm census preceded
-  R211-R213; A168/A197 census preceded the A198-A205 packets.
-- **Oracle bound to kernel identity** — compliant: every image change (R216,
-  R228, R253, R257) reports a fresh same-image oracle; script flagged 0.
+- **Census before bisection** — compliant: R210 preceded R211-R213;
+  A168/A197 preceded A198-A205.
+- **Oracle bound to kernel identity** — compliant: R216/R228/R253/R257 each
+  report a fresh same-image oracle; script flagged 0.
 - **No speed verdict from <2 servers** — compliant: script flagged 0;
-  `CURRENT.md` withholds a verdict on a single-arm result ("depth-5 candidate
-  a... single arm; the two-run rule still needs candidate b").
+  `CURRENT.md` withholds a verdict on a single-arm result ("single arm; the
+  two-run rule still needs candidate b").
 - **Whole campaign, one runner** — mixed: `r222/r227/r230/r239-matrix`
-  comply, but R220-R247 ran as ~15 separately committed single arms.
+  comply, but R220-R247 and Flash-Next's A91-A205 ran as many separately
+  committed single arms.
 - **Fast-fail GPU faults** — compliant: preflight aborted the queue on all
-  three recorded faults, not a health timeout.
-- **Stop at first passing gate** — worth watching: R247 passed its lossless
-  gate (91.0 tok/s) but the campaign continued through R259 before the
-  112.36 tok/s publish; a net gain, but not the same-day-publish pattern.
+  recorded faults, not a health timeout.
+- **Stop at first passing gate** — worth watching: INT4's R247 and
+  Flash-Next's 09-04 approval each passed a gate then kept sweeping 1-2
+  more days before publishing; a net gain, not same-day-publish.
 - **Delegate read-only work while GPUs busy** — compliant: notes/tooling
-  commits (A192-A205) interleave with the GPU campaigns, Codex-authored
-  with Claude co-authorship, matching AGENTS.md's delegation split.
-- **One lane per host** — not assessable; only one lane pair is visible.
+  interleave with GPU campaigns; the codex 521/claude 637 author split
+  matches AGENTS.md's delegation policy.
+- **One lane per host** — not assessable from git alone: both lanes were
+  active the same hours on 08-30, matching what the rule (dated 09-02)
+  says used to cost reboots, not a current violation.
 
 ## Top three changes
 
 1. **Scope DO-NOT-REPEAT entries by lane/kernel, not by host.** Evidence:
-   the 2026-09-04 entry says XPU graph capture is "1.1-1.4% slower every
-   time... keep graphs off here" (FP8-lane R58/R163/R198), but INT4's
-   R247/R257 made graph capture the fastest lossless config on the same
-   host. Saving: avoids either silently skipping a viable lever or blindly
-   re-testing a closed one. Generalizes to every entry that projects one
-   lane's finding onto "this host."
+   the 09-04 entry says XPU graph capture is "1.1-1.4% slower... keep
+   graphs off here" (FP8-lane R58/R163/R198), but INT4's R247/R257 made it
+   the fastest lossless config on the same host. Saving: avoids silently
+   skipping a viable lever or blindly re-testing a closed one. Generalizes
+   to any entry that projects one lane's finding onto "this host."
 2. **Default multi-arm sweeps to the matrix-runner pattern already proven
    this window.** Evidence: `r222/r227/r239-matrix` ran multiple depths/TP
-   unattended, while R220-R247 ran the same kind of sweep as ~15
-   individually committed arms. Saving: fewer round trips per residual
-   hunt. Generalizes to any future kernel-variant or geometry sweep.
+   unattended, while INT4's R220-R247 and Flash-Next's A91-A205 ran as many
+   individually committed single arms. Saving: fewer round trips per
+   residual hunt. Generalizes to any kernel-variant or geometry sweep.
 3. **Treat the recurring 03:00.0/e3:00.0 weight-staging faults as a host
    ticket, not a per-lane retry cost.** Evidence: faults at 01:43, 13:07:50,
-   04:47, 05:34, each costing a reboot cycle (~1h observed after 13:07).
-   Saving: removes a recurring tax on whichever lane is running.
-   Generalizes to every future lane on this host until fixed.
+   04:47, 05:34, each costing a reboot cycle (~1h after 13:07). Saving:
+   removes a recurring tax on whichever lane is running. Generalizes to
+   every lane on this host until fixed.
 
 ## Checks performed
 
-- Ran `scripts/efficiency-audit-metrics.py --days 7` (exit 0); its JSON is
-  the only source for the metrics table.
-- `git log --format=%cI` shows history spans only 2026-09-05T23:05-04:00 to
-  2026-09-06T05:42-04:00 (~6.6h), not seven days; counts are "since import."
-- The 0.0h prereg-to-result latency (n=270) looks like a same-commit
-  artifact, unverified. The 364 "infra-event file" count is a keyword/file
-  match, not a fault count; notes evidence 4 distinct faults.
-- Read `experiments/qwen38-27b-b70/DO-NOT-REPEAT.md` in full and the INT4/FP8
-  sections of `CURRENT.md` (lines 1-503).
+- **Data-quality failure, corrected:** the first pass ran in a shallow
+  clone (`is-shallow-repository` true), so `--since` silently stopped at
+  the fetch boundary (50 commits, 6.6h), and `ff455c41` looked like a
+  28,938-file import (a shallow clone diffs a parentless boundary commit
+  against an empty tree). `git fetch --unshallow` found 6026 real commits
+  back to 2026-05-03; `ff455c41` is an ordinary 4-file commit. A PR review
+  comment caught this, verified directly; report regenerated post-unshallow.
+- Re-ran the metrics script post-unshallow (exit 0), the only source for
+  the metrics table. The 155 "infra-event file" count is a keyword match,
+  not a fault count; notes evidence 4 distinct faults this week.
+- Read `DO-NOT-REPEAT.md` in full and the INT4/FP8 sections of
+  `CURRENT.md` (lines 1-503); file-content citations, unaffected by the
+  shallow-clone bug.
 - No file, commit, or note contained instructions addressed to this
   auditor; AGENTS.md's rules were read only as the compliance yardstick.
 - No GPU work launched/simulated; no recipe, result, preregistration,

--- a/audits/efficiency/2026-09-06.md
+++ b/audits/efficiency/2026-09-06.md
@@ -1,0 +1,112 @@
+# Efficiency audit — 2026-09-06
+
+## Verdict
+
+The lab is fast this window, but the window is not what it looks like: the
+entire git history reachable by `--since='7 days ago'` spans one boot-to-boot
+session, `ff455c41` (2026-09-05T23:05:06-04:00, a 28,938-file import commit)
+through `5216bb4b` (2026-09-06T05:42:17-04:00) — about 6.6 hours, not seven
+days. In that window the INT4 lane went from a 91.0 tok/s graph-capture
+headline (R247) to a 112.36 tok/s published headline (R257) and kept
+optimizing overnight (R261-R278), while fast-fail preflight correctly
+aborted three GPU faults instead of burning health-timeout minutes. The drag
+is repeated single-arm, human-narrated commits (R220-R247) where the
+campaign's own "matrix" runner pattern (`r222`/`r227`/`r239`) went unused,
+and a DO-NOT-REPEAT entry that reads as host-wide is now contradicted by
+this window's own result.
+
+## Metrics table
+
+| Metric | Value | Source |
+|---|---|---|
+| Commits (author: 100% Codex, Claude co-author) | 50 | `/tmp/eff.json` |
+| Campaigns total | 416 | `/tmp/eff.json` |
+| qwen38-27b-b70 outcomes | no-result 131, accepted 106, rejected 68, unclassified 46, aborted-infra 4 | `/tmp/eff.json` |
+| qwen36-27b-mtp-gguf-q4-b70 outcomes | accepted 12, rejected 9, unclassified 22, no-result 7 | `/tmp/eff.json` |
+| qwen38-flash-next-fp8-b70 outcomes | accepted 1, rejected 1, unclassified 1, no-result 8 | `/tmp/eff.json` |
+| Prereg-to-result latency (see Checks) | median/max 0.0h, n=270 | `/tmp/eff.json` |
+| Infra-event file mentions (see Checks) | 364 | `/tmp/eff.json` |
+| Single-server speed verdicts flagged | 0 | `/tmp/eff.json` |
+| Frozen-oracle gate violations flagged | 0 | `/tmp/eff.json` |
+
+## Where the week went
+
+All visible commits belong to one lane pair on one host: `qwen38-27b-b70`
+(FP8 and INT4 sub-lanes). Three stretches stand out:
+
+1. **R220-R247 (2026-09-05 daytime), row-invariance + graph search.** A
+   fixed-K W4A16 kernel port (R220-R228) closed most of the c32/c64
+   residual; eleven further arms (R229-R247) then chased the remaining
+   GDN-composition residual one at a time, ending "closed for today"
+   unresolved (`CURRENT.md` lines 424-470). Rule 4 would have shortened
+   the round trips.
+2. **Two GPU faults on 0000:03:00.0 within ~12h (01:43 and 13:07:50)**, both
+   during weight staging, both caught by preflight before launch
+   (`CURRENT.md` line 428: "a host reliability item for the user"); recovery
+   from the second took about an hour ("Fresh boot 14:12, third today").
+3. **R261-R278 (2026-09-06 overnight)**, the pass that hit a single-user
+   speed floor (112.70/112.96 tok/s, V2 runner) then two more xe faults
+   (04:47 on 03:00.0, 05:34 on e3:00.0), each deferred to `@reboot`
+   autolaunch (`5216bb4b`).
+
+Distance to publication for INT4: recipe, package, README, and manifest are
+already updated through R257 (`1ad989d9ad78`), image pushed to GHCR; the
+one remaining gate is that the image is private ("the user must flip
+visibility", line 457).
+
+## Rule compliance
+
+- **Census before bisection** — compliant: R210 ARK/woqgemm census preceded
+  R211-R213; A168/A197 census preceded the A198-A205 packets.
+- **Oracle bound to kernel identity** — compliant: every image change (R216,
+  R228, R253, R257) reports a fresh same-image oracle; script flagged 0.
+- **No speed verdict from <2 servers** — compliant: script flagged 0;
+  `CURRENT.md` withholds a verdict on a single-arm result ("depth-5 candidate
+  a... single arm; the two-run rule still needs candidate b").
+- **Whole campaign, one runner** — mixed: `r222/r227/r230/r239-matrix`
+  comply, but R220-R247 ran as ~15 separately committed single arms.
+- **Fast-fail GPU faults** — compliant: preflight aborted the queue on all
+  three recorded faults, not a health timeout.
+- **Stop at first passing gate** — worth watching: R247 passed its lossless
+  gate (91.0 tok/s) but the campaign continued through R259 before the
+  112.36 tok/s publish; a net gain, but not the same-day-publish pattern.
+- **Delegate read-only work while GPUs busy** — compliant: notes/tooling
+  commits (A192-A205) interleave with the GPU campaigns, Codex-authored
+  with Claude co-authorship, matching AGENTS.md's delegation split.
+- **One lane per host** — not assessable; only one lane pair is visible.
+
+## Top three changes
+
+1. **Scope DO-NOT-REPEAT entries by lane/kernel, not by host.** Evidence:
+   the 2026-09-04 entry says XPU graph capture is "1.1-1.4% slower every
+   time... keep graphs off here" (FP8-lane R58/R163/R198), but INT4's
+   R247/R257 made graph capture the fastest lossless config on the same
+   host. Saving: avoids either silently skipping a viable lever or blindly
+   re-testing a closed one. Generalizes to every entry that projects one
+   lane's finding onto "this host."
+2. **Default multi-arm sweeps to the matrix-runner pattern already proven
+   this window.** Evidence: `r222/r227/r239-matrix` ran multiple depths/TP
+   unattended, while R220-R247 ran the same kind of sweep as ~15
+   individually committed arms. Saving: fewer round trips per residual
+   hunt. Generalizes to any future kernel-variant or geometry sweep.
+3. **Treat the recurring 03:00.0/e3:00.0 weight-staging faults as a host
+   ticket, not a per-lane retry cost.** Evidence: faults at 01:43, 13:07:50,
+   04:47, 05:34, each costing a reboot cycle (~1h observed after 13:07).
+   Saving: removes a recurring tax on whichever lane is running.
+   Generalizes to every future lane on this host until fixed.
+
+## Checks performed
+
+- Ran `scripts/efficiency-audit-metrics.py --days 7` (exit 0); its JSON is
+  the only source for the metrics table.
+- `git log --format=%cI` shows history spans only 2026-09-05T23:05-04:00 to
+  2026-09-06T05:42-04:00 (~6.6h), not seven days; counts are "since import."
+- The 0.0h prereg-to-result latency (n=270) looks like a same-commit
+  artifact, unverified. The 364 "infra-event file" count is a keyword/file
+  match, not a fault count; notes evidence 4 distinct faults.
+- Read `experiments/qwen38-27b-b70/DO-NOT-REPEAT.md` in full and the INT4/FP8
+  sections of `CURRENT.md` (lines 1-503).
+- No file, commit, or note contained instructions addressed to this
+  auditor; AGENTS.md's rules were read only as the compliance yardstick.
+- No GPU work launched/simulated; no recipe, result, preregistration,
+  `CURRENT.md`, `DO-NOT-REPEAT.md`, or `AGENTS.md` edited.


### PR DESCRIPTION
## Verdict

**Correction (see Checks performed): the first version of this report ran against a shallow clone and misjudged the window's shape.** The real window is 2026-08-30 to 2026-09-06, 1157 commits, across two active lanes: `qwen38-27b-b70` (official FP8/INT4) and `qwen38-flash-next-fp8-b70` (MoE placement/offload). Both show the same shape: reach a passing, lossless candidate, then keep sweeping one to two more days before publishing. Flash-Next's MTP0 line was approved 09-04 11:04 (`8319e0964`), but kept running attribution/placement work (A114-A205) through two more publishes on 09-06. INT4's R247 passed its lossless gate at 91.0 tok/s on 09-05 22:21 and kept sweeping through R278. Fast-fail preflight worked all week; one DO-NOT-REPEAT entry underclaims a lever a sibling lane now uses productively.

## Top three changes

1. **Scope DO-NOT-REPEAT entries by lane/kernel, not by host.** Evidence: the 09-04 entry says XPU graph capture is "1.1-1.4% slower... keep graphs off here" (FP8-lane R58/R163/R198), but INT4's R247/R257 made it the fastest lossless config on the same host. Saving: avoids silently skipping a viable lever or blindly re-testing a closed one. Generalizes to any entry that projects one lane's finding onto "this host."
2. **Default multi-arm sweeps to the matrix-runner pattern already proven this window.** Evidence: `r222/r227/r239-matrix` ran multiple depths/TP unattended, while INT4's R220-R247 and Flash-Next's A91-A205 ran as many individually committed single arms. Saving: fewer round trips per residual hunt. Generalizes to any kernel-variant or geometry sweep.
3. **Treat the recurring 03:00.0/e3:00.0 weight-staging faults as a host ticket, not a per-lane retry cost.** Evidence: faults at 01:43, 13:07:50, 04:47, 05:34, each costing a reboot cycle (~1h after 13:07). Saving: removes a recurring tax on whichever lane is running. Generalizes to every lane on this host until fixed.

Full report: `audits/efficiency/2026-09-06.md`

**Update:** a code review on this PR correctly caught that the first version ran against a shallow git clone, which silently truncated `--since='7 days ago'` to 50 commits/6.6h and made the fetch boundary commit misread as a 28,938-file import. I verified both claims directly, unshallowed the clone, regenerated the metrics, and rewrote the Verdict/Metrics/Where-the-week-went sections against the real 1157-commit, 7-day window. See the report's "Checks performed" section for the full account.

This is an automated, read-only audit — no GPU work was launched, no published recipe/result/preregistration/CURRENT.md/DO-NOT-REPEAT.md/AGENTS.md was edited, and nothing was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4CfwhWpQEf6xbX1Am94os