### PR TITLE
Efficiency audit 2026-09-08

### DIFF
--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -3,7 +3,7 @@
 ## Verdict
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
-failure falls outside them or a passing candidate gets swept past —
+failure falls outside them or a candidate gets swept past —
 and the classifier still can't draw exact boundaries after
 twenty-six correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
@@ -11,10 +11,10 @@ unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
 non-accepted stretches (59/28/19 arms — Checks) reduce to two
 incidents:
-AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
-census, and a separate R166-on "phantom token", history-dependent not
+AGENTS.md's own R64-R146 GDN/kernel bisection, closed by R151-R162,
+and a separate R166-on "phantom token", history-dependent not
 batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; seventeen single-server results
+its gate got swept into two more depths; eighteen single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable. This audit missed
 `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -28,19 +28,19 @@ were reported as speed verdicts (rule 3). None of 10 gapped
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra time lost | ≥752 min (R277 45+A61 73+R278 14+A57 5+A174 111+A204/A207 504); 68 file mentions, rest untimed | `/tmp/eff.json` |
+| Infra time lost | ≥784 min (R277 45+A61 73+R278 14+A57 5+A174 111+A204/A207 504+R147 32); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
 10 gapped: 5 Flash-Next, 5 more — 3 qwen35 (shared
-gaps: int4 README, `qwen35-9b-b70`'s scripts, + 2 broken Qwen3.6-guide
-refs — `staged-package`, `data/quality.json`, neither exists); `qwen38-27b-autoround-int4-b70` (missing_path and
-unreachable-builder both unreliable: 4/7 and 2/4 confirmed artifacts,
-≤3 and ≤2 real); `qwen38-27b-fp8-vllm-tp2-asrock-b70` (33
+gaps: int4 README, `qwen35-9b-b70`'s scripts, +2 broken Qwen3.6-guide
+refs — `staged-package`, `data/quality.json`, neither exists); `qwen38-27b-autoround-int4-b70`
+(missing_path/unreachable-builder both unreliable: 4/7&2/4 confirmed artifacts,
+≤3&≤2 real); `qwen38-27b-fp8-vllm-tp2-asrock-b70` (33
 missing_release_asset, 4 host_path_hardcoded).
 
 Caveats: (1) the metric only sees `*prereg*.json`-linked campaigns;
-R261/R265b/R273/R277 and others within qwen38-27b-b70 are
+R261/R265b/R273/R277+others within qwen38-27b-b70 are
 notes-only, undercounting 157; `qwen35-4b-b70`/`qwen35-9b-b70`
 (CURRENT.md:35's active lane; published, one-card lossless; gated on
 clean-host replay (`clean_host_tested: false`, all 3 manifests;
@@ -49,18 +49,17 @@ two-card divergence separate, narrower),
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
 through — treat counts as directional. (3)
-per-accepted document cost (week-only): 153 preregs + 49 notes / 6
-accepted ≈ 34 each (all-time 355+795; caveat 2);
-composite-arm/duplicate-artifact not computed. (4)
+per-accepted document cost (week-only): 153 preregs+49 notes/6
+accepted≈34 each; composite-arm/duplicate-artifact not computed. (4)
 `/tmp/eff.json`/`/tmp/eff.md`
-aren't committed (one-file limit); rerunning after 2026-09-08 won't
-reproduce these counts. (5) flash-next `accepted 0` is
-JSON-prereg-only; its day-summary note records ≥2 certified/published
+aren't committed (one-file limit); reruns won't reproduce these
+counts. (5) flash-next `accepted 0` is
+JSON-prereg-only; its day-summary records ≥2 certified/published
 results it misses (A270 MTP0, A272 MTP1) — narrative-log ingestion is
 change #3's.
 
-Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2; #1
-and #2 both stem from R64-R146, split by R119's 09:15):
+Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
+#1&#2 both stem from R64-R146, split by R119's 09:15):
 
 1. **~59 arms**, 09-01 11:38→09-02 01:32, `r63-concurrency`→`r118b`.
 2. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16.
@@ -74,29 +73,29 @@ and #2 both stem from R64-R146, split by R119's 09:15):
 ## Rule compliance
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
-   servers; the R151-R162 census closed them; **not applicable** to
-   the phantom (history-dependent).
+   servers; R151-R162 closed them; **not applicable** to the phantom
+   (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated on
-   the frozen oracle (8/12); R147's regen matched 12/12.
-3. No speed verdict from one server: **violated** — R140 rejected on
-   -1.14% (two R147 servers beat it); R58/R60/R65 rejected on one
-   server (R65 despite identity-qualified);
-   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b/R198/R207
+   frozen oracle (8/12); R147's regen matched 12/12.
+3. No speed verdict from one server: **violated** — R140 rejected at
+   -1.14% (two R147 beat it); R58/R60/R65 rejected on one server (R65
+   despite identity);
+   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b/R198/R207/A165
    publish single-server profiles; R203's lone attempt decided turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
-   separate; R184-186/R190-191/R182 multi-arm.
+   separate, R184-186/R190-191/R182 multi-arm.
 5. Fast-fail on GPU faults: **violated** — R277 faulted, hung to its
    45-min timeout.
 6. Stop at first passing gate: **violated** — depth 5 cleared its
    bar but 6-7 swept first; R186j passed, R186n ran before R187.
 7. Read-only work: unverified.
-8. One lane per host: **unverified** — no host field traces it.
+8. One lane per host: **unverified**.
 
 ## Top three changes
 
 1. **Change**: extend rule 1's census to state/scheduling transitions,
    not just batch shape. **Evidence**: R168-169 found async-off avoids
-   (AGENTS.md's wording) the MTP2 phantom by arm 4. **Expected
+   (AGENTS.md's wording) the phantom by arm 4. **Expected
    saving**: unmeasured; a census could shortcut it. **Generalizes**:
    any scheduler/state-bleed bug a shape-only census can't catch.
 
@@ -107,9 +106,9 @@ and #2 both stem from R64-R146, split by R119's 09:15):
    release view` failures (MTP1's tarball is published, `status:
    pass`, not missing). **Evidence**: gaps
    hit all 5; MTP1's build script, int4's
-   `rebuild-w4a16-incremental-r221.sh`, and fixed-k-tp2's preflight
-   provision their tagged image — `image_without_reachable_builder`
-   false on all three.
+   `rebuild-w4a16-incremental-r221.sh`, + fixed-k-tp2's preflight
+   provision it — `image_without_reachable_builder` false on all
+   three.
    **Expected saving**: clears the real gaps. **Generalizes**: don't
    trust scanner counts without verifying, like the classifier.
 
@@ -117,9 +116,9 @@ and #2 both stem from R64-R146, split by R119's 09:15):
    structured `outcome` enum; join via `preregistration`; ingest
    result/note-only records via a required artifact; log GPU time
    lost per infra fault. **Evidence**: twenty-six rounds found new
-   defects. **Expected saving**: every future audit
-   starts from a count, not an estimate. **Generalizes**: the stick
-   every audit reads.
+   defects. **Expected saving**: every future audit starts from a
+   count, not an estimate. **Generalizes**: every future audit
+   inherits it.
 
 ## Checks performed
 
@@ -128,6 +127,8 @@ and #2 both stem from R64-R146, split by R119's 09:15):
   `tools/public-closure-scanner.py`.
 - Twenty-six review rounds (Codex), verified and reflected above —
   why this file reports directional estimates, not a patched regex.
+  Word count now via Python `split()` — `wc -w` undercounted
+  dashes/arrows under this sandbox's locale.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`; scanned for auditor-directed
   text — none.
 - No GPU work run/simulated; no recipe/result/prereg/note/

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after thirteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after fourteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -13,8 +13,8 @@ non-accepted stretches (59/30/28 arms) reduce to two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; three single-server results
-(R140/R195/R196) were reported as a speed verdict (rule 3). None of 10
+its gate got swept into two more depths; six single-server results were
+reported as speed verdicts (rule 3). None of 10
 gapped `status: candidate` packages
 (5 Flash-Next, 5 below) is publishable. This audit missed
 `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -34,15 +34,15 @@ gapped `status: candidate` packages
 
 10 gapped candidates: 5 Flash-Next (below) plus `qwen35-4b-w4a16-b70`,
 `qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`, `qwen38-27b-autoround-int4-b70`,
-`qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps), not
-investigated further.
+`qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps),
+unexamined.
 
 Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one.
-(2) outcomes are keyword matches, not a structured field; some cases still
-slip through after thirteen fix rounds — treat counts as directional. (3)
+(2) outcomes are keyword matches, not structured; some still slip
+through after fourteen rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -52,13 +52,12 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2; #1
 and #3 both stem from R64-R146, split by R119's 09:15 promotion, not
 distinct):
 
-1. **~59 arms**, 09-01 11:38 → 09-02 01:32, `r63-concurrency`→`r118b`.
-2. **~30 arms**, 09-03 02:52 → 09-04 21:45, `r166`→`r208`: R165 found what
+1. **~59 arms**, 09-01 11:38→09-02 01:32, `r63-concurrency`→`r118b`.
+2. **~30 arms**, 09-03 02:52→09-04 21:45, `r166`→`r208`: R165 found what
    looked like a greedy flip; R166 reran fresh, identical — no flip.
    R168-169 traced it from history-bound to async scheduling by arm 4;
    9 more probes localized it.
-3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16
-   kernel work.
+3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16.
 
 ## Rule compliance
 
@@ -69,12 +68,13 @@ distinct):
    row-invariant kernel against the frozen natural-kernel oracle (8/12);
    R147's regenerated same-image oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
-   candidate on one server's -1.14% (two R147 servers beat it); R195/R196
-   (`unrepeated`) declare depth 3 fastest from one server.
+   candidate on one server's -1.14% (two R147 servers beat it);
+   R195/R196/R150/R189 (`unrepeated`) publish single-server profiles;
+   R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
    R202-203 are three separate preregs, no human round trip;
-   R184-186/R190-191 batch multi-arm preregs; R166-183 are singleton.
-5. Fast-fail on GPU faults: 68 files matched, timing unchecked.
+   R184-186/R190-191/R182 batch multi-arm; R166-183 less R182 singleton.
+5. Fast-fail on GPU faults: 68 files matched; timing unchecked.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
    but the lane swept depths 6-7 first (fault blocked its ladders);
    R186j passed; R186n ran before R187's endpoint.
@@ -91,21 +91,21 @@ distinct):
    could shortcut it. **Generalizes**: any scheduler/state-bleed bug a
    shape-only census can't catch.
 
-2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
-   scripts (hardcoded `/home`/`/mnt` paths in `launch-*.sh`); fix the
-   scanner's parser (truncates `E=...json` filenames at `=`/`,`, a
-   false `missing_path` on MTP0's own docs); and publish the missing
-   MTP1 runtime tarball and a reachable builder. **Evidence**: path
-   gaps hit all 5; MTP0 also carries 3 parser-truncation hits; only
-   MTP1 carries `missing_release_asset`/`image_without_reachable_builder`.
-   **Expected saving**: script+parser fixes clear MTP0; MTP1 needs the
-   asset/builder work too. **Generalizes**: a shared script or scanner
-   bug propagates everywhere it's used.
+2. **Change**: fix ALL MTP0's hardcoded-host scripts, not just
+   `launch-*.sh` (63 hits, only 31 there); replace the README's literal
+   `E=128,N=640,…json` args with real filenames; fix the scanner parser
+   separately (truncates the same filenames even where the manifest
+   path is correct); and publish the missing MTP1 runtime tarball and a
+   reachable builder. **Evidence**: path gaps hit all 5; only MTP1
+   carries `missing_release_asset`/`image_without_reachable_builder`.
+   **Expected saving**: the four fixes clear MTP0; MTP1 needs the
+   asset/builder work too. **Generalizes**: a shared script, doc, or
+   scanner bug propagates wherever reused.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: thirteen rounds found new
+   lost per infra fault. **Evidence**: fourteen rounds found new
    keyword-matching defects. **Expected saving**: every audit starts
    from an estimate, not a count. **Generalizes**: the stick every
    audit reads.
@@ -116,7 +116,7 @@ distinct):
   clone; ran `git fetch --unshallow origin main` and re-ran against
   full history.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Thirteen review rounds (Codex), verified and reflected above:
+- Fourteen review rounds (Codex), verified and reflected above:
   classifier bugs; rule-1/2/3/4/6/8 findings; scanner false positives;
   unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
   accept keywords despite being diagnostic/non-promotable — why this

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after twelve correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after thirteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -13,10 +13,10 @@ non-accepted stretches (59/30/28 arms) reduce to two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths, and three single-server results
+its gate got swept into two more depths; three single-server results
 (R140/R195/R196) were reported as a speed verdict (rule 3). None of 10
-gapped `status: candidate` packages (5
-Flash-Next, 5 below) is publishable. This audit missed
+gapped `status: candidate` packages
+(5 Flash-Next, 5 below) is publishable. This audit missed
 `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 
 ## Metrics table
@@ -30,7 +30,7 @@ Flash-Next, 5 below) is publishable. This audit missed
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
 | Infra-event file mentions (not time-lost) | 68; top `.../r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
-| Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
+| Closure scan | 26 candidates (10 gaps); 12 informational guides (3 gaps) | `/tmp/closure.md` |
 
 10 gapped candidates: 5 Flash-Next (below) plus `qwen35-4b-w4a16-b70`,
 `qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`, `qwen38-27b-autoround-int4-b70`,
@@ -42,7 +42,7 @@ Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one.
 (2) outcomes are keyword matches, not a structured field; some cases still
-slip through after twelve fix rounds — treat counts as directional. (3)
+slip through after thirteen fix rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -56,7 +56,7 @@ distinct):
 2. **~30 arms**, 09-03 02:52 → 09-04 21:45, `r166`→`r208`: R165 found what
    looked like a greedy flip; R166 reran fresh, identical — no flip.
    R168-169 traced it from history-bound to async scheduling by arm 4;
-   9 more probes localized it. R195-203 (rules 4/6) ran concurrently.
+   9 more probes localized it.
 3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16
    kernel work.
 
@@ -69,59 +69,59 @@ distinct):
    row-invariant kernel against the frozen natural-kernel oracle (8/12);
    R147's regenerated same-image oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
-   candidate on one server's -1.14% (two R147 servers beat the prior
-   center); R195/R196 (`unrepeated`) declare depth 3 fastest from one
-   server.
+   candidate on one server's -1.14% (two R147 servers beat it); R195/R196
+   (`unrepeated`) declare depth 3 fastest from one server.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
    R202-203 are three separate preregs, no human round trip;
-   R184-186/R190-191 batch 3 arms/stages per prereg; R166-183 singleton
-   preregs.
+   R184-186/R190-191 batch multi-arm preregs; R166-183 are singleton.
 5. Fast-fail on GPU faults: 68 files matched, timing unchecked.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
    but the lane swept depths 6-7 first (fault blocked its ladders);
    R186j passed; R186n ran before R187's endpoint.
 7. Read-only work delegated: unverified.
-8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
-   no per-campaign host field traces the window.
+8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot; no
+   per-campaign host field traces the window.
 
 ## Top three changes
 
 1. **Change**: extend rule 1's census discipline to state
    transitions/scheduling — it only covers batch shape today. **Evidence**:
    R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9
-   more probes followed. **Expected saving**:
-   unmeasured; a census could shortcut it. **Generalizes**: any
-   scheduler/state-bleed bug a shape-only census can't catch.
+   more probes followed. **Expected saving**: unmeasured; a census
+   could shortcut it. **Generalizes**: any scheduler/state-bleed bug a
+   shape-only census can't catch.
 
 2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
-   scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths;
-   scanner `/opt/*`/`results/...-r1-attempt` hits are false positives),
-   and publish the missing MTP1 runtime tarball and a reachable builder.
-   **Evidence**: path gaps hit all 5; only MTP1 carries
-   `missing_release_asset`/`image_without_reachable_builder`.
-   **Expected saving**: the script fix alone clears MTP0; MTP1 needs both.
-   **Generalizes**: shared scripts propagate bugs everywhere built from them.
+   scripts (hardcoded `/home`/`/mnt` paths in `launch-*.sh`); fix the
+   scanner's parser (truncates `E=...json` filenames at `=`/`,`, a
+   false `missing_path` on MTP0's own docs); and publish the missing
+   MTP1 runtime tarball and a reachable builder. **Evidence**: path
+   gaps hit all 5; MTP0 also carries 3 parser-truncation hits; only
+   MTP1 carries `missing_release_asset`/`image_without_reachable_builder`.
+   **Expected saving**: script+parser fixes clear MTP0; MTP1 needs the
+   asset/builder work too. **Generalizes**: a shared script or scanner
+   bug propagates everywhere it's used.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: twelve rounds found new
-   keyword-matching defects. **Expected saving**: every audit
-   starts from an estimate, not a count. **Generalizes**: the stick
-   every audit reads first.
+   lost per infra fault. **Evidence**: thirteen rounds found new
+   keyword-matching defects. **Expected saving**: every audit starts
+   from an estimate, not a count. **Generalizes**: the stick every
+   audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
-  clone (6h window); ran `git fetch --unshallow origin main` and re-ran
-  against full history.
+  clone; ran `git fetch --unshallow origin main` and re-ran against
+  full history.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Twelve review rounds (Codex), verified and reflected above:
+- Thirteen review rounds (Codex), verified and reflected above:
   classifier bugs; rule-1/2/3/4/6/8 findings; scanner false positives;
   unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
   accept keywords despite being diagnostic/non-promotable — why this
   file reports directional estimates, not a patched regex.
-- Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes.
-- Scanned for auditor-directed text: none.
+- Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes; scanned for
+  auditor-directed text: none.
 - No GPU work run/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after seventeen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after eighteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -39,12 +39,11 @@ unexamined.
 
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
-notes-only, undercounting 157;
-`qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
-`gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
-`laguna-s-2.1-xpu-b70` lack any prereg file.
+notes-only, undercounting 157; `qwen35-4b-b70`/`qwen35-9b-b70`
+(CURRENT.md:35's active lane), `gemma4-26b-a4b-q8-b70`,
+`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after seventeen rounds — treat counts as directional. (3)
+through after eighteen rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -64,14 +63,15 @@ distinct):
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
    servers before the R151-R162 census closed them in 20 minutes; **not
-   applicable** to the MTP2 phantom (history-, not shape-dependent).
+   applicable** to the MTP2 phantom (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated the
    row-invariant kernel against the frozen oracle (8/12); R147's
    regenerated same-image oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
    candidate on one server's -1.14% (two R147 servers beat it);
-   R195/R196/R150/R189/R260b/R265b publish single-server profiles;
-   R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
+   R60 declined a second server; R195/R196/R150/R189/R260b/R265b
+   publish single-server profiles; R203's lone depth-7 attempt decided
+   the depth-6-vs-7 turnover.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
    R202-203 are three separate preregs; R184-186/R190-191/R182 batch
    multi-arm; R166-183 less R182 singleton.
@@ -81,49 +81,48 @@ distinct):
    but the lane swept depths 6-7 first (fault blocked its ladders);
    R186j passed; R186n ran before R187's endpoint.
 7. Read-only work delegated: unverified.
-8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot,
-   no per-campaign host field traces the window.
+8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
+   no host field traces the window.
 
 ## Top three changes
 
 1. **Change**: extend rule 1's census discipline to state/scheduling
-   transitions, not just batch shape. **Evidence**: R168-169 localized
-   the MTP2 phantom to async scheduling by arm 4; 9 more probes
-   followed. **Expected saving**: unmeasured; a census could shortcut
-   it. **Generalizes**: any scheduler/state-bleed bug a shape-only
-   census can't catch.
+   transitions, not just batch shape. **Evidence**: R168-169 found
+   `--no-async-scheduling` avoids the MTP2 phantom by arm 4 (per
+   AGENTS.md's wording rule, not "fixes"); 9 more probes followed.
+   **Expected saving**: unmeasured; a census could shortcut it.
+   **Generalizes**: any scheduler/state-bleed bug a shape-only census
+   can't catch.
 
 2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not the
    ~25 container-internal `/opt/...` Dockerfile/entrypoint paths
    inflating HCTriton/lossless/placement's 80+ counts); replace the
-   README's literal `E=...json` args with real filenames; publish
-   MTP1's missing runtime tarball. **Evidence**: path gaps hit all 5;
-   MTP1's `build-image.sh` already builds the tagged image via
+   README's literal `E=...json` args with real filenames; fix the
+   scanner's `=`/`,`-truncation and `$var`-template parsing bugs;
+   publish MTP1's missing runtime tarball. **Evidence**: path gaps hit
+   all 5; MTP1's `build-image.sh` already builds the tagged image via
    `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
-   false positive, not missing work. **Expected saving**: script/doc
-   fixes clear the real gaps; only the tarball is missing.
-   **Generalizes**: don't trust this scanner's counts without
-   verifying, like the metrics classifier.
+   false positive. **Expected saving**: these fixes clear the real
+   gaps; only the tarball is missing. **Generalizes**: don't trust this
+   scanner's counts without verifying, like the metrics classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
-   `preregistration`; ingest result-only records for the caveat's lanes
-   (no prereg file exists to glob for); log GPU time lost per infra
-   fault. **Evidence**:
-   seventeen rounds found new keyword-matching defects. **Expected
-   saving**: every future audit starts from a count, not an estimate.
-   **Generalizes**: the stick every audit reads.
+   `preregistration`; ingest result-only records for the caveat's
+   lanes; log GPU time lost per infra fault. **Evidence**: eighteen
+   rounds found new keyword-matching defects.
+   **Expected saving**: every future audit starts from a count, not an
+   estimate. **Generalizes**: the stick every audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
   clone; `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Seventeen review rounds (Codex), verified and reflected above:
-  classifier and scanner bugs; rule-1/2/3/4/5/6/8 findings;
-  R101/R104/R165 matching accept keywords despite being
-  diagnostic/non-promotable — why this file reports directional
-  estimates, not a patched regex.
+- Eighteen review rounds (Codex), verified and reflected above:
+  classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings; R101/R104/R165
+  matching accept keywords despite being diagnostic/non-promotable —
+  why this file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes; scanned for
   auditor-directed text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -3,19 +3,21 @@
 ## Verdict
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
-failure falls outside them or a passing candidate keeps getting swept past.
-This week's own measuring stick needed seven rounds of correction,
-including a keyword classifier too fragile for precise arm-counts (Checks,
-below). Reclassified: `qwen38-27b-b70` 15 accepted / 79 rejected / 23
-unclassified / 38 no-result-yet / 2 aborted-infra of 157. Its longest
-stretches are mostly one incident, AGENTS.md's own R64-R146 GDN bisection
-("three days... settled in an evening"), closed by the R151-R162 census. A
-second issue (R166 on) chased a history-dependent "phantom token" no rule
-covers, while a depth-5 candidate that passed its gate got swept into two
+failure falls outside them or a passing candidate keeps getting swept
+past — and this week's keyword classifier can't draw exact boundaries
+even after eight correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
+unclassified of 157 (accepted itself uncertain — R165 says "NOT
+PROMOTABLE" despite matching a "pass" keyword). Its three longest
+non-accepted stretches (59/30/28 arms) reduce to two real incidents:
+AGENTS.md's own R64-R146 GDN/kernel bisection ("three days... settled in
+an evening"), closed by the R151-R162 census, and a separate R166-on
+"phantom token" that's history-dependent, not batch-shape, a class no
+rule covers. A depth-5 candidate that passed its gate got swept into two
 more depths, and two single-server results were reported as a speed
-verdict (rule 3). None of the 5 Flash-Next `status: candidate` packages
-is publishable (change #2). This audit could not cover
-`qwen35-4b-b70`/`qwen35-9b-b70` — CURRENT.md's stated active lane — at all.
+verdict (rule 3). None of 10 gapped `status: candidate` packages (5
+Flash-Next, 5 more below) is publishable. This audit missed
+`qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's stated active lane, entirely.
 
 ## Metrics table
 
@@ -23,57 +25,61 @@ is publishable (change #2). This audit could not cover
 |---|---|---|
 | Commits, 7d | 1185 (codex 225 / claude 960) | `/tmp/eff.json` |
 | Campaigns tracked | 165 (qwen38-27b-b70: 157, flash-next: 8) | `/tmp/eff.json` |
-| qwen38-27b-b70 outcomes (reclassified) | accepted 15, rejected 79, no-result-yet 38, unclassified 23, aborted-infra 2 | see Checks |
-| flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
+| qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
+| flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra-event file mentions (not time-lost — unmeasured) | 68; top: `.../r261-r268.md` (8) | `/tmp/eff.json` |
+| Infra-event file mentions (not time-lost) | 68; top `.../r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
+
+10 gapped candidates: 5 Flash-Next (below) plus `qwen35-4b-w4a16-b70`,
+`qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`, `qwen38-27b-autoround-int4-b70`,
+`qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps) — not
+investigated further this round.
 
 Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one, missing the lane the lab calls active.
-(2) outcomes are keyword matches — estimates, not counts (Checks).
+(2) outcomes are keyword matches, not a structured field; some cases still
+slip through after eight fix rounds — treat counts as directional. (3)
+per-accepted prereg/note counts and composite-arm expansion (protocol's
+token-cost and stretch requirements) were not computed.
 
-Three longest non-accepted `qwen38-27b-b70` stretches (rejected checked
-before accepted; see Checks):
+Three longest non-accepted `qwen38-27b-b70` stretches (**not fully
+reliable**, caveat 2; #1/#3 are the same incident):
 
-1. **40 arms**, 09-01 11:38-19:40, `r63-concurrency`→`r100`: the tail of
-   AGENTS.md's own R64-R146 GDN bisection ("three days... settled in an
-   evening"), closed by R151-R162's census — the incident rule 1 stops.
-2. **22 arms**, 09-03 02:52-22:10, `r166`→`r190/191`: R165 found what
-   looked like a greedy flip; R166 reran fresh, identical — no flip. R168:
-   "NOT positional, history-bound." R169: "PHANTOM GONE with
-   --no-async-scheduling" — async implicated by arm 4. Nine more probes
-   localized the mechanism — no batch-shape census would have caught it.
-   Concurrently the R195/200/202-203 group (rule 4) published depths 3-4;
-   depth 5 also passed but was swept past (rule 6).
-3. **15 arms**, 09-01 20:49 → 09-02 01:32, `r105`→`r118b`: more of #1's
-   incident, split off only by one borderline "accepted" `r104`.
+1. **~59 arms**, 09-01 11:38 → 09-02 01:32, `r63-concurrency`→`r118b`.
+2. **~30 arms**, 09-03 02:52 → 09-04 21:45, `r166`→`r208`: R165 found what
+   looked like a greedy flip; R166 reran fresh, identical — no flip.
+   R168: "NOT positional, history-bound." R169: "PHANTOM GONE with
+   --no-async-scheduling" — async implicated by arm 4; 9 more probes
+   localized it. Concurrently R195-197/R200/R202-203 (rule 4) published
+   depths 3-4; depth 5 also passed but was swept past (rule 6).
+3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16
+   kernel work, part of #1's R64-R146 incident.
 
 ## Rule compliance
 
 1. Census before bisection: followed (R151-R162 closed R64-R146); **not
    applicable** to the MTP2 phantom (history-, not shape-dependent).
-2. Oracle regeneration per kernel change: followed.
+2. Oracle regenerated per kernel change: followed.
 3. No speed verdict from one server: **violated** — R195/R196
-   (`classification: unrepeated`) declare depth 3 fastest at every
-   measured depth from one server each.
+   (`unrepeated`) declare depth 3 fastest at every depth from one
+   server each.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 are three separate preregs, queued immediately behind each
-   other with no human round trip evident; R166-R190 were one server per
-   prereg.
-5. Fast-fail on GPU faults: 68 files matched (timing unchecked).
-6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
+   R202-203 are three separate preregs queued back-to-back with no human
+   round trip evident; R166-R190 one server per prereg.
+5. Fast-fail on GPU faults: 68 files matched, timing unchecked.
+6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar,
    but the lane swept depths 6-7 first; the fault that followed blocked
-   its own ladders.
+   its ladders.
 7. Read-only work delegated: unverified.
 8. One lane per host: matches CURRENT.md.
 
 ## Top three changes
 
-1. **Change**: extend AGENTS.md's rule 1 census discipline to state
+1. **Change**: extend rule 1's census discipline to state
    transitions/scheduling — it only covers batch shape today. **Evidence**:
    R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9
    more arms searched one hypothesis at a time. **Expected saving**:
@@ -83,34 +89,34 @@ before accepted; see Checks):
 2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
    scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths;
    scanner `/opt/*`/`results/...-r1-attempt` hits are false positives);
-   separately, publish the missing runtime tarball and a reachable builder
-   for the image the 4 MTP1 candidates reference. **Evidence**: path gaps
-   hit all 5; only MTP1 also carries `missing_release_asset`/
-   `image_without_reachable_builder`. **Expected saving**: the script fix
-   alone clears MTP0; MTP1 needs both. **Generalizes**: shared scripts
-   propagate bugs to every package built from them.
+   separately publish the missing runtime tarball and a reachable builder
+   for the MTP1 candidates' image. **Evidence**: path gaps hit all 5; only
+   MTP1 also carries `missing_release_asset`/`image_without_reachable_builder`.
+   **Expected saving**: the script fix alone clears MTP0; MTP1 needs both.
+   **Generalizes**: shared scripts propagate bugs everywhere built from
+   them.
 
-3. **Change**: fix the metrics script — check "rejected" before "accepted";
-   classify on `status`/`classification`, not `decision`; join via
-   `preregistration`; extend the glob to the caveat's lanes; replace the
-   keyword match with a structured `outcome` enum; log GPU time lost per
-   infra fault. **Evidence**: seven rounds found new defects each time.
-   **Expected saving**: every audit starts from an estimate, not a count.
-   **Generalizes**: the stick every audit reads first.
+3. **Change**: replace the metrics script's keyword match with a
+   structured `outcome` enum, not another regex patch; join via
+   `preregistration`; extend the glob to the caveat's lanes; log GPU time
+   lost per infra fault. **Evidence**: eight review rounds found new
+   keyword-matching defects each time. **Expected saving**: every audit
+   starts from a moving estimate, not a count. **Generalizes**: the stick
+   every audit reads first.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first ran against a
-  shallow clone, giving a 6h window. Ran `git fetch --unshallow origin
+  shallow clone, giving a 6h window; ran `git fetch --unshallow origin
   main` (read-only) and re-ran against the full history.
 - Ran `tools/public-closure-scanner.py` against `packages/catalog.json`.
-- Seven rounds of PR review (Codex): accept/reject order; scanner false
-  positives; candidate-status language; missing preregistration join;
-  `classification`-only fields; chronology; rule-3/4/6 findings; a `pass:`
-  pattern forcing derived, not eyeballed, stretches above; release-asset/
-  builder gaps on the 4 MTP1 packages; unmeasured infra-time-lost; no
-  active-lane analysis. Fixed except the last.
-- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes.
-- Scanned commits/notes for auditor-directed text: none.
+- Eight review rounds (Codex), each finding verified and reflected above:
+  classifier order/field/join/chronology bugs; rule-3/4/6 findings;
+  scanner false positives; unmeasured infra-time/token-cost metrics; 5
+  unlisted gapped candidates; R101/R104/R165 matching accept keywords
+  despite being diagnostic/non-promotable — why this file reports
+  directional estimates, not a patched regex.
+- Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes.
+- Scanned commits/notes for auditor-directed text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -2,16 +2,19 @@
 
 ## Verdict
 
-The lab is faster where the census/chained-runner discipline in AGENTS.md is
-followed, no faster where it isn't. The tracked lane (`qwen38-27b-b70`)
-produced 32 accepted results out of 157 campaigns at 0.14h median
-prereg-to-result latency once preregistered — but also spent a 30-arm,
-~43-hour stretch (R166-R208) on a per-hypothesis "phantom token" bisection
-with no census note, echoing the R64-R146 incident the AGENTS.md rule set
-(2026-09-02) was written to close. Separately, all 5 Flash-Next records
-shipped this week carried the same broken repro-package template
-(`tools/public-closure-scanner.py`): publication throughput taxed by a
-fixable, repeating defect, not new work.
+The lab is faster where AGENTS.md's census/chained-runner discipline is
+followed, no faster where it isn't — and this week's measuring stick needed
+a correction to see that. `scripts/efficiency-audit-metrics.py` checks
+"accepted" before "rejected" and matches text inside JSON key names like
+`*_gate_passed`, so R57 (`passed-gates-rejected-no-material-benefit`), R60,
+R63 all counted as accepted; reclassifying `status` text rejected-first gives
+`qwen38-27b-b70` 11 accepted / 71 rejected / 29 unclassified of 157 (still
+an overcount — R123, R165 read as rejects but keyword-match
+"passed"/"promotable" too). The lane also spent a 30-arm, ~43h stretch
+(R166-R208) on a "phantom token" bisection with no census note, echoing the
+R64-R146 incident AGENTS.md's rule set (2026-09-02) was written to close.
+All 5 Flash-Next `status: candidate` packages shipped this week carry the
+same repro-package gaps, none yet publishable.
 
 ## Metrics table
 
@@ -19,105 +22,99 @@ fixable, repeating defect, not new work.
 |---|---|---|
 | Commits, 7d | 1185 (codex 225 / claude 960) | `/tmp/eff.json` |
 | Campaigns tracked | 165 (qwen38-27b-b70: 157, flash-next: 8) | `/tmp/eff.json` |
-| qwen38-27b-b70 outcomes | accepted 32, rejected 56, no-result-yet 45, unclassified 20, aborted-infra 4 | `/tmp/eff.json` |
-| flash-next outcomes | accepted 1, rejected 1, no-result-yet 5, unclassified 1 | `/tmp/eff.json` |
+| qwen38-27b-b70 outcomes (reclassified) | accepted 11, rejected 71, no-result-yet 45, unclassified 29, aborted-infra 1 | `status` fields, see Checks |
+| flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | recomputed |
 | Prereg→result latency | median 0.14h, max 3.28h, n=115 | `/tmp/eff.json` |
 | Infra-event files matched | 68; top: `.../notes/2026-09-06-qwen38-int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
-| Closure scan | 38 packages; 10 `status:candidate` with real gaps, 25 clean | `/tmp/closure.md` |
+| Closure scan | 38 packages; 10 candidates with real gaps, 25 clean | `/tmp/closure.md` |
 
 Caveat: the campaign metric only sees lanes with a `*prereg*.json` file under
-`data/`. `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
-`minimax-m27-reap-autoround-vllm`, and `laguna-s-2.1-xpu-b70` had commits and
-results this week under no such filename, so `campaigns_by_lane_outcome`
-misses them — 165 tracked campaigns understate total throughput.
+`data/`; `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
+`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits and
+results this week under no such filename, so the outcome table misses them.
 
 ## Where the week went
 
-- **Longest accepted-result-free stretch**: 30 consecutive non-accepted
-  `qwen38-27b-b70` campaigns, `r156-mtp2-first-token-diag-r166` through
-  `qwen38-int4-autoround-r187-stack-r208` (09-03 02:52 → 09-04 21:45, both
-  under `experiments/qwen38-27b-b70/notes/2026-09-0[34]-*.md`). Hypothesis: a
-  single-token mismatch at batch position 32/33 in MTP2, chased arm-by-arm in
-  `...-mtp2-phantom-*-r17[6-9]*.md` and `-r18[0-4]*.md` (state-slot probe,
-  zero-mamba-pages, layer0-control, layer-trace, enforce-eager,
-  inductor-knobs). No MTP2 census note exists, unlike the compliant
-  `2026-09-03-qwen38-fp8-c32-identity-source-census-r151-r162.md` that had
-  just cleared the sibling MTP0/MTP1 issue — rule 1 targets exactly this
-  flip. The stretch ended when the method changed to a chained ladder
-  (`2026-09-04-qwen38-fp8-mtp-depth-turnover-r200-r203.md`, depths 1-7 in one
-  run), producing an accepted depth-4 promotion the same day.
-- **Second** (26 arms, `r63-control`→`r87`, Sept 1) and **third** (15 arms,
-  `r89`→`r103`): both are the tail of the R64-R146 GDN bisection that
-  AGENTS.md's rule set (2026-09-02) was written to stop, falling inside this
-  window because the rule was recorded mid-incident; R151-R162's census then
-  closed it.
+- **Longest**: 30 non-accepted `qwen38-27b-b70` campaigns,
+  `r156-mtp2-first-token-diag-r166` through `r187-stack-r208`
+  (09-03 02:52 → 09-04 21:45, `experiments/qwen38-27b-b70/notes/2026-09-0[34]-*.md`).
+  A single-token mismatch at batch position 32/33 in MTP2, chased arm-by-arm
+  (state-slot probe, zero-mamba-pages, layer0-control, layer-trace,
+  enforce-eager, inductor-knobs; `...-mtp2-phantom-*-r17[6-9]*.md`,
+  `-r18[0-4]*.md`) with no MTP2 census note, unlike `c32-identity-source-census-r151-r162.md`,
+  which had just cleared the sibling MTP0/MTP1 issue — rule 1 names exactly
+  this flip. Ended when the method changed to a chained ladder
+  (`mtp-depth-turnover-r200-r203.md`, depths 1-7 in one run), producing an
+  accepted depth-4 promotion same day.
+- **Second** (26 arms, `r63-control`→`r87`) and **third** (15 arms,
+  `r89`→`r103`): the tail of the R64-R146 GDN bisection AGENTS.md's rule set
+  was written to stop, inside this window because the rule was recorded
+  mid-incident; R151-R162's census then closed it.
 
 ## Rule compliance
 
-1. Census before bisection: **violated**, R166-R208 (no census note); followed
-   once R151-R162 landed for the sibling issue.
-2. Oracle regenerated when kernel changed: followed, e.g.
-   `mtp1-fixed-k-regenerated-oracle-r147-partial.md`.
-3. No speed verdict from one server: no violation matched (regex empty both
-   runs); not independently verified.
-4. Whole campaign as one preregistered runner: followed for R200-R203; **not
-   clearly followed** for R166-R184 (each probe its own dated result, fresh
-   boot/image).
-5. Fast-fail on GPU faults: 68 infra-event files found; timeout-vs-startup
-   detection not verifiable.
-6. Stop at first passing gate: followed — MTP0 W13-N64 and MTP1 depth-4
+1. Census before bisection: **violated**, R166-R208 (no census note);
+   followed once R151-R162 landed for the sibling issue.
+2. Oracle regenerated when kernel changed: followed (`...r147-partial.md`).
+3. No speed verdict from one server: no violation matched; unverified.
+4. Whole campaign as one preregistered runner: followed R200-R203; **not**
+   R166-R184 (each probe its own dated result, fresh boot/image).
+5. Fast-fail on GPU faults: 68 infra-event files found; startup-vs-timeout
+   detection unverifiable.
+6. Stop at first passing gate: followed — MTP0 W13-N64, MTP1 depth-4
    promoted the day their gate passed.
-7. Read-only work delegated while GPUs busy: not verifiable from git alone.
-8. One lane per host: no shared-host infra events this week, consistent with
-   CURRENT.md stating Flash-Next now runs on a separate host.
+7. Read-only work delegated while GPUs busy: unverifiable from git.
+8. One lane per host: no shared-host infra events, consistent with
+   CURRENT.md's separate-host statement.
 
 ## Top three changes
 
 1. **Change**: block arm 3+ of any bisection whose result filenames contain
    "phantom", "trace", or "isolation" without a linked census note.
-   **Evidence**: R166-R184 (10 result files) ran without one, unlike the
-   compliant R151-R162 census that closed the sibling issue.
-   **Expected saving**: the stretch cost ~43h across 30 non-accepted
-   campaigns; the sibling issue closed in under a day once censused.
-   **Generalizes**: any lane where output flips with batch shape/position —
-   the failure mode rule 1 already names.
+   **Evidence**: R166-R184 (10 files) ran without one, unlike the compliant
+   R151-R162 census that closed the sibling issue. **Expected saving**: the
+   stretch cost ~43h across 30 non-accepted campaigns; the sibling issue
+   closed in under a day once censused. **Generalizes**: any lane where
+   output flips with batch shape/position — the failure mode rule 1 names.
 
-2. **Change**: fix the shared Flash-Next repro-package template once (the
-   `wait-and-run-client.sh`/`run-record-gate.sh` reference to the missing
-   `results/qwen38-flash-next-fp8-tp4-ep4-fullgraphdet-mtp1-4352-ple-only-r1-attempt`
-   path, and the 63-88 hardcoded `/opt/*` paths per package), then regenerate
-   affected packages. **Evidence**: `tools/public-closure-scanner.py` reports
-   the same gaps in all 5 `repro/qwen38-flash-next-fp8-tp4-mtp*` candidates
-   published 2026-09-05 through 2026-09-08. **Expected saving**: one fix
-   clears 5 already-paid-for repeats and every future Flash-Next record.
-   **Generalizes**: any lane stamping packages from a shared template
-   inherits its bugs; fix the template, not each instance.
+2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
+   template once (missing `results/...-r1-attempt` path in
+   `wait-and-run-client.sh`/`run-record-gate.sh`; ~30 `/home/steve/...` plus
+   ~28 `/mnt/usb-models/...` hardcoded paths — the scanner's `/opt/*` hits
+   are mostly deliberate Dockerfile-internal paths, not the defect), then
+   regenerate. **Evidence**: `tools/public-closure-scanner.py` finds the same
+   gaps in all 5 `repro/qwen38-flash-next-fp8-tp4-mtp*` `status:candidate`
+   packages, 2026-09-05 through 2026-09-08. **Expected saving**: one fix
+   clears 5 paid-for repeats and every future record. **Generalizes**: any
+   lane stamping packages from a shared template inherits its bugs.
 
-3. **Change**: extend the prereg/result convention (or the metrics glob) so
-   lanes without `*prereg*.json` under `data/` (`qwen35-4b-b70`,
+3. **Change**: fix the metrics script's classifier (check "rejected" before
+   "accepted"; classify on `status` alone, not `decision`, whose
+   `*_gate_passed` keys leak into keyword matches) and extend its
+   `data/*prereg*.json` glob to lanes that skip it (`qwen35-4b-b70`,
    `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
-   `laguna-s-2.1-xpu-b70`) are counted. **Evidence**:
-   `campaigns_by_lane_outcome` in `/tmp/eff.json` lists only two lanes despite
-   commit subjects showing active work on five more. **Expected saving**: a
-   measurement fix — without it, every audit under-counts throughput and can
-   misjudge which lanes are slow. **Generalizes**: every new lane must keep
-   the shared measuring stick working, not just the two it was built against.
+   `laguna-s-2.1-xpu-b70`). **Evidence**: see Verdict; `/tmp/eff.json` lists
+   only two lanes despite five more active. **Expected saving**: every audit
+   currently starts from a wrong count and an incomplete lane list; one fix
+   removes both. **Generalizes**: this is the stick every future audit
+   reads first.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first ran against a shallow
   clone (50 commits, ~6h), silently giving a 6h window and 0.0h latencies.
   Ran `git fetch --unshallow origin main` (read-only) and re-ran against the
-  full 1185-commit history before writing this report; the shallow-clone run
-  should not be trusted.
+  full 1185-commit history before writing this report.
 - Ran `tools/public-closure-scanner.py`; 10 of 38 packages are
   `status:candidate` with real gaps (listed above).
+- After review flagged the raw script's accepted/rejected split as
+  unreliable (confirmed on R57/R60/R63), recomputed outcomes from each
+  campaign's `status` field, rejected checked before accepted.
 - Read AGENTS.md rules (lines 317-355), `DO-NOT-REPEAT.md`, `CURRENT.md`, and
   notes under both lanes' `notes/` committed 09-01 to 09-08.
-- Scanned commits, notes, `CURRENT.md`, `DO-NOT-REPEAT.md`, `AGENTS.md` for
-  text addressed to an auditor/AI; found none.
+- Scanned commits and notes for text addressed to an auditor/AI; found none.
 - Rules 3, 5, 7, 8 rely only on regex (both empty) or absence of contrary
-  evidence; not independently verified. No GPU work launched or simulated;
-  no recipe, result, prereg, note, DO-NOT-REPEAT.md, CURRENT.md, or
-  AGENTS.md edited; nothing merged.
+  evidence; unverified. No GPU work launched or simulated; no recipe,
+  result, prereg, note, DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited;
+  nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after twenty-one correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after twenty-two correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -28,14 +28,15 @@ missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra time lost | ≥45 min (R277); 68 file mentions, rest untimed | `/tmp/eff.json` |
+| Infra time lost | ≥118 min (R277 45 + A61 73); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
-10 gapped candidates: 5 Flash-Next (below) plus `qwen35-4b-w4a16-b70`,
-`qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`, `qwen38-27b-autoround-int4-b70`,
-`qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps),
-unexamined.
+10 gapped candidates: 5 Flash-Next (below), 5 more — 3 qwen35
+(shared-file gaps: `qwen38-27b-autoround-int4-b70`'s README,
+`qwen35-9b-b70`'s scripts), `qwen38-27b-autoround-int4-b70` (7
+missing_path, 4 unreachable-builder), `qwen38-27b-fp8-vllm-tp2-asrock-b70`
+(33 missing_release_asset, 4 host_path_hardcoded).
 
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
@@ -46,10 +47,11 @@ two-card divergence is separate, narrower),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after twenty-one rounds — treat counts as directional. (3)
-per-accepted document cost: 355 preregs + 795 notes / 6 accepted ≈ 192
-each (directional, caveat 2); composite-arm/duplicate-artifact counts
-not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
+through after twenty-two rounds — treat counts as directional. (3)
+per-accepted document cost (this week only): 153 preregs + 49 notes / 6
+accepted ≈ 34 each (355+795 all-time; directional, caveat 2);
+composite-arm/duplicate-artifact not computed. (4)
+`/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
 reproduce these counts.
 
@@ -68,12 +70,11 @@ distinct):
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
    servers; R151-R162's census closed them in 20 minutes; **not
    applicable** to the MTP2 phantom (history-dependent).
-2. Oracle regenerated per kernel change: **violated** — R140 gated
-   against the frozen oracle (8/12); R147's regenerated oracle matched
-   12/12.
-3. No speed verdict from one server: **violated** — R140 rejected a
-   candidate on -1.14% (two R147 servers beat it); R58/R60/R65 rejected
-   on one server (R65 despite identity-qualified);
+2. Oracle regenerated per kernel change: **violated** — R140 gated on
+   the frozen oracle (8/12); R147 regenerated it, matched 12/12.
+3. No speed verdict from one server: **violated** — R140 rejected on
+   -1.14% (two R147 servers beat it); R58/R60/R65 rejected on one
+   server (R65 despite identity-qualified);
    R57/R195/R196/R150/R189/R260b/R265b publish single-server profiles;
    R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
@@ -83,51 +84,47 @@ distinct):
    to the 45-min timeout; 68 files matched.
 6. Stop at first passing gate: **violated** — depth 5 cleared its bar
    but the lane swept 6-7 first (fault blocked those ladders); R186j
-   passed, R186n ran before R187's endpoint.
+   passed, R186n ran before R187.
 7. Read-only work: unverified.
-8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
-   no host field traces the window.
+8. One lane per host: **unverified** — no host field traces the
+   window.
 
 ## Top three changes
 
 1. **Change**: extend rule 1's census to state/scheduling transitions,
-   not just batch shape. **Evidence**: R168-169 found
-   `--no-async-scheduling` avoids the MTP2 phantom by arm 4 (per
-   AGENTS.md's wording rule, not "fixes"); 9 more probes followed.
-   **Expected saving**: unmeasured; a census could shortcut it.
-   **Generalizes**: any scheduler/state-bleed bug a shape-only census
-   can't catch.
+   not just batch shape. **Evidence**: R168-169 found async-off avoids
+   (AGENTS.md's wording rule) the MTP2 phantom by arm 4; 9 more probes
+   followed. **Expected saving**: unmeasured; a census could shortcut
+   it. **Generalizes**: any scheduler/state-bleed bug a shape-only
+   census can't catch.
 
 2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not the
-   ~25 container-internal `/opt/...` Dockerfile/entrypoint paths
-   inflating HCTriton/lossless/placement's counts); replace the
-   README's literal `E=...json` args with real filenames; fix the
-   scanner's truncation/`$var`-template bugs; publish MTP1's missing
-   runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
+   ~25 container-internal `/opt/...` paths inflating 3 of them);
+   replace the README's literal `E=...json` args with real filenames;
+   fix the scanner's truncation/`$var`-template bugs; publish MTP1's
+   missing runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
    `build-image.sh` already builds the tagged image via
    `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
-   false positive. **Expected saving**: these fixes clear the real
-   gaps; only the tarball is missing. **Generalizes**: don't trust this
-   scanner's counts without verifying, like the metrics classifier.
+   false positive. **Expected saving**: these clear the real gaps;
+   only the tarball is missing. **Generalizes**: don't trust scanner
+   counts without verifying, like the metrics classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum; join via `preregistration`; ingest
-   result-only/note-only records (R261/R273/R277) via a required
-   structured artifact per campaign; log GPU time lost per infra
-   fault. **Evidence**: twenty-one rounds found new keyword-matching
-   defects. **Expected saving**: every future audit starts from a
-   count, not an estimate. **Generalizes**: the stick every audit
-   reads.
+   result/note-only records (R261/R273/R277) via a required artifact
+   per campaign; log GPU time lost per infra fault. **Evidence**:
+   twenty-two rounds found new keyword-matching defects. **Expected
+   saving**: every future audit starts from a count, not an estimate.
+   **Generalizes**: the stick every audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
   clone; `git fetch --unshallow origin main` then re-ran it.
-- Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Twenty-one review rounds (Codex), verified and reflected above:
-  classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings — why this file
-  reports directional estimates, not a patched regex.
-- Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`; scanned for
-  auditor-directed text — none.
+- Ran `tools/public-closure-scanner.py`.
+- Twenty-two review rounds (Codex), verified and reflected above —
+  why this file reports directional estimates, not a patched regex.
+- Read AGENTS.md, `DO-NOT-REPEAT.md`; scanned for auditor-directed
+  text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,
   CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -4,18 +4,18 @@
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept past.
-This week's own measuring stick needed four rounds of correction:
-`scripts/efficiency-audit-metrics.py` checked "accepted" before "rejected",
-matched `decision` keys like `*_gate_passed`, and joined by filename prefix
-only, missing composite campaigns and their latency. Reclassified,
-rejected-first, joined via `preregistration`: `qwen38-27b-b70` 12 accepted /
-79 rejected / 26 unclassified / 38 no-result-yet of 157. Separately, the
-lane spent a 30-arm, ~43h stretch (R166-R208) chasing a "phantom token"
-R168 confirmed is history-dependent, not batch-shape — a class no AGENTS.md
-rule covers — and a depth-5 candidate that passed its gate got swept into
-two more depths before its own ladders finished. All 5 Flash-Next
-`status: candidate` packages this week carry the same repro-package gaps,
-none publishable.
+This week's own measuring stick needed five rounds of correction, including
+a keyword classifier too fragile for precise arm-counts (Checks, below).
+Reclassified: `qwen38-27b-b70` 15 accepted / 79 rejected / 23 unclassified
+/ 38 no-result-yet / 2 aborted-infra of 157. AGENTS.md's own account of the
+R64-R146 GDN bisection ("three days... settled in an evening") is this
+window's longest-running issue, closed by the R151-R162 census. A second
+issue (R166 on) chased a "phantom token" R168 confirmed is
+history-dependent, not batch-shape — a class no rule covers — while a
+depth-5 candidate that passed its gate got swept into two more depths
+first. All 5 Flash-Next `status: candidate` packages this week carry the
+same gaps, none publishable. This audit could not cover
+`qwen35-4b-b70`/`qwen35-9b-b70` — CURRENT.md's stated active lane — at all.
 
 ## Metrics table
 
@@ -23,97 +23,96 @@ none publishable.
 |---|---|---|
 | Commits, 7d | 1185 (codex 225 / claude 960) | `/tmp/eff.json` |
 | Campaigns tracked | 165 (qwen38-27b-b70: 157, flash-next: 8) | `/tmp/eff.json` |
-| qwen38-27b-b70 outcomes (reclassified) | accepted 12, rejected 79, no-result-yet 38, unclassified 26, aborted-infra 2 | `status`/`classification`, joined via `preregistration`; see Checks |
-| flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | recomputed |
-| Prereg→result latency | median 0.14h, max 3.28h, n=122 | recomputed post-join; see Checks |
+| qwen38-27b-b70 outcomes (reclassified) | accepted 15, rejected 79, no-result-yet 38, unclassified 23, aborted-infra 2 | see Checks |
+| flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
+| Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
 | Infra-event files matched | 68; top: `.../int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
 
-Caveat: the campaign metric only sees lanes with a `*prereg*.json` file under
-`data/`; `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
-`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits under
-no such filename, so the table misses them.
+Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
+`data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
+`gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
+`laguna-s-2.1-xpu-b70` had commits under no such filename, so the table
+misses the lane the lab itself calls active. (2) outcome buckets are
+keyword matches over free text — estimates, not exact counts (Checks).
 
 ## Where the week went
 
-- **Longest**: 30 non-accepted `qwen38-27b-b70` campaigns, `r166` through
-  `r208` (09-03 02:52 → 09-04 21:45). R165's ladder found a token that looked
-  like a greedy flip at cache-c032; R166 reran fresh, identical MTP2/MTP0 —
-  no flip. R168: "NOT positional, history-bound." R169, the next arm, found
-  "PHANTOM GONE with --no-async-scheduling" — async implicated by arm 4.
-  Nine more probes (state-slot, zero-pages, layer0-control, layer-trace,
-  enforce-eager, inductor-knobs; `.../mtp2-phantom-*.md`) localized the
-  mechanism inside that path. Concurrently, a chained sequence (R195-R197
-  preregistered together, R198-R203 "queued behind" each last) published
-  depths 3-4; depth 5 also passed but was swept past (rule 6, below).
-- **Second/third** (26 + 15 arms, `r63-control`→`r103`): tail of the
-  R64-R146 GDN bisection, in-window only because the rule set was recorded
-  mid-incident; R151-R162's census closed it.
+- **Longest-running**: AGENTS.md itself records the R64-R146 GDN bisection
+  as spanning three days before "one operator-level sweep and one chained
+  campaign" (R151-R162, this window) closed it — the incident rule 1 was
+  written to stop.
+- **A second, rule-gap issue**: R165's ladder found what looked like a
+  greedy flip at cache-c032; R166 reran fresh, identical MTP2/MTP0 — no
+  flip. R168: "NOT positional, history-bound." R169: "PHANTOM GONE with
+  --no-async-scheduling" — async implicated by arm 4. Nine more probes
+  (`.../mtp2-phantom-*.md`) localized the mechanism — no batch-shape census
+  would have caught it. Concurrently, a chained sequence (R195-R203, each
+  "queued behind" the last) published depths 3-4; depth 5 also passed but
+  was swept past (rule 6, below).
 
 ## Rule compliance
 
-1. Census before bisection: followed (R151-R162 closed MTP0/MTP1). **Not
-   applicable** to the MTP2 phantom — history-, not shape-dependent per
-   R168; no rule covers it.
+1. Census before bisection: followed (R151-R162 closed R64-R146). **Not
+   applicable** to the MTP2 phantom — history-, not shape-dependent; no
+   rule covers it.
 2. Oracle regenerated when kernel changed: followed.
-3. No speed verdict from one server: none matched.
-4. Whole campaign as one preregistered runner: mixed — R195-R203 chained
-   without human round trips; R166-R190 were one server per prereg.
-5. Fast-fail on GPU faults: 68 infra-event files matched; runner
-   abort-before-timeout behavior unverified.
+3. No speed verdict from one server: none.
+4. Whole campaign as one preregistered runner: mixed — R195-R203 chained;
+   R166-R190 were one server per prereg.
+5. Fast-fail on GPU faults: 68 files matched; abort-timing unverified.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
-   (R200), but the lane swept depths 6-7 first; the resulting fault blocked
-   its own ladders that boot.
+   (R200), but the lane swept depths 6-7 first; the fault that followed
+   blocked its own ladders.
 7. Read-only work delegated: unverifiable.
-8. One lane per host: no shared-host infra events; consistent with
-   CURRENT.md.
+8. One lane per host: no shared-host infra events; consistent with CURRENT.md.
 
 ## Top three changes
 
 1. **Change**: extend AGENTS.md with rule 1's census discipline for state
-   transitions/scheduling, which it doesn't currently cover (only batch
-   shape). **Evidence**: R168-R169 localized this to async scheduling by arm
-   4, then 9 more arms searched the mechanism inside it one hypothesis at a
-   time — directed but still uncensused. **Expected saving**: unmeasured; a
-   mechanism census could shortcut that tail. **Generalizes**: any future
-   scheduler/state-bleed bug this shape-focused census can't catch.
+   transitions/scheduling, which it doesn't cover (only batch shape).
+   **Evidence**: R168-169 localized the MTP2 phantom to async scheduling by
+   arm 4; 9 more arms then searched the mechanism one hypothesis at a
+   time. **Expected saving**: unmeasured; a mechanism census could
+   shortcut that tail. **Generalizes**: any scheduler/state-bleed bug a
+   shape-only census can't catch.
 
 2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
-   template (~30 `/home/steve/...` plus ~28 `/mnt/usb-models/...` hardcoded
-   paths in `supervise-*`/`run-*-client.sh` — the scanner's `/opt/*` and
-   `results/...-r1-attempt` hits are false positives, not the defect), then
-   regenerate. **Evidence**: the scanner finds the same gaps in all 5
-   candidate packages, 09-05 to 09-08. **Expected saving**: one fix clears 5
+   scripts once (`launch-*.sh` carries most hardcoded `/home`/`/mnt`
+   paths, then `run-*-client.sh`, `supervise-*.sh`,
+   `q38-launch-frozen-attempt.sh`; the scanner's `/opt/*` and
+   `results/...-r1-attempt` hits are false positives), then regenerate.
+   **Evidence**: same gaps, dominated by `launch-*.sh`, in all 5
+   candidates, 09-05 to 09-08. **Expected saving**: one fix clears 5
    paid-for repeats and every future record. **Generalizes**: shared
-   templates propagate bugs.
+   scripts propagate bugs to every package built from them.
 
 3. **Change**: fix the metrics script — check "rejected" before "accepted";
    classify on `status`/`classification`, not `decision`; join via
-   `preregistration`, not filename prefix (also feeds the latency sample);
-   extend the glob to lanes that skip it (`qwen35-4b-b70`, `qwen35-9b-b70`,
-   `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
-   `laguna-s-2.1-xpu-b70`). **Evidence**: see Verdict; 7 campaigns and 7
-   latency points were missed before the join fix. **Expected saving**:
-   every audit starts from wrong counts. **Generalizes**: the stick every
-   future audit reads first.
+   `preregistration`; extend the glob to the lanes in the Metrics caveat;
+   replace the keyword match with a structured `outcome` enum.
+   **Evidence**: five review rounds found new keyword-matching defects
+   each time. **Expected saving**: every audit starts from an estimate,
+   not a count. **Generalizes**: the stick every future audit reads first.
 
 ## Checks performed
 
-- `scripts/efficiency-audit-metrics.py --days 7` first ran against a shallow
-  clone (50 commits, ~6h), silently giving a 6h window and 0.0h latencies.
-  Ran `git fetch --unshallow origin main` (read-only) and re-ran against the
+- `scripts/efficiency-audit-metrics.py --days 7` first ran against a
+  shallow clone (50 commits), silently giving a 6h window. Ran
+  `git fetch --unshallow origin main` (read-only) and re-ran against the
   full 1185-commit history before writing this report.
-- Ran `tools/public-closure-scanner.py`; verified 26/12 split, 10/3 gaps
-  against `packages/catalog.json` and the scanner's JSON.
-- Four rounds of PR review (Codex), each finding verified against primary
-  sources before fixing: accept/reject order bug; `/opt/*` and
-  `results/...-r1-attempt` false positives; candidate-status language;
-  missing preregistration join (stale latency n too); `classification`-only
-  terminal fields; R166/R168/R169 chronology; a real rule-6 violation.
-  Fixed and pushed.
-- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes under
-  both lanes committed 09-01 to 09-08.
+- Ran `tools/public-closure-scanner.py`; verified 26/12, 10/3 against
+  `packages/catalog.json`.
+- Five rounds of PR review (Codex): accept/reject order; scanner false
+  positives; candidate-status language; missing preregistration join;
+  `classification`-only fields; chronology; a real rule-6 violation; a
+  `pass:` pattern the regex missed, which moved counts and ruled out
+  arm-counting (rewrote "longest stretch" around AGENTS.md's own account);
+  no active-lane analysis. Fixed except the last (follow-up needed on
+  `qwen35-4b-b70`/`-9b-b70`).
+- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes,
+  09-01 to 09-08.
 - Scanned commits/notes for text addressed to an auditor/AI; found none.
 - No GPU work launched/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after nineteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after twenty correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; nine single-server results
+its gate got swept into two more depths; ten single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable (metrics table). This audit
 missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -45,9 +45,10 @@ an unexplained two-card divergence — `docs/model-effort-index.md`),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after nineteen rounds — treat counts as directional. (3)
-per-accepted token-cost and composite-arm expansion (protocol
-requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
+through after twenty rounds — treat counts as directional. (3)
+per-accepted document cost: 355 preregs + 795 notes / 6 accepted ≈ 192
+each (directional, caveat 2); composite-arm and duplicate-artifact
+counts not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
 reproduce these counts.
 
@@ -67,29 +68,29 @@ distinct):
    servers; the R151-R162 census closed them in 20 minutes; **not
    applicable** to the MTP2 phantom (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated
-   against the frozen oracle (8/12); R147's regenerated same-image
-   oracle matched 12/12.
+   against the frozen oracle (8/12); R147's regenerated oracle matched
+   12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
-   candidate on -1.14% (two R147 servers beat it); R60 declined a
-   second server; R195/R196/R150/R189/R260b/R265b publish
-   single-server profiles; R203's lone depth-7 attempt decided the
-   depth-6-vs-7 turnover.
-4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 separate preregs; R184-186/R190-191/R182 batch multi-arm;
-   R166-183 less R182 singleton.
+   candidate on -1.14% (two R147 servers beat it); R58/R60 declined a
+   second server on a near-miss; R195/R196/R150/R189/R260b/R265b
+   publish single-server profiles; R203's lone depth-7 attempt decided
+   the depth-6-vs-7 turnover.
+4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
+   separate preregs; R184-186/R190-191/R182 batch multi-arm; R166-183
+   less R182 singleton.
 5. Fast-fail on GPU faults: **violated** — R277 faulted at 04:47 but
    hung to the 45-min timeout; 68 files matched.
-6. Stop at first passing gate: **violated** — depth 5 cleared its 2%
-   bar but the lane swept 6-7 first (fault blocked those ladders);
-   R186j passed; R186n ran before R187's endpoint.
-7. Read-only work delegated: unverified.
+6. Stop at first passing gate: **violated** — depth 5 cleared its bar
+   but the lane swept 6-7 first (fault blocked those ladders); R186j
+   passed; R186n ran before R187's endpoint.
+7. Read-only work: unverified.
 8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
    no host field traces the window.
 
 ## Top three changes
 
-1. **Change**: extend rule 1's census discipline to state/scheduling
-   transitions, not just batch shape. **Evidence**: R168-169 found
+1. **Change**: extend rule 1's census to state/scheduling transitions,
+   not just batch shape. **Evidence**: R168-169 found
    `--no-async-scheduling` avoids the MTP2 phantom by arm 4 (per
    AGENTS.md's wording rule, not "fixes"); 9 more probes followed.
    **Expected saving**: unmeasured; a census could shortcut it.
@@ -100,8 +101,8 @@ distinct):
    ~25 container-internal `/opt/...` Dockerfile/entrypoint paths
    inflating HCTriton/lossless/placement's 80+ counts); replace the
    README's literal `E=...json` args with real filenames; fix the
-   scanner's truncation/`$var`-template parsing bugs; publish MTP1's
-   missing runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
+   scanner's truncation/`$var`-template bugs; publish MTP1's missing
+   runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
    `build-image.sh` already builds the tagged image via
    `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
    false positive. **Expected saving**: these fixes clear the real
@@ -109,24 +110,23 @@ distinct):
    scanner's counts without verifying, like the metrics classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
-   structured `outcome` enum, not another regex patch; join via
-   `preregistration`; ingest result-only and note-only records
-   (R261/R273/R277) by requiring a structured artifact per campaign;
-   log GPU time lost per infra fault. **Evidence**: nineteen rounds
-   found new keyword-matching defects. **Expected saving**: every
-   future audit starts from a count, not an estimate. **Generalizes**:
-   the stick every audit reads.
+   structured `outcome` enum; join via `preregistration`; ingest
+   result-only and note-only records (R261/R273/R277) by requiring a
+   structured artifact per campaign; log GPU time lost per infra
+   fault. **Evidence**: twenty rounds found new keyword-matching
+   defects. **Expected saving**: every future audit starts from a
+   count, not an estimate. **Generalizes**: the stick every audit
+   reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
   clone; `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Nineteen review rounds (Codex), verified and reflected above:
-  classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings; accept-keyword
-  false matches — why this file reports directional estimates, not a
-  patched regex.
-- Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes; scanned for
+- Twenty review rounds (Codex), verified and reflected above:
+  classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings — why this file
+  reports directional estimates, not a patched regex.
+- Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`; scanned for
   auditor-directed text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,
   CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,19 +5,19 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after fifteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after sixteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
-non-accepted stretches (59/30/28 arms) reduce to two real incidents:
+non-accepted stretches (59/~28 arms, #2 miscounted — Checks) reduce to
+two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; six single-server results were
-reported as speed verdicts (rule 3). None of 10
-gapped `status: candidate` packages
-(5 Flash-Next, 5 below) is publishable. This audit missed
-`qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
+its gate got swept into two more depths; seven single-server results
+were reported as speed verdicts (rule 3). None of 10 gapped
+`status: candidate` packages is publishable (metrics table). This audit
+missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 
 ## Metrics table
 
@@ -30,19 +30,19 @@ gapped `status: candidate` packages
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
 | Infra-event file mentions (not time-lost) | 68; top `.../r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
-| Closure scan | 26 candidates (10 gaps); 12 informational guides (3 gaps) | `/tmp/closure.md` |
+| Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
 10 gapped candidates: 5 Flash-Next (below) plus `qwen35-4b-w4a16-b70`,
 `qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`, `qwen38-27b-autoround-int4-b70`,
 `qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps),
 unexamined.
 
-Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
-`data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
+Caveats: (1) the metric only sees lanes with a `*prereg*.json` file;
+`qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one.
 (2) outcomes are keyword matches, not structured; some still slip
-through after fifteen rounds — treat counts as directional. (3)
+through after sixteen rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -53,34 +53,36 @@ and #3 both stem from R64-R146, split by R119's 09:15 promotion, not
 distinct):
 
 1. **~59 arms**, 09-01 11:38→09-02 01:32, `r63-concurrency`→`r118b`.
-2. **~30 arms**, 09-03 02:52→09-04 21:45, `r166`→`r208`: R165 found what
-   looked like a greedy flip; R166 reran fresh, identical — no flip.
-   R168-169 traced it from history-bound to async scheduling by arm 4;
-   9 more probes localized it.
+2. **Miscounted**: R187 (09-03 20:02-20:42) passed every gate inside
+   this window, so `r166`→`r208` isn't one 30-arm stretch (MTP2 phantom
+   detail: change #1); not recomputed this round.
 3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16.
 
 ## Rule compliance
 
-1. Census before bisection: **violated** — R64-R116 ran fifty-odd servers
-   before the R151-R162 census closed them in twenty minutes; **not
+1. Census before bisection: **violated** — R64-R116 ran fifty-odd
+   servers before the R151-R162 census closed them in 20 minutes; **not
    applicable** to the MTP2 phantom (history-, not shape-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated the
-   row-invariant kernel against the frozen natural-kernel oracle (8/12);
-   R147's regenerated same-image oracle matched 12/12.
+   row-invariant kernel against the frozen oracle (8/12); R147's
+   regenerated same-image oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
    candidate on one server's -1.14% (two R147 servers beat it);
-   R195/R196/R150/R189 (`unrepeated`) publish single-server profiles;
-   R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
+   R195/R196/R150/R189/R260b (`unrepeated`) publish single-server
+   profiles; R203's lone depth-7 attempt decided the depth-6-vs-7
+   turnover.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 are three separate preregs, no human round trip;
+   R202-203 are three separate preregs, no round trip;
    R184-186/R190-191/R182 batch multi-arm; R166-183 less R182 singleton.
-5. Fast-fail on GPU faults: 68 files matched; timing unchecked.
-6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
+5. Fast-fail on GPU faults: **violated** — R277 faulted and coredumped
+   at 04:47 but hung to the 45-min timeout; 68 files matched, most
+   timing unchecked.
+6. Stop at first passing gate: **violated** — depth 5 cleared its 2% bar
    but the lane swept depths 6-7 first (fault blocked its ladders);
    R186j passed; R186n ran before R187's endpoint.
 7. Read-only work delegated: unverified.
-8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot; no
-   per-campaign host field traces the window.
+8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
+   no per-campaign host field traces the window.
 
 ## Top three changes
 
@@ -91,25 +93,25 @@ distinct):
    could shortcut it. **Generalizes**: any scheduler/state-bleed bug a
    shape-only census can't catch.
 
-2. **Change**: fix ALL MTP0's hardcoded-host scripts, not just
-   `launch-*.sh` (63 hits, only 31 there); replace the README's literal
-   `E=128,N=640,…json` args with real filenames; fix the scanner
-   parser's two false-positive classes (`=`/`,`-heavy filenames, and
-   shell `$var`-templated paths like `wait-and-run-client.sh:22`); and
-   publish the missing MTP1 runtime tarball and a reachable builder.
-   **Evidence**: path gaps hit all 5; only MTP1 carries
+2. **Change**: fix ALL 5 candidates' hardcoded-host scripts, not just
+   MTP0's (`launch-*.sh` covers 31/63 there; HCTriton/lossless/placement
+   carry 80+ each); replace the README's literal `E=...json` args with
+   real filenames; fix the scanner's two path-parsing false-positive
+   classes; publish MTP1's missing runtime tarball and reachable
+   builder. **Evidence**: path gaps hit all 5; only MTP1 also carries
    `missing_release_asset`/`image_without_reachable_builder`.
-   **Expected saving**: the four fixes clear MTP0; MTP1 needs the
-   asset/builder work too. **Generalizes**: a shared script, doc, or
-   scanner bug propagates wherever reused.
+   **Expected saving**: script/doc/parser fixes clear the path gaps;
+   MTP1 still needs the asset/builder work. **Generalizes**: a shared
+   script, doc, or scanner bug propagates wherever reused.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
-   `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: fifteen rounds found new
-   keyword-matching defects. **Expected saving**: every audit starts
-   from an estimate, not a count. **Generalizes**: the stick every
-   audit reads.
+   `preregistration`; ingest result-only records for the caveat's lanes
+   (no prereg file exists to glob for); log GPU time lost per infra
+   fault. **Evidence**:
+   sixteen rounds found new keyword-matching defects. **Expected
+   saving**: every future audit starts from a count, not an estimate.
+   **Generalizes**: the stick every audit reads.
 
 ## Checks performed
 
@@ -117,12 +119,12 @@ distinct):
   clone; ran `git fetch --unshallow origin main` and re-ran against
   full history.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Fifteen review rounds (Codex), verified and reflected above:
-  classifier bugs; rule-1/2/3/4/6/8 findings; scanner false positives;
+- Sixteen review rounds (Codex), verified and reflected above:
+  classifier bugs; rule-1/2/3/4/5/6/8 findings; scanner false positives;
   unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
   accept keywords despite being diagnostic/non-promotable — why this
   file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes; scanned for
-  auditor-directed text: none.
-- No GPU work run/simulated; no recipe, result, prereg, note,
-  DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.
+  auditor-directed text — none.
+- No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,
+  CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -4,19 +4,18 @@
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept past.
-This week's own measuring stick needed six rounds of correction, including
-a keyword classifier too fragile for precise arm-counts (Checks, below).
-Reclassified: `qwen38-27b-b70` 15 accepted / 79 rejected / 23 unclassified
-/ 38 no-result-yet / 2 aborted-infra of 157. Its longest stretches are
-mostly one incident, AGENTS.md's own R64-R146 GDN bisection ("three
-days... settled in an evening"), closed by the R151-R162 census. A second
-issue (R166 on) chased a history-dependent "phantom token," a class no
-rule covers, while a depth-5 candidate that passed its gate got swept
-into two more depths, and two single-server results were reported as a
-speed verdict (rule 3). All 5 Flash-Next `status: candidate` packages
-this week carry the same gaps, none publishable. This audit could not
-cover `qwen35-4b-b70`/`qwen35-9b-b70` — CURRENT.md's stated active lane —
-at all.
+This week's own measuring stick needed seven rounds of correction,
+including a keyword classifier too fragile for precise arm-counts (Checks,
+below). Reclassified: `qwen38-27b-b70` 15 accepted / 79 rejected / 23
+unclassified / 38 no-result-yet / 2 aborted-infra of 157. Its longest
+stretches are mostly one incident, AGENTS.md's own R64-R146 GDN bisection
+("three days... settled in an evening"), closed by the R151-R162 census. A
+second issue (R166 on) chased a history-dependent "phantom token" no rule
+covers, while a depth-5 candidate that passed its gate got swept into two
+more depths, and two single-server results were reported as a speed
+verdict (rule 3). None of the 5 Flash-Next `status: candidate` packages
+is publishable (change #2). This audit could not cover
+`qwen35-4b-b70`/`qwen35-9b-b70` — CURRENT.md's stated active lane — at all.
 
 ## Metrics table
 
@@ -27,16 +26,15 @@ at all.
 | qwen38-27b-b70 outcomes (reclassified) | accepted 15, rejected 79, no-result-yet 38, unclassified 23, aborted-infra 2 | see Checks |
 | flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra-event files matched | 68; top: `.../int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
+| Infra-event file mentions (not time-lost — unmeasured) | 68; top: `.../r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
 
 Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
-`laguna-s-2.1-xpu-b70` lack one, so the table misses the lane the lab
-calls active. (2) outcome buckets are keyword matches — estimates, not
-exact counts (Checks).
+`laguna-s-2.1-xpu-b70` lack one, missing the lane the lab calls active.
+(2) outcomes are keyword matches — estimates, not counts (Checks).
 
 Three longest non-accepted `qwen38-27b-b70` stretches (rejected checked
 before accepted; see Checks):
@@ -45,75 +43,74 @@ before accepted; see Checks):
    AGENTS.md's own R64-R146 GDN bisection ("three days... settled in an
    evening"), closed by R151-R162's census — the incident rule 1 stops.
 2. **22 arms**, 09-03 02:52-22:10, `r166`→`r190/191`: R165 found what
-   looked like a greedy flip; R166 reran fresh, identical MTP2/MTP0 — no
-   flip. R168: "NOT positional, history-bound." R169: "PHANTOM GONE with
+   looked like a greedy flip; R166 reran fresh, identical — no flip. R168:
+   "NOT positional, history-bound." R169: "PHANTOM GONE with
    --no-async-scheduling" — async implicated by arm 4. Nine more probes
    localized the mechanism — no batch-shape census would have caught it.
-   Concurrently R195-R203 published depths 3-4; depth 5 also passed but
-   was swept past (rule 6, below).
+   Concurrently the R195/200/202-203 group (rule 4) published depths 3-4;
+   depth 5 also passed but was swept past (rule 6).
 3. **15 arms**, 09-01 20:49 → 09-02 01:32, `r105`→`r118b`: more of #1's
-   incident, split off only by one borderline "accepted" `r104` — likely
-   one continuous incident in practice.
+   incident, split off only by one borderline "accepted" `r104`.
 
 ## Rule compliance
 
-1. Census before bisection: followed (R151-R162 closed R64-R146). **Not
-   applicable** to the MTP2 phantom — history-, not shape-dependent.
-2. Oracle regeneration on kernel change: followed.
+1. Census before bisection: followed (R151-R162 closed R64-R146); **not
+   applicable** to the MTP2 phantom (history-, not shape-dependent).
+2. Oracle regeneration per kernel change: followed.
 3. No speed verdict from one server: **violated** — R195/R196
-   (`classification: unrepeated`) conclude "Depth 3 is the fastest lossless
-   profile at every measured depth" from one server each.
-4. Whole campaign as one preregistered runner: mixed — R195-R203 chained,
-   R166-R190 one server per prereg.
-5. Fast-fail on GPU faults: 68 files matched; abort-timing unverified.
+   (`classification: unrepeated`) declare depth 3 fastest at every
+   measured depth from one server each.
+4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
+   R202-203 are three separate preregs, queued immediately behind each
+   other with no human round trip evident; R166-R190 were one server per
+   prereg.
+5. Fast-fail on GPU faults: 68 files matched (timing unchecked).
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
    but the lane swept depths 6-7 first; the fault that followed blocked
    its own ladders.
-7. Read-only work delegated: unverifiable.
-8. One lane per host: no shared-host events; matches CURRENT.md.
+7. Read-only work delegated: unverified.
+8. One lane per host: matches CURRENT.md.
 
 ## Top three changes
 
-1. **Change**: extend AGENTS.md with rule 1's census discipline for state
+1. **Change**: extend AGENTS.md's rule 1 census discipline to state
    transitions/scheduling — it only covers batch shape today. **Evidence**:
-   R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9 more
-   arms searched the mechanism one hypothesis at a time. **Expected
-   saving**: unmeasured; a census could shortcut that tail.
-   **Generalizes**: any scheduler/state-bleed bug a shape-only census
-   can't catch.
+   R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9
+   more arms searched one hypothesis at a time. **Expected saving**:
+   unmeasured; a census could shortcut that tail. **Generalizes**: any
+   scheduler/state-bleed bug a shape-only census can't catch.
 
-2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
-   scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths, then
-   `run-*-client.sh`, `supervise-*.sh`, `q38-launch-frozen-attempt.sh`; the
-   scanner's `/opt/*`/`results/...-r1-attempt` hits are false positives),
-   then regenerate. **Evidence**: same gaps, dominated by `launch-*.sh`, in
-   all 5 candidates. **Expected saving**: clears 5 paid-for repeats and
-   every future record. **Generalizes**: shared scripts propagate bugs to
-   every package built from them.
+2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
+   scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths;
+   scanner `/opt/*`/`results/...-r1-attempt` hits are false positives);
+   separately, publish the missing runtime tarball and a reachable builder
+   for the image the 4 MTP1 candidates reference. **Evidence**: path gaps
+   hit all 5; only MTP1 also carries `missing_release_asset`/
+   `image_without_reachable_builder`. **Expected saving**: the script fix
+   alone clears MTP0; MTP1 needs both. **Generalizes**: shared scripts
+   propagate bugs to every package built from them.
 
 3. **Change**: fix the metrics script — check "rejected" before "accepted";
    classify on `status`/`classification`, not `decision`; join via
    `preregistration`; extend the glob to the caveat's lanes; replace the
-   keyword match with a structured `outcome` enum. **Evidence**: six
-   review rounds found new keyword-matching defects each time. **Expected
-   saving**: every audit starts from an estimate, not a count.
+   keyword match with a structured `outcome` enum; log GPU time lost per
+   infra fault. **Evidence**: seven rounds found new defects each time.
+   **Expected saving**: every audit starts from an estimate, not a count.
    **Generalizes**: the stick every audit reads first.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first ran against a
-  shallow clone, silently giving a 6h window. Ran `git fetch --unshallow
-  origin main` (read-only) and re-ran against the full 1185-commit history
-  before writing this report.
-- Ran `tools/public-closure-scanner.py`; verified 26/12, 10/3 vs
-  `packages/catalog.json`.
-- Six rounds of PR review (Codex): accept/reject order; scanner false
+  shallow clone, giving a 6h window. Ran `git fetch --unshallow origin
+  main` (read-only) and re-ran against the full history.
+- Ran `tools/public-closure-scanner.py` against `packages/catalog.json`.
+- Seven rounds of PR review (Codex): accept/reject order; scanner false
   positives; candidate-status language; missing preregistration join;
-  `classification`-only fields; chronology; rule-3 and rule-6 violations; a
-  `pass:` pattern the regex missed, forcing the three stretches above to
-  be derived, not eyeballed; no active-lane analysis. Fixed except the
-  last (`qwen35-4b-b70`/`-9b-b70` needs a follow-up run).
-- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes.
-- Scanned commits/notes for text addressed to an auditor: none.
-- No GPU work launched/simulated; no recipe, result, prereg, note,
+  `classification`-only fields; chronology; rule-3/4/6 findings; a `pass:`
+  pattern forcing derived, not eyeballed, stretches above; release-asset/
+  builder gaps on the 4 MTP1 packages; unmeasured infra-time-lost; no
+  active-lane analysis. Fixed except the last.
+- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes.
+- Scanned commits/notes for auditor-directed text: none.
+- No GPU work run/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -1,0 +1,123 @@
+# Efficiency audit — 2026-09-08
+
+## Verdict
+
+The lab is faster where the census/chained-runner discipline in AGENTS.md is
+followed, no faster where it isn't. The tracked lane (`qwen38-27b-b70`)
+produced 32 accepted results out of 157 campaigns at 0.14h median
+prereg-to-result latency once preregistered — but also spent a 30-arm,
+~43-hour stretch (R166-R208) on a per-hypothesis "phantom token" bisection
+with no census note, echoing the R64-R146 incident the AGENTS.md rule set
+(2026-09-02) was written to close. Separately, all 5 Flash-Next records
+shipped this week carried the same broken repro-package template
+(`tools/public-closure-scanner.py`): publication throughput taxed by a
+fixable, repeating defect, not new work.
+
+## Metrics table
+
+| Metric | Value | Source |
+|---|---|---|
+| Commits, 7d | 1185 (codex 225 / claude 960) | `/tmp/eff.json` |
+| Campaigns tracked | 165 (qwen38-27b-b70: 157, flash-next: 8) | `/tmp/eff.json` |
+| qwen38-27b-b70 outcomes | accepted 32, rejected 56, no-result-yet 45, unclassified 20, aborted-infra 4 | `/tmp/eff.json` |
+| flash-next outcomes | accepted 1, rejected 1, no-result-yet 5, unclassified 1 | `/tmp/eff.json` |
+| Prereg→result latency | median 0.14h, max 3.28h, n=115 | `/tmp/eff.json` |
+| Infra-event files matched | 68; top: `.../notes/2026-09-06-qwen38-int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
+| Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
+| Closure scan | 38 packages; 10 `status:candidate` with real gaps, 25 clean | `/tmp/closure.md` |
+
+Caveat: the campaign metric only sees lanes with a `*prereg*.json` file under
+`data/`. `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
+`minimax-m27-reap-autoround-vllm`, and `laguna-s-2.1-xpu-b70` had commits and
+results this week under no such filename, so `campaigns_by_lane_outcome`
+misses them — 165 tracked campaigns understate total throughput.
+
+## Where the week went
+
+- **Longest accepted-result-free stretch**: 30 consecutive non-accepted
+  `qwen38-27b-b70` campaigns, `r156-mtp2-first-token-diag-r166` through
+  `qwen38-int4-autoround-r187-stack-r208` (09-03 02:52 → 09-04 21:45, both
+  under `experiments/qwen38-27b-b70/notes/2026-09-0[34]-*.md`). Hypothesis: a
+  single-token mismatch at batch position 32/33 in MTP2, chased arm-by-arm in
+  `...-mtp2-phantom-*-r17[6-9]*.md` and `-r18[0-4]*.md` (state-slot probe,
+  zero-mamba-pages, layer0-control, layer-trace, enforce-eager,
+  inductor-knobs). No MTP2 census note exists, unlike the compliant
+  `2026-09-03-qwen38-fp8-c32-identity-source-census-r151-r162.md` that had
+  just cleared the sibling MTP0/MTP1 issue — rule 1 targets exactly this
+  flip. The stretch ended when the method changed to a chained ladder
+  (`2026-09-04-qwen38-fp8-mtp-depth-turnover-r200-r203.md`, depths 1-7 in one
+  run), producing an accepted depth-4 promotion the same day.
+- **Second** (26 arms, `r63-control`→`r87`, Sept 1) and **third** (15 arms,
+  `r89`→`r103`): both are the tail of the R64-R146 GDN bisection that
+  AGENTS.md's rule set (2026-09-02) was written to stop, falling inside this
+  window because the rule was recorded mid-incident; R151-R162's census then
+  closed it.
+
+## Rule compliance
+
+1. Census before bisection: **violated**, R166-R208 (no census note); followed
+   once R151-R162 landed for the sibling issue.
+2. Oracle regenerated when kernel changed: followed, e.g.
+   `mtp1-fixed-k-regenerated-oracle-r147-partial.md`.
+3. No speed verdict from one server: no violation matched (regex empty both
+   runs); not independently verified.
+4. Whole campaign as one preregistered runner: followed for R200-R203; **not
+   clearly followed** for R166-R184 (each probe its own dated result, fresh
+   boot/image).
+5. Fast-fail on GPU faults: 68 infra-event files found; timeout-vs-startup
+   detection not verifiable.
+6. Stop at first passing gate: followed — MTP0 W13-N64 and MTP1 depth-4
+   promoted the day their gate passed.
+7. Read-only work delegated while GPUs busy: not verifiable from git alone.
+8. One lane per host: no shared-host infra events this week, consistent with
+   CURRENT.md stating Flash-Next now runs on a separate host.
+
+## Top three changes
+
+1. **Change**: block arm 3+ of any bisection whose result filenames contain
+   "phantom", "trace", or "isolation" without a linked census note.
+   **Evidence**: R166-R184 (10 result files) ran without one, unlike the
+   compliant R151-R162 census that closed the sibling issue.
+   **Expected saving**: the stretch cost ~43h across 30 non-accepted
+   campaigns; the sibling issue closed in under a day once censused.
+   **Generalizes**: any lane where output flips with batch shape/position —
+   the failure mode rule 1 already names.
+
+2. **Change**: fix the shared Flash-Next repro-package template once (the
+   `wait-and-run-client.sh`/`run-record-gate.sh` reference to the missing
+   `results/qwen38-flash-next-fp8-tp4-ep4-fullgraphdet-mtp1-4352-ple-only-r1-attempt`
+   path, and the 63-88 hardcoded `/opt/*` paths per package), then regenerate
+   affected packages. **Evidence**: `tools/public-closure-scanner.py` reports
+   the same gaps in all 5 `repro/qwen38-flash-next-fp8-tp4-mtp*` candidates
+   published 2026-09-05 through 2026-09-08. **Expected saving**: one fix
+   clears 5 already-paid-for repeats and every future Flash-Next record.
+   **Generalizes**: any lane stamping packages from a shared template
+   inherits its bugs; fix the template, not each instance.
+
+3. **Change**: extend the prereg/result convention (or the metrics glob) so
+   lanes without `*prereg*.json` under `data/` (`qwen35-4b-b70`,
+   `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
+   `laguna-s-2.1-xpu-b70`) are counted. **Evidence**:
+   `campaigns_by_lane_outcome` in `/tmp/eff.json` lists only two lanes despite
+   commit subjects showing active work on five more. **Expected saving**: a
+   measurement fix — without it, every audit under-counts throughput and can
+   misjudge which lanes are slow. **Generalizes**: every new lane must keep
+   the shared measuring stick working, not just the two it was built against.
+
+## Checks performed
+
+- `scripts/efficiency-audit-metrics.py --days 7` first ran against a shallow
+  clone (50 commits, ~6h), silently giving a 6h window and 0.0h latencies.
+  Ran `git fetch --unshallow origin main` (read-only) and re-ran against the
+  full 1185-commit history before writing this report; the shallow-clone run
+  should not be trusted.
+- Ran `tools/public-closure-scanner.py`; 10 of 38 packages are
+  `status:candidate` with real gaps (listed above).
+- Read AGENTS.md rules (lines 317-355), `DO-NOT-REPEAT.md`, `CURRENT.md`, and
+  notes under both lanes' `notes/` committed 09-01 to 09-08.
+- Scanned commits, notes, `CURRENT.md`, `DO-NOT-REPEAT.md`, `AGENTS.md` for
+  text addressed to an auditor/AI; found none.
+- Rules 3, 5, 7, 8 rely only on regex (both empty) or absence of contrary
+  evidence; not independently verified. No GPU work launched or simulated;
+  no recipe, result, prereg, note, DO-NOT-REPEAT.md, CURRENT.md, or
+  AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -3,20 +3,20 @@
 ## Verdict
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
-failure falls outside them or a passing candidate keeps getting swept
-past — and this week's keyword classifier can't draw exact boundaries
-even after eleven correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+failure falls outside them or a passing candidate gets swept past —
+and this week's keyword classifier can't draw exact boundaries
+even after twelve correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
 non-accepted stretches (59/30/28 arms) reduce to two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
-not batch-shape, a class no rule covers. A depth-5 candidate that passed
+not batch-shape; no rule covers it. A depth-5 candidate that passed
 its gate got swept into two more depths, and three single-server results
 (R140/R195/R196) were reported as a speed verdict (rule 3). None of 10
 gapped `status: candidate` packages (5
-Flash-Next, 5 more below) is publishable. This audit missed
+Flash-Next, 5 below) is publishable. This audit missed
 `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 
 ## Metrics table
@@ -34,20 +34,23 @@ Flash-Next, 5 more below) is publishable. This audit missed
 
 10 gapped candidates: 5 Flash-Next (below) plus `qwen35-4b-w4a16-b70`,
 `qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`, `qwen38-27b-autoround-int4-b70`,
-`qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps) — not
-investigated further this round.
+`qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps), not
+investigated further.
 
 Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one.
 (2) outcomes are keyword matches, not a structured field; some cases still
-slip through after eleven fix rounds — treat counts as directional. (3)
+slip through after twelve fix rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
-requirements) were not computed.
+requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
+aren't committed (one-file limit); rerunning after 2026-09-08 won't
+reproduce these counts.
 
-Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
-#1/#3 same incident):
+Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2; #1
+and #3 both stem from R64-R146, split by R119's 09:15 promotion, not
+distinct):
 
 1. **~59 arms**, 09-01 11:38 → 09-02 01:32, `r63-concurrency`→`r118b`.
 2. **~30 arms**, 09-03 02:52 → 09-04 21:45, `r166`→`r208`: R165 found what
@@ -55,7 +58,7 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
    R168-169 traced it from history-bound to async scheduling by arm 4;
    9 more probes localized it. R195-203 (rules 4/6) ran concurrently.
 3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16
-   kernel work, part of #1's R64-R146 incident.
+   kernel work.
 
 ## Rule compliance
 
@@ -67,19 +70,19 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
    R147's regenerated same-image oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
    candidate on one server's -1.14% (two R147 servers beat the prior
-   center); R195/R196 (`unrepeated`) each declare depth 3 fastest from
-   one server.
+   center); R195/R196 (`unrepeated`) declare depth 3 fastest from one
+   server.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 are three separate preregs queued back-to-back, no human
-   round trip; R184-186/R190-191 batch 3 arms/stages per prereg;
-   R166-183 singleton preregs.
-5. Fast-fail on GPU faults: 68 files matched; timing unchecked.
+   R202-203 are three separate preregs, no human round trip;
+   R184-186/R190-191 batch 3 arms/stages per prereg; R166-183 singleton
+   preregs.
+5. Fast-fail on GPU faults: 68 files matched, timing unchecked.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
    but the lane swept depths 6-7 first (fault blocked its ladders);
-   R186j's gate passed but R186n ran before R187's endpoint began.
+   R186j passed; R186n ran before R187's endpoint.
 7. Read-only work delegated: unverified.
-8. One lane per host: **unverified** — CURRENT.md:25/35 is a
-   snapshot; no per-campaign host field traces the window.
+8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
+   no per-campaign host field traces the window.
 
 ## Top three changes
 
@@ -87,39 +90,38 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
    transitions/scheduling — it only covers batch shape today. **Evidence**:
    R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9
    more probes followed. **Expected saving**:
-   unmeasured; a census could shortcut that tail. **Generalizes**: any
+   unmeasured; a census could shortcut it. **Generalizes**: any
    scheduler/state-bleed bug a shape-only census can't catch.
 
 2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
    scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths;
    scanner `/opt/*`/`results/...-r1-attempt` hits are false positives),
    and publish the missing MTP1 runtime tarball and a reachable builder.
-   **Evidence**: path gaps hit all 5; only
-   MTP1 also carries `missing_release_asset`/`image_without_reachable_builder`.
+   **Evidence**: path gaps hit all 5; only MTP1 carries
+   `missing_release_asset`/`image_without_reachable_builder`.
    **Expected saving**: the script fix alone clears MTP0; MTP1 needs both.
-   **Generalizes**: shared scripts propagate bugs everywhere built from
-   them.
+   **Generalizes**: shared scripts propagate bugs everywhere built from them.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: eleven review rounds found new
+   lost per infra fault. **Evidence**: twelve rounds found new
    keyword-matching defects. **Expected saving**: every audit
-   starts from a moving estimate, not a count. **Generalizes**: the stick
+   starts from an estimate, not a count. **Generalizes**: the stick
    every audit reads first.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
-  clone (6h window); ran `git fetch --unshallow origin main` (read-only)
-  and re-ran against full history.
-- Ran `tools/public-closure-scanner.py` against `packages/catalog.json`.
-- Eleven review rounds (Codex), verified and reflected above:
+  clone (6h window); ran `git fetch --unshallow origin main` and re-ran
+  against full history.
+- Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
+- Twelve review rounds (Codex), verified and reflected above:
   classifier bugs; rule-1/2/3/4/6/8 findings; scanner false positives;
   unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
   accept keywords despite being diagnostic/non-promotable — why this
   file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes.
-- Scanned commits/notes for auditor-directed text — none.
+- Scanned for auditor-directed text: none.
 - No GPU work run/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -2,19 +2,19 @@
 
 ## Verdict
 
-The lab is faster where AGENTS.md's census/chained-runner discipline is
-followed, no faster where it isn't — and this week's measuring stick needed
-a correction to see that. `scripts/efficiency-audit-metrics.py` checks
-"accepted" before "rejected" and matches text inside JSON key names like
-`*_gate_passed`, so R57 (`passed-gates-rejected-no-material-benefit`), R60,
-R63 all counted as accepted; reclassifying `status` text rejected-first gives
-`qwen38-27b-b70` 11 accepted / 71 rejected / 29 unclassified of 157 (still
-an overcount — R123, R165 read as rejects but keyword-match
-"passed"/"promotable" too). The lane also spent a 30-arm, ~43h stretch
-(R166-R208) on a "phantom token" bisection with no census note, echoing the
-R64-R146 incident AGENTS.md's rule set (2026-09-02) was written to close.
-All 5 Flash-Next `status: candidate` packages shipped this week carry the
-same repro-package gaps, none yet publishable.
+The lab is faster where AGENTS.md's rules are followed, no faster where a
+failure falls outside what any rule covers — and this week's measuring stick
+needed two rounds of correction to see that. `scripts/efficiency-audit-metrics.py`
+checked "accepted" before "rejected", matched `decision` keys like
+`*_gate_passed`, and joined results by filename prefix only, missing
+composite campaigns. Reclassified from `status`/`classification`,
+rejected-first, joined via `preregistration`: `qwen38-27b-b70` 12 accepted /
+79 rejected / 26 unclassified / 38 no-result-yet of 157. Separately, the
+lane spent a 30-arm, ~43h stretch (R166-R208) chasing a "phantom token"
+R168 confirmed is history-dependent, not a batch-shape flip — a class none
+of AGENTS.md's eight rules covers. All 5 Flash-Next `status: candidate`
+packages shipped this week carry the same repro-package gaps, none
+publishable.
 
 ## Metrics table
 
@@ -22,83 +22,83 @@ same repro-package gaps, none yet publishable.
 |---|---|---|
 | Commits, 7d | 1185 (codex 225 / claude 960) | `/tmp/eff.json` |
 | Campaigns tracked | 165 (qwen38-27b-b70: 157, flash-next: 8) | `/tmp/eff.json` |
-| qwen38-27b-b70 outcomes (reclassified) | accepted 11, rejected 71, no-result-yet 45, unclassified 29, aborted-infra 1 | `status` fields, see Checks |
+| qwen38-27b-b70 outcomes (reclassified) | accepted 12, rejected 79, no-result-yet 38, unclassified 26, aborted-infra 2 | `status`/`classification`, joined via `preregistration`; see Checks |
 | flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | recomputed |
 | Prereg→result latency | median 0.14h, max 3.28h, n=115 | `/tmp/eff.json` |
 | Infra-event files matched | 68; top: `.../notes/2026-09-06-qwen38-int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
-| Closure scan | 38 packages; 10 candidates with real gaps, 25 clean | `/tmp/closure.md` |
+| Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
 
 Caveat: the campaign metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
 `minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits and
-results this week under no such filename, so the outcome table misses them.
+results this week under no such filename, so the table misses them.
 
 ## Where the week went
 
-- **Longest**: 30 non-accepted `qwen38-27b-b70` campaigns,
-  `r156-mtp2-first-token-diag-r166` through `r187-stack-r208`
-  (09-03 02:52 → 09-04 21:45, `experiments/qwen38-27b-b70/notes/2026-09-0[34]-*.md`).
-  A single-token mismatch at batch position 32/33 in MTP2, chased arm-by-arm
-  (state-slot probe, zero-mamba-pages, layer0-control, layer-trace,
-  enforce-eager, inductor-knobs; `...-mtp2-phantom-*-r17[6-9]*.md`,
-  `-r18[0-4]*.md`) with no MTP2 census note, unlike `c32-identity-source-census-r151-r162.md`,
-  which had just cleared the sibling MTP0/MTP1 issue — rule 1 names exactly
-  this flip. Ended when the method changed to a chained ladder
-  (`mtp-depth-turnover-r200-r203.md`, depths 1-7 in one run), producing an
-  accepted depth-4 promotion same day.
-- **Second** (26 arms, `r63-control`→`r87`) and **third** (15 arms,
-  `r89`→`r103`): the tail of the R64-R146 GDN bisection AGENTS.md's rule set
-  was written to stop, inside this window because the rule was recorded
-  mid-incident; R151-R162's census then closed it.
+- **Longest**: 30 non-accepted `qwen38-27b-b70` campaigns, `r166` through
+  `r208` (09-03 02:52 → 09-04 21:45). R165's ladder found a token that looked
+  like a greedy flip at cache-c032; R166 reran the prompt fresh and got
+  identical MTP2/MTP0 output — no flip. R168 narrowed it further: "NOT
+  positional, history-bound," tied to the request right after evidence-c031.
+  Ten more single-hypothesis probes followed anyway (state-slot, zero-pages,
+  layer0-control, layer-trace, enforce-eager, inductor-knobs;
+  `.../notes/2026-09-03-qwen38-fp8-mtp2-phantom-*.md`) before async
+  scheduling was implicated. Concurrently, a chained overnight sequence
+  (R195-R197 preregistered together, R198-R203 each "queued behind" the
+  last) published depths 3, 4, then 5 as each passed its gate.
+- **Second** (26 arms) and **third** (15 arms), `r63-control`→`r103`: the
+  tail of the R64-R146 GDN bisection, inside this window because AGENTS.md's
+  rule set was recorded mid-incident; R151-R162's census closed it.
 
 ## Rule compliance
 
-1. Census before bisection: **violated**, R166-R208 (no census note);
-   followed once R151-R162 landed for the sibling issue.
-2. Oracle regenerated when kernel changed: followed (`...r147-partial.md`).
-3. No speed verdict from one server: no violation matched; unverified.
-4. Whole campaign as one preregistered runner: followed R200-R203; **not**
-   R166-R184 (each probe its own dated result, fresh boot/image).
-5. Fast-fail on GPU faults: 68 infra-event files found; startup-vs-timeout
-   detection unverifiable.
-6. Stop at first passing gate: followed — MTP0 W13-N64, MTP1 depth-4
-   promoted the day their gate passed.
-7. Read-only work delegated while GPUs busy: unverifiable from git.
-8. One lane per host: no shared-host infra events, consistent with
+1. Census before bisection: followed (R151-R162 closed MTP0/MTP1).
+   **Not applicable** to the MTP2 phantom (R166-R208) — R168 confirmed it's
+   history-, not shape-dependent; no rule covers it.
+2. Oracle regenerated when kernel changed: followed (`r147-partial.md`).
+3. No speed verdict from one server: no violation matched.
+4. Whole campaign as one preregistered runner: mixed — R195-R203 chained
+   without a human round trip; R166-R190 were one server per
+   preregistration with review between each.
+5. Fast-fail on GPU faults: 68 infra-event files found.
+6. Stop at first passing gate: followed — depths 3-5 published the day
+   their gate passed.
+7. Read-only work delegated while GPUs busy: unverifiable.
+8. One lane per host: no shared-host infra events; consistent with
    CURRENT.md's separate-host statement.
 
 ## Top three changes
 
-1. **Change**: block arm 3+ of any bisection whose result filenames contain
-   "phantom", "trace", or "isolation" without a linked census note.
-   **Evidence**: R166-R184 (10 files) ran without one, unlike the compliant
-   R151-R162 census that closed the sibling issue. **Expected saving**: the
-   stretch cost ~43h across 30 non-accepted campaigns; the sibling issue
-   closed in under a day once censused. **Generalizes**: any lane where
-   output flips with batch shape/position — the failure mode rule 1 names.
+1. **Change**: extend AGENTS.md with a process control for non-positional,
+   history-dependent flips — build a minimal repro of the triggering state
+   transition before further single-subsystem probes; rule 1 only covers
+   batch-shape/prompt-length/concurrency flips. **Evidence**: R168
+   established "NOT positional, history-bound" at arm 3; 10 more
+   single-hypothesis probes (R169-R184) followed anyway. **Expected
+   saving**: unmeasured but real — the stretch ran ~43h past the point its
+   own trigger was already narrowed. **Generalizes**: any future
+   scheduler/state-bleed bug this shape-focused census can't catch.
 
 2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
    template once (missing `results/...-r1-attempt` path in
    `wait-and-run-client.sh`/`run-record-gate.sh`; ~30 `/home/steve/...` plus
    ~28 `/mnt/usb-models/...` hardcoded paths — the scanner's `/opt/*` hits
-   are mostly deliberate Dockerfile-internal paths, not the defect), then
-   regenerate. **Evidence**: `tools/public-closure-scanner.py` finds the same
-   gaps in all 5 `repro/qwen38-flash-next-fp8-tp4-mtp*` `status:candidate`
-   packages, 2026-09-05 through 2026-09-08. **Expected saving**: one fix
-   clears 5 paid-for repeats and every future record. **Generalizes**: any
-   lane stamping packages from a shared template inherits its bugs.
+   are mostly deliberate Dockerfile paths, not the defect), then regenerate.
+   **Evidence**: the scanner finds the same gaps in all 5 candidate packages,
+   2026-09-05 through 2026-09-08. **Expected saving**: one fix clears 5
+   paid-for repeats and every future record. **Generalizes**: shared
+   templates propagate their bugs.
 
-3. **Change**: fix the metrics script's classifier (check "rejected" before
-   "accepted"; classify on `status` alone, not `decision`, whose
-   `*_gate_passed` keys leak into keyword matches) and extend its
-   `data/*prereg*.json` glob to lanes that skip it (`qwen35-4b-b70`,
-   `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
-   `laguna-s-2.1-xpu-b70`). **Evidence**: see Verdict; `/tmp/eff.json` lists
-   only two lanes despite five more active. **Expected saving**: every audit
-   currently starts from a wrong count and an incomplete lane list; one fix
-   removes both. **Generalizes**: this is the stick every future audit
-   reads first.
+3. **Change**: fix the metrics script itself — check "rejected" before
+   "accepted"; classify on `status`/`classification`, not `decision` (whose
+   `*_gate_passed` keys leak into matches); join via `preregistration`, not
+   filename prefix; extend the `data/*prereg*.json` glob to lanes that skip
+   it (`qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
+   `minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70`). **Evidence**:
+   see Verdict; 7 composite campaigns were miscounted before the join fix.
+   **Expected saving**: every audit starts from wrong counts.
+   **Generalizes**: the stick every future audit reads first.
 
 ## Checks performed
 
@@ -106,15 +106,15 @@ results this week under no such filename, so the outcome table misses them.
   clone (50 commits, ~6h), silently giving a 6h window and 0.0h latencies.
   Ran `git fetch --unshallow origin main` (read-only) and re-ran against the
   full 1185-commit history before writing this report.
-- Ran `tools/public-closure-scanner.py`; 10 of 38 packages are
-  `status:candidate` with real gaps (listed above).
-- After review flagged the raw script's accepted/rejected split as
-  unreliable (confirmed on R57/R60/R63), recomputed outcomes from each
-  campaign's `status` field, rejected checked before accepted.
-- Read AGENTS.md rules (lines 317-355), `DO-NOT-REPEAT.md`, `CURRENT.md`, and
-  notes under both lanes' `notes/` committed 09-01 to 09-08.
-- Scanned commits and notes for text addressed to an auditor/AI; found none.
-- Rules 3, 5, 7, 8 rely only on regex (both empty) or absence of contrary
-  evidence; unverified. No GPU work launched or simulated; no recipe,
-  result, prereg, note, DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited;
-  nothing merged.
+- Ran `tools/public-closure-scanner.py`; verified the 26/12 split and 10/3
+  gap counts against `packages/catalog.json` and the scanner's own JSON.
+- Two rounds of PR review (Codex) found six issues, each verified against
+  primary sources before fixing: accept/reject order bug; `/opt/*`
+  mischaracterization; "published" language for candidates; missing
+  preregistration-field join; `classification`-only terminal fields;
+  R166/R168 batch-position misreading. All fixed and pushed.
+- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes under
+  both lanes' `notes/` committed 09-01 to 09-08.
+- Scanned commits/notes for text addressed to an auditor/AI; found none.
+- No GPU work launched or simulated; no recipe, result, prereg, note,
+  DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept
 past — and this week's keyword classifier can't draw exact boundaries
-even after nine correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after ten correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -42,7 +42,7 @@ Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one, missing the lane the lab calls active.
 (2) outcomes are keyword matches, not a structured field; some cases still
-slip through after nine fix rounds — treat counts as directional. (3)
+slip through after ten fix rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed.
 
@@ -71,11 +71,12 @@ reliable**, caveat 2; #1/#3 are the same incident):
    one server.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
    R202-203 are three separate preregs queued back-to-back, no human
-   round trip; R166-R190 one server per prereg.
+   round trip; R184-186/R190-191 batch 3 arms/stages per prereg;
+   R166-183 singleton preregs.
 5. Fast-fail on GPU faults: 68 files matched; timing unchecked.
-6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar,
-   but the lane swept depths 6-7 first; the fault that followed blocked
-   its ladders.
+6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
+   but the lane swept depths 6-7 first (fault blocked its ladders);
+   R186j's gate passed but R186n ran before R187's endpoint began.
 7. Read-only work delegated: unverified.
 8. One lane per host: matches CURRENT.md.
 
@@ -84,15 +85,15 @@ reliable**, caveat 2; #1/#3 are the same incident):
 1. **Change**: extend rule 1's census discipline to state
    transitions/scheduling — it only covers batch shape today. **Evidence**:
    R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9
-   more arms searched one hypothesis at a time. **Expected saving**:
+   more probes followed. **Expected saving**:
    unmeasured; a census could shortcut that tail. **Generalizes**: any
    scheduler/state-bleed bug a shape-only census can't catch.
 
 2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
    scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths;
    scanner `/opt/*`/`results/...-r1-attempt` hits are false positives),
-   and publish the missing runtime tarball and a reachable builder
-   for the MTP1 candidates' image. **Evidence**: path gaps hit all 5; only
+   and publish the missing MTP1 runtime tarball and a reachable builder.
+   **Evidence**: path gaps hit all 5; only
    MTP1 also carries `missing_release_asset`/`image_without_reachable_builder`.
    **Expected saving**: the script fix alone clears MTP0; MTP1 needs both.
    **Generalizes**: shared scripts propagate bugs everywhere built from
@@ -101,8 +102,8 @@ reliable**, caveat 2; #1/#3 are the same incident):
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: nine review rounds found new
-   keyword-matching defects each time. **Expected saving**: every audit
+   lost per infra fault. **Evidence**: ten review rounds found new
+   keyword-matching defects. **Expected saving**: every audit
    starts from a moving estimate, not a count. **Generalizes**: the stick
    every audit reads first.
 

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after fourteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after fifteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -42,7 +42,7 @@ Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one.
 (2) outcomes are keyword matches, not structured; some still slip
-through after fourteen rounds — treat counts as directional. (3)
+through after fifteen rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -93,11 +93,12 @@ distinct):
 
 2. **Change**: fix ALL MTP0's hardcoded-host scripts, not just
    `launch-*.sh` (63 hits, only 31 there); replace the README's literal
-   `E=128,N=640,…json` args with real filenames; fix the scanner parser
-   separately (truncates the same filenames even where the manifest
-   path is correct); and publish the missing MTP1 runtime tarball and a
-   reachable builder. **Evidence**: path gaps hit all 5; only MTP1
-   carries `missing_release_asset`/`image_without_reachable_builder`.
+   `E=128,N=640,…json` args with real filenames; fix the scanner
+   parser's two false-positive classes (`=`/`,`-heavy filenames, and
+   shell `$var`-templated paths like `wait-and-run-client.sh:22`); and
+   publish the missing MTP1 runtime tarball and a reachable builder.
+   **Evidence**: path gaps hit all 5; only MTP1 carries
+   `missing_release_asset`/`image_without_reachable_builder`.
    **Expected saving**: the four fixes clear MTP0; MTP1 needs the
    asset/builder work too. **Generalizes**: a shared script, doc, or
    scanner bug propagates wherever reused.
@@ -105,7 +106,7 @@ distinct):
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: fourteen rounds found new
+   lost per infra fault. **Evidence**: fifteen rounds found new
    keyword-matching defects. **Expected saving**: every audit starts
    from an estimate, not a count. **Generalizes**: the stick every
    audit reads.
@@ -116,7 +117,7 @@ distinct):
   clone; ran `git fetch --unshallow origin main` and re-ran against
   full history.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Fourteen review rounds (Codex), verified and reflected above:
+- Fifteen review rounds (Codex), verified and reflected above:
   classifier bugs; rule-1/2/3/4/6/8 findings; scanner false positives;
   unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
   accept keywords despite being diagnostic/non-promotable — why this

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after twenty-three correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after twenty-four correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; thirteen single-server results
+its gate got swept into two more depths; fourteen single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable (metrics table). This audit
 missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -28,16 +28,18 @@ missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra time lost | ≥118 min (R277 45 + A61 73); 68 file mentions, rest untimed | `/tmp/eff.json` |
+| Infra time lost | ≥132 min (R277 45 + A61 73 + R278 14); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
-10 gapped candidates: 5 Flash-Next (below), 5 more — 3 qwen35
-(shared-file gaps: `qwen38-27b-autoround-int4-b70`'s README,
-`qwen35-9b-b70`'s scripts), `qwen38-27b-autoround-int4-b70` (4
-missing_path — 3/7 scanned are brace/glob artifacts, files exist — + 4
-unreachable-builder), `qwen38-27b-fp8-vllm-tp2-asrock-b70` (33
-missing_release_asset, 4 host_path_hardcoded).
+10 gapped candidates: 5 Flash-Next (below), 5 more — 3 qwen35 (shared
+gaps: int4 README, `qwen35-9b-b70`'s scripts, + 2 genuinely broken
+refs each from an old Qwen3.6 guide — `staged-package`,
+`data/quality.json`, neither exists); `qwen38-27b-autoround-int4-b70`
+(missing_path unreliable: 4/7 confirmed brace/glob artifacts, ≤3 real,
+unchecked further; + 4 unreachable-builder);
+`qwen38-27b-fp8-vllm-tp2-asrock-b70` (33 missing_release_asset, 4
+host_path_hardcoded).
 
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
@@ -48,7 +50,7 @@ two-card divergence is separate, narrower),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after twenty-three rounds — treat counts as directional. (3)
+through after twenty-four rounds — treat counts as directional. (3)
 per-accepted document cost (this week only): 153 preregs + 49 notes / 6
 accepted ≈ 34 each (355+795 all-time; directional, caveat 2);
 composite-arm/duplicate-artifact not computed. (4)
@@ -69,22 +71,21 @@ distinct):
 ## Rule compliance
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
-   servers; R151-R162's census closed them in 20 min; **not
-   applicable** to the MTP2 phantom (history-dependent).
+   servers; the R151-R162 census closed them; **not applicable** to
+   the MTP2 phantom (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated on
    the frozen oracle (8/12); R147's regen matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected on
    -1.14% (two R147 servers beat it); R58/R60/R65 rejected on one
    server (R65 despite identity-qualified);
-   R57/R139/R195/R196/R150/R189/R260b/R265b publish single-server
-   profiles; R203's lone depth-7 attempt decided the turnover.
+   R57/R139/R179/R195/R196/R150/R189/R260b/R265b publish single-server
+   profiles; R203's lone attempt decided the turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
-   separate preregs; R184-186/R190-191/R182 multi-arm; rest singleton.
+   separate; R184-186/R190-191/R182 multi-arm; rest singleton.
 5. Fast-fail on GPU faults: **violated** — R277 faulted, hung to its
    45-min timeout; 68 files matched.
 6. Stop at first passing gate: **violated** — depth 5 cleared its bar
-   but the lane swept 6-7 first (fault blocked those ladders); R186j
-   passed, R186n ran before R187.
+   but the lane swept 6-7 first; R186j passed, R186n ran before R187.
 7. Read-only work: unverified.
 8. One lane per host: **unverified** — no host field traces the
    window.
@@ -93,7 +94,7 @@ distinct):
 
 1. **Change**: extend rule 1's census to state/scheduling transitions,
    not just batch shape. **Evidence**: R168-169 found async-off avoids
-   (AGENTS.md's wording rule) the MTP2 phantom by arm 4; 9 more probes
+   (AGENTS.md's wording) the MTP2 phantom by arm 4; 9 more probes
    followed. **Expected saving**: unmeasured; a census could shortcut
    it. **Generalizes**: any scheduler/state-bleed bug a shape-only
    census can't catch.
@@ -101,30 +102,30 @@ distinct):
 2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not
    ~25 container-internal `/opt/...` paths inflating 3 of them);
    replace the README's literal `E=...json` args with real filenames;
-   fix the scanner's truncation/`$var`/brace-glob bugs; publish MTP1's
-   missing runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
-   `build-image.sh` already builds the tagged image via
-   `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
-   false positive. **Expected saving**: these clear the real gaps;
-   only the tarball is missing. **Generalizes**: don't trust scanner
+   fix the scanner's truncation/`$var`/brace-glob bugs. **Evidence**:
+   path gaps hit all 5; MTP1's `build-image.sh` already builds the
+   tagged image via `${IMAGE_TAG:-...}` —
+   `image_without_reachable_builder` is also a false positive.
+   **Expected saving**: these clear the real gaps; MTP1's runtime
+   tarball is still missing. **Generalizes**: don't trust scanner
    counts without verifying, like the metrics classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum; join via `preregistration`; ingest
-   result/note-only records (R261/R273/R277) via a required artifact
-   per campaign; log GPU time lost per infra fault. **Evidence**:
-   twenty-three rounds found new keyword-matching defects. **Expected
-   saving**: every future audit starts from a count, not an estimate.
-   **Generalizes**: the stick every audit reads.
+   result/note-only records via a required artifact per campaign; log
+   GPU time lost per infra fault. **Evidence**: twenty-four rounds
+   found new keyword-matching defects. **Expected saving**: every
+   future audit starts from a count, not an estimate. **Generalizes**:
+   the stick every audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` hit a shallow clone;
   `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py`.
-- Twenty-three review rounds (Codex), verified and reflected above —
+- Twenty-four review rounds (Codex), verified and reflected above —
   why this file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`; scanned for auditor-directed
   text — none.
-- No GPU work run/simulated; no recipe, result, prereg, note,
-  DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.
+- No GPU work run/simulated; no recipe/result/prereg/note/
+  DO-NOT-REPEAT.md/CURRENT.md/AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,19 +5,19 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept
 past — and this week's keyword classifier can't draw exact boundaries
-even after eight correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after nine correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
 non-accepted stretches (59/30/28 arms) reduce to two real incidents:
-AGENTS.md's own R64-R146 GDN/kernel bisection ("three days... settled in
-an evening"), closed by the R151-R162 census, and a separate R166-on
-"phantom token" that's history-dependent, not batch-shape, a class no
-rule covers. A depth-5 candidate that passed its gate got swept into two
-more depths, and two single-server results were reported as a speed
-verdict (rule 3). None of 10 gapped `status: candidate` packages (5
+AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
+census, and a separate R166-on "phantom token" that's history-dependent,
+not batch-shape, a class no rule covers. A depth-5 candidate that passed
+its gate got swept into two more depths, and three single-server results
+(R140/R195/R196) were reported as a speed verdict (rule 3). None of 10
+gapped `status: candidate` packages (5
 Flash-Next, 5 more below) is publishable. This audit missed
-`qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's stated active lane, entirely.
+`qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 
 ## Metrics table
 
@@ -42,9 +42,9 @@ Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
 `laguna-s-2.1-xpu-b70` lack one, missing the lane the lab calls active.
 (2) outcomes are keyword matches, not a structured field; some cases still
-slip through after eight fix rounds — treat counts as directional. (3)
-per-accepted prereg/note counts and composite-arm expansion (protocol's
-token-cost and stretch requirements) were not computed.
+slip through after nine fix rounds — treat counts as directional. (3)
+per-accepted token-cost and composite-arm expansion (protocol
+requirements) were not computed.
 
 Three longest non-accepted `qwen38-27b-b70` stretches (**not fully
 reliable**, caveat 2; #1/#3 are the same incident):
@@ -52,25 +52,27 @@ reliable**, caveat 2; #1/#3 are the same incident):
 1. **~59 arms**, 09-01 11:38 → 09-02 01:32, `r63-concurrency`→`r118b`.
 2. **~30 arms**, 09-03 02:52 → 09-04 21:45, `r166`→`r208`: R165 found what
    looked like a greedy flip; R166 reran fresh, identical — no flip.
-   R168: "NOT positional, history-bound." R169: "PHANTOM GONE with
-   --no-async-scheduling" — async implicated by arm 4; 9 more probes
-   localized it. Concurrently R195-197/R200/R202-203 (rule 4) published
-   depths 3-4; depth 5 also passed but was swept past (rule 6).
+   R168-169 traced it from history-bound to async scheduling by arm 4;
+   9 more probes localized it. R195-203 (rules 4/6) ran concurrently.
 3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16
    kernel work, part of #1's R64-R146 incident.
 
 ## Rule compliance
 
-1. Census before bisection: followed (R151-R162 closed R64-R146); **not
+1. Census before bisection: **violated** — R64-R116 ran fifty-odd servers
+   before the R151-R162 census closed them in twenty minutes; **not
    applicable** to the MTP2 phantom (history-, not shape-dependent).
-2. Oracle regenerated per kernel change: followed.
-3. No speed verdict from one server: **violated** — R195/R196
-   (`unrepeated`) declare depth 3 fastest at every depth from one
-   server each.
+2. Oracle regenerated per kernel change: **violated** — R140 gated the
+   row-invariant kernel against the frozen natural-kernel oracle (8/12);
+   R147's regenerated same-image oracle matched 12/12.
+3. No speed verdict from one server: **violated** — R140 rejected a
+   candidate on one server's -1.14% (two R147 servers beat the prior
+   center); R195/R196 (`unrepeated`) each declare depth 3 fastest from
+   one server.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 are three separate preregs queued back-to-back with no human
-   round trip evident; R166-R190 one server per prereg.
-5. Fast-fail on GPU faults: 68 files matched, timing unchecked.
+   R202-203 are three separate preregs queued back-to-back, no human
+   round trip; R166-R190 one server per prereg.
+5. Fast-fail on GPU faults: 68 files matched; timing unchecked.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar,
    but the lane swept depths 6-7 first; the fault that followed blocked
    its ladders.
@@ -88,8 +90,8 @@ reliable**, caveat 2; #1/#3 are the same incident):
 
 2. **Change**: fix the shared `.../qwen38-flash-next-fp8-b70/tools/`
    scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths;
-   scanner `/opt/*`/`results/...-r1-attempt` hits are false positives);
-   separately publish the missing runtime tarball and a reachable builder
+   scanner `/opt/*`/`results/...-r1-attempt` hits are false positives),
+   and publish the missing runtime tarball and a reachable builder
    for the MTP1 candidates' image. **Evidence**: path gaps hit all 5; only
    MTP1 also carries `missing_release_asset`/`image_without_reachable_builder`.
    **Expected saving**: the script fix alone clears MTP0; MTP1 needs both.
@@ -99,23 +101,22 @@ reliable**, caveat 2; #1/#3 are the same incident):
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: eight review rounds found new
+   lost per infra fault. **Evidence**: nine review rounds found new
    keyword-matching defects each time. **Expected saving**: every audit
    starts from a moving estimate, not a count. **Generalizes**: the stick
    every audit reads first.
 
 ## Checks performed
 
-- `scripts/efficiency-audit-metrics.py --days 7` first ran against a
-  shallow clone, giving a 6h window; ran `git fetch --unshallow origin
-  main` (read-only) and re-ran against the full history.
+- `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
+  clone (6h window); ran `git fetch --unshallow origin main` (read-only)
+  and re-ran against full history.
 - Ran `tools/public-closure-scanner.py` against `packages/catalog.json`.
-- Eight review rounds (Codex), each finding verified and reflected above:
-  classifier order/field/join/chronology bugs; rule-3/4/6 findings;
-  scanner false positives; unmeasured infra-time/token-cost metrics; 5
-  unlisted gapped candidates; R101/R104/R165 matching accept keywords
-  despite being diagnostic/non-promotable — why this file reports
-  directional estimates, not a patched regex.
+- Nine review rounds (Codex), verified and reflected above:
+  classifier bugs; rule-1/2/3/4/6 findings; scanner false positives;
+  unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
+  accept keywords despite being diagnostic/non-promotable — why this
+  file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes.
 - Scanned commits/notes for auditor-directed text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note,

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept
 past — and this week's keyword classifier can't draw exact boundaries
-even after ten correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after eleven correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -40,14 +40,14 @@ investigated further this round.
 Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
-`laguna-s-2.1-xpu-b70` lack one, missing the lane the lab calls active.
+`laguna-s-2.1-xpu-b70` lack one.
 (2) outcomes are keyword matches, not a structured field; some cases still
-slip through after ten fix rounds — treat counts as directional. (3)
+slip through after eleven fix rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed.
 
-Three longest non-accepted `qwen38-27b-b70` stretches (**not fully
-reliable**, caveat 2; #1/#3 are the same incident):
+Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
+#1/#3 same incident):
 
 1. **~59 arms**, 09-01 11:38 → 09-02 01:32, `r63-concurrency`→`r118b`.
 2. **~30 arms**, 09-03 02:52 → 09-04 21:45, `r166`→`r208`: R165 found what
@@ -78,7 +78,8 @@ reliable**, caveat 2; #1/#3 are the same incident):
    but the lane swept depths 6-7 first (fault blocked its ladders);
    R186j's gate passed but R186n ran before R187's endpoint began.
 7. Read-only work delegated: unverified.
-8. One lane per host: matches CURRENT.md.
+8. One lane per host: **unverified** — CURRENT.md:25/35 is a
+   snapshot; no per-campaign host field traces the window.
 
 ## Top three changes
 
@@ -102,7 +103,7 @@ reliable**, caveat 2; #1/#3 are the same incident):
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; extend the glob to the caveat's lanes; log GPU time
-   lost per infra fault. **Evidence**: ten review rounds found new
+   lost per infra fault. **Evidence**: eleven review rounds found new
    keyword-matching defects. **Expected saving**: every audit
    starts from a moving estimate, not a count. **Generalizes**: the stick
    every audit reads first.
@@ -113,8 +114,8 @@ reliable**, caveat 2; #1/#3 are the same incident):
   clone (6h window); ran `git fetch --unshallow origin main` (read-only)
   and re-ran against full history.
 - Ran `tools/public-closure-scanner.py` against `packages/catalog.json`.
-- Nine review rounds (Codex), verified and reflected above:
-  classifier bugs; rule-1/2/3/4/6 findings; scanner false positives;
+- Eleven review rounds (Codex), verified and reflected above:
+  classifier bugs; rule-1/2/3/4/6/8 findings; scanner false positives;
   unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
   accept keywords despite being diagnostic/non-promotable — why this
   file reports directional estimates, not a patched regex.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after twenty-two correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after twenty-three correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; twelve single-server results
+its gate got swept into two more depths; thirteen single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable (metrics table). This audit
 missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -34,9 +34,10 @@ missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 
 10 gapped candidates: 5 Flash-Next (below), 5 more — 3 qwen35
 (shared-file gaps: `qwen38-27b-autoround-int4-b70`'s README,
-`qwen35-9b-b70`'s scripts), `qwen38-27b-autoround-int4-b70` (7
-missing_path, 4 unreachable-builder), `qwen38-27b-fp8-vllm-tp2-asrock-b70`
-(33 missing_release_asset, 4 host_path_hardcoded).
+`qwen35-9b-b70`'s scripts), `qwen38-27b-autoround-int4-b70` (4
+missing_path — 3/7 scanned are brace/glob artifacts, files exist — + 4
+unreachable-builder), `qwen38-27b-fp8-vllm-tp2-asrock-b70` (33
+missing_release_asset, 4 host_path_hardcoded).
 
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
@@ -47,7 +48,7 @@ two-card divergence is separate, narrower),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after twenty-two rounds — treat counts as directional. (3)
+through after twenty-three rounds — treat counts as directional. (3)
 per-accepted document cost (this week only): 153 preregs + 49 notes / 6
 accepted ≈ 34 each (355+795 all-time; directional, caveat 2);
 composite-arm/duplicate-artifact not computed. (4)
@@ -68,20 +69,19 @@ distinct):
 ## Rule compliance
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
-   servers; R151-R162's census closed them in 20 minutes; **not
+   servers; R151-R162's census closed them in 20 min; **not
    applicable** to the MTP2 phantom (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated on
-   the frozen oracle (8/12); R147 regenerated it, matched 12/12.
+   the frozen oracle (8/12); R147's regen matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected on
    -1.14% (two R147 servers beat it); R58/R60/R65 rejected on one
    server (R65 despite identity-qualified);
-   R57/R195/R196/R150/R189/R260b/R265b publish single-server profiles;
-   R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
+   R57/R139/R195/R196/R150/R189/R260b/R265b publish single-server
+   profiles; R203's lone depth-7 attempt decided the turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
-   separate preregs; R184-186/R190-191/R182 multi-arm; R166-183 less
-   R182 singleton.
-5. Fast-fail on GPU faults: **violated** — R277 faulted at 04:47, hung
-   to the 45-min timeout; 68 files matched.
+   separate preregs; R184-186/R190-191/R182 multi-arm; rest singleton.
+5. Fast-fail on GPU faults: **violated** — R277 faulted, hung to its
+   45-min timeout; 68 files matched.
 6. Stop at first passing gate: **violated** — depth 5 cleared its bar
    but the lane swept 6-7 first (fault blocked those ladders); R186j
    passed, R186n ran before R187.
@@ -98,10 +98,10 @@ distinct):
    it. **Generalizes**: any scheduler/state-bleed bug a shape-only
    census can't catch.
 
-2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not the
+2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not
    ~25 container-internal `/opt/...` paths inflating 3 of them);
    replace the README's literal `E=...json` args with real filenames;
-   fix the scanner's truncation/`$var`-template bugs; publish MTP1's
+   fix the scanner's truncation/`$var`/brace-glob bugs; publish MTP1's
    missing runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
    `build-image.sh` already builds the tagged image via
    `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
@@ -113,18 +113,18 @@ distinct):
    structured `outcome` enum; join via `preregistration`; ingest
    result/note-only records (R261/R273/R277) via a required artifact
    per campaign; log GPU time lost per infra fault. **Evidence**:
-   twenty-two rounds found new keyword-matching defects. **Expected
+   twenty-three rounds found new keyword-matching defects. **Expected
    saving**: every future audit starts from a count, not an estimate.
    **Generalizes**: the stick every audit reads.
 
 ## Checks performed
 
-- `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
-  clone; `git fetch --unshallow origin main` then re-ran it.
+- `scripts/efficiency-audit-metrics.py --days 7` hit a shallow clone;
+  `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py`.
-- Twenty-two review rounds (Codex), verified and reflected above —
+- Twenty-three review rounds (Codex), verified and reflected above —
   why this file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`; scanned for auditor-directed
   text — none.
-- No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,
-  CURRENT.md, or AGENTS.md edited; nothing merged.
+- No GPU work run/simulated; no recipe, result, prereg, note,
+  DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -4,18 +4,19 @@
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept past.
-This week's own measuring stick needed five rounds of correction, including
+This week's own measuring stick needed six rounds of correction, including
 a keyword classifier too fragile for precise arm-counts (Checks, below).
 Reclassified: `qwen38-27b-b70` 15 accepted / 79 rejected / 23 unclassified
-/ 38 no-result-yet / 2 aborted-infra of 157. AGENTS.md's own account of the
-R64-R146 GDN bisection ("three days... settled in an evening") is this
-window's longest-running issue, closed by the R151-R162 census. A second
-issue (R166 on) chased a "phantom token" R168 confirmed is
-history-dependent, not batch-shape — a class no rule covers — while a
-depth-5 candidate that passed its gate got swept into two more depths
-first. All 5 Flash-Next `status: candidate` packages this week carry the
-same gaps, none publishable. This audit could not cover
-`qwen35-4b-b70`/`qwen35-9b-b70` — CURRENT.md's stated active lane — at all.
+/ 38 no-result-yet / 2 aborted-infra of 157. Its longest stretches are
+mostly one incident, AGENTS.md's own R64-R146 GDN bisection ("three
+days... settled in an evening"), closed by the R151-R162 census. A second
+issue (R166 on) chased a history-dependent "phantom token," a class no
+rule covers, while a depth-5 candidate that passed its gate got swept
+into two more depths, and two single-server results were reported as a
+speed verdict (rule 3). All 5 Flash-Next `status: candidate` packages
+this week carry the same gaps, none publishable. This audit could not
+cover `qwen35-4b-b70`/`qwen35-9b-b70` — CURRENT.md's stated active lane —
+at all.
 
 ## Metrics table
 
@@ -33,86 +34,86 @@ same gaps, none publishable. This audit could not cover
 Caveats: (1) the metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
-`laguna-s-2.1-xpu-b70` had commits under no such filename, so the table
-misses the lane the lab itself calls active. (2) outcome buckets are
-keyword matches over free text — estimates, not exact counts (Checks).
+`laguna-s-2.1-xpu-b70` lack one, so the table misses the lane the lab
+calls active. (2) outcome buckets are keyword matches — estimates, not
+exact counts (Checks).
 
-## Where the week went
+Three longest non-accepted `qwen38-27b-b70` stretches (rejected checked
+before accepted; see Checks):
 
-- **Longest-running**: AGENTS.md itself records the R64-R146 GDN bisection
-  as spanning three days before "one operator-level sweep and one chained
-  campaign" (R151-R162, this window) closed it — the incident rule 1 was
-  written to stop.
-- **A second, rule-gap issue**: R165's ladder found what looked like a
-  greedy flip at cache-c032; R166 reran fresh, identical MTP2/MTP0 — no
-  flip. R168: "NOT positional, history-bound." R169: "PHANTOM GONE with
-  --no-async-scheduling" — async implicated by arm 4. Nine more probes
-  (`.../mtp2-phantom-*.md`) localized the mechanism — no batch-shape census
-  would have caught it. Concurrently, a chained sequence (R195-R203, each
-  "queued behind" the last) published depths 3-4; depth 5 also passed but
-  was swept past (rule 6, below).
+1. **40 arms**, 09-01 11:38-19:40, `r63-concurrency`→`r100`: the tail of
+   AGENTS.md's own R64-R146 GDN bisection ("three days... settled in an
+   evening"), closed by R151-R162's census — the incident rule 1 stops.
+2. **22 arms**, 09-03 02:52-22:10, `r166`→`r190/191`: R165 found what
+   looked like a greedy flip; R166 reran fresh, identical MTP2/MTP0 — no
+   flip. R168: "NOT positional, history-bound." R169: "PHANTOM GONE with
+   --no-async-scheduling" — async implicated by arm 4. Nine more probes
+   localized the mechanism — no batch-shape census would have caught it.
+   Concurrently R195-R203 published depths 3-4; depth 5 also passed but
+   was swept past (rule 6, below).
+3. **15 arms**, 09-01 20:49 → 09-02 01:32, `r105`→`r118b`: more of #1's
+   incident, split off only by one borderline "accepted" `r104` — likely
+   one continuous incident in practice.
 
 ## Rule compliance
 
 1. Census before bisection: followed (R151-R162 closed R64-R146). **Not
-   applicable** to the MTP2 phantom — history-, not shape-dependent; no
-   rule covers it.
-2. Oracle regenerated when kernel changed: followed.
-3. No speed verdict from one server: none.
-4. Whole campaign as one preregistered runner: mixed — R195-R203 chained;
-   R166-R190 were one server per prereg.
+   applicable** to the MTP2 phantom — history-, not shape-dependent.
+2. Oracle regeneration on kernel change: followed.
+3. No speed verdict from one server: **violated** — R195/R196
+   (`classification: unrepeated`) conclude "Depth 3 is the fastest lossless
+   profile at every measured depth" from one server each.
+4. Whole campaign as one preregistered runner: mixed — R195-R203 chained,
+   R166-R190 one server per prereg.
 5. Fast-fail on GPU faults: 68 files matched; abort-timing unverified.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
-   (R200), but the lane swept depths 6-7 first; the fault that followed
-   blocked its own ladders.
+   but the lane swept depths 6-7 first; the fault that followed blocked
+   its own ladders.
 7. Read-only work delegated: unverifiable.
-8. One lane per host: no shared-host infra events; consistent with CURRENT.md.
+8. One lane per host: no shared-host events; matches CURRENT.md.
 
 ## Top three changes
 
 1. **Change**: extend AGENTS.md with rule 1's census discipline for state
-   transitions/scheduling, which it doesn't cover (only batch shape).
-   **Evidence**: R168-169 localized the MTP2 phantom to async scheduling by
-   arm 4; 9 more arms then searched the mechanism one hypothesis at a
-   time. **Expected saving**: unmeasured; a mechanism census could
-   shortcut that tail. **Generalizes**: any scheduler/state-bleed bug a
-   shape-only census can't catch.
+   transitions/scheduling — it only covers batch shape today. **Evidence**:
+   R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9 more
+   arms searched the mechanism one hypothesis at a time. **Expected
+   saving**: unmeasured; a census could shortcut that tail.
+   **Generalizes**: any scheduler/state-bleed bug a shape-only census
+   can't catch.
 
 2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
-   scripts once (`launch-*.sh` carries most hardcoded `/home`/`/mnt`
-   paths, then `run-*-client.sh`, `supervise-*.sh`,
-   `q38-launch-frozen-attempt.sh`; the scanner's `/opt/*` and
-   `results/...-r1-attempt` hits are false positives), then regenerate.
-   **Evidence**: same gaps, dominated by `launch-*.sh`, in all 5
-   candidates, 09-05 to 09-08. **Expected saving**: one fix clears 5
-   paid-for repeats and every future record. **Generalizes**: shared
-   scripts propagate bugs to every package built from them.
+   scripts (`launch-*.sh` carries most hardcoded `/home`/`/mnt` paths, then
+   `run-*-client.sh`, `supervise-*.sh`, `q38-launch-frozen-attempt.sh`; the
+   scanner's `/opt/*`/`results/...-r1-attempt` hits are false positives),
+   then regenerate. **Evidence**: same gaps, dominated by `launch-*.sh`, in
+   all 5 candidates. **Expected saving**: clears 5 paid-for repeats and
+   every future record. **Generalizes**: shared scripts propagate bugs to
+   every package built from them.
 
 3. **Change**: fix the metrics script — check "rejected" before "accepted";
    classify on `status`/`classification`, not `decision`; join via
-   `preregistration`; extend the glob to the lanes in the Metrics caveat;
-   replace the keyword match with a structured `outcome` enum.
-   **Evidence**: five review rounds found new keyword-matching defects
-   each time. **Expected saving**: every audit starts from an estimate,
-   not a count. **Generalizes**: the stick every future audit reads first.
+   `preregistration`; extend the glob to the caveat's lanes; replace the
+   keyword match with a structured `outcome` enum. **Evidence**: six
+   review rounds found new keyword-matching defects each time. **Expected
+   saving**: every audit starts from an estimate, not a count.
+   **Generalizes**: the stick every audit reads first.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first ran against a
-  shallow clone (50 commits), silently giving a 6h window. Ran
-  `git fetch --unshallow origin main` (read-only) and re-ran against the
-  full 1185-commit history before writing this report.
-- Ran `tools/public-closure-scanner.py`; verified 26/12, 10/3 against
+  shallow clone, silently giving a 6h window. Ran `git fetch --unshallow
+  origin main` (read-only) and re-ran against the full 1185-commit history
+  before writing this report.
+- Ran `tools/public-closure-scanner.py`; verified 26/12, 10/3 vs
   `packages/catalog.json`.
-- Five rounds of PR review (Codex): accept/reject order; scanner false
+- Six rounds of PR review (Codex): accept/reject order; scanner false
   positives; candidate-status language; missing preregistration join;
-  `classification`-only fields; chronology; a real rule-6 violation; a
-  `pass:` pattern the regex missed, which moved counts and ruled out
-  arm-counting (rewrote "longest stretch" around AGENTS.md's own account);
-  no active-lane analysis. Fixed except the last (follow-up needed on
-  `qwen35-4b-b70`/`-9b-b70`).
-- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes,
-  09-01 to 09-08.
-- Scanned commits/notes for text addressed to an auditor/AI; found none.
+  `classification`-only fields; chronology; rule-3 and rule-6 violations; a
+  `pass:` pattern the regex missed, forcing the three stretches above to
+  be derived, not eyeballed; no active-lane analysis. Fixed except the
+  last (`qwen35-4b-b70`/`-9b-b70` needs a follow-up run).
+- Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes.
+- Scanned commits/notes for text addressed to an auditor: none.
 - No GPU work launched/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after sixteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after seventeen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -37,12 +37,14 @@ missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 `qwen38-27b-fp8-vllm-tp2-asrock-b70` (path/asset/builder gaps),
 unexamined.
 
-Caveats: (1) the metric only sees lanes with a `*prereg*.json` file;
+Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
+file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
+notes-only, undercounting 157;
 `qwen35-4b-b70`/`qwen35-9b-b70` (CURRENT.md:35's active lane),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`, and
-`laguna-s-2.1-xpu-b70` lack one.
+`laguna-s-2.1-xpu-b70` lack any prereg file.
 (2) outcomes are keyword matches, not structured; some still slip
-through after sixteen rounds — treat counts as directional. (3)
+through after seventeen rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -68,62 +70,60 @@ distinct):
    regenerated same-image oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
    candidate on one server's -1.14% (two R147 servers beat it);
-   R195/R196/R150/R189/R260b (`unrepeated`) publish single-server
-   profiles; R203's lone depth-7 attempt decided the depth-6-vs-7
-   turnover.
+   R195/R196/R150/R189/R260b/R265b publish single-server profiles;
+   R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 are three separate preregs, no round trip;
-   R184-186/R190-191/R182 batch multi-arm; R166-183 less R182 singleton.
+   R202-203 are three separate preregs; R184-186/R190-191/R182 batch
+   multi-arm; R166-183 less R182 singleton.
 5. Fast-fail on GPU faults: **violated** — R277 faulted and coredumped
-   at 04:47 but hung to the 45-min timeout; 68 files matched, most
-   timing unchecked.
+   at 04:47 but hung to the 45-min timeout; 68 files matched.
 6. Stop at first passing gate: **violated** — depth 5 cleared its 2% bar
    but the lane swept depths 6-7 first (fault blocked its ladders);
    R186j passed; R186n ran before R187's endpoint.
 7. Read-only work delegated: unverified.
-8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
+8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot,
    no per-campaign host field traces the window.
 
 ## Top three changes
 
-1. **Change**: extend rule 1's census discipline to state
-   transitions/scheduling — it only covers batch shape today. **Evidence**:
-   R168-169 localized the MTP2 phantom to async scheduling by arm 4; 9
-   more probes followed. **Expected saving**: unmeasured; a census
-   could shortcut it. **Generalizes**: any scheduler/state-bleed bug a
-   shape-only census can't catch.
+1. **Change**: extend rule 1's census discipline to state/scheduling
+   transitions, not just batch shape. **Evidence**: R168-169 localized
+   the MTP2 phantom to async scheduling by arm 4; 9 more probes
+   followed. **Expected saving**: unmeasured; a census could shortcut
+   it. **Generalizes**: any scheduler/state-bleed bug a shape-only
+   census can't catch.
 
-2. **Change**: fix ALL 5 candidates' hardcoded-host scripts, not just
-   MTP0's (`launch-*.sh` covers 31/63 there; HCTriton/lossless/placement
-   carry 80+ each); replace the README's literal `E=...json` args with
-   real filenames; fix the scanner's two path-parsing false-positive
-   classes; publish MTP1's missing runtime tarball and reachable
-   builder. **Evidence**: path gaps hit all 5; only MTP1 also carries
-   `missing_release_asset`/`image_without_reachable_builder`.
-   **Expected saving**: script/doc/parser fixes clear the path gaps;
-   MTP1 still needs the asset/builder work. **Generalizes**: a shared
-   script, doc, or scanner bug propagates wherever reused.
+2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not the
+   ~25 container-internal `/opt/...` Dockerfile/entrypoint paths
+   inflating HCTriton/lossless/placement's 80+ counts); replace the
+   README's literal `E=...json` args with real filenames; publish
+   MTP1's missing runtime tarball. **Evidence**: path gaps hit all 5;
+   MTP1's `build-image.sh` already builds the tagged image via
+   `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
+   false positive, not missing work. **Expected saving**: script/doc
+   fixes clear the real gaps; only the tarball is missing.
+   **Generalizes**: don't trust this scanner's counts without
+   verifying, like the metrics classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
    `preregistration`; ingest result-only records for the caveat's lanes
    (no prereg file exists to glob for); log GPU time lost per infra
    fault. **Evidence**:
-   sixteen rounds found new keyword-matching defects. **Expected
+   seventeen rounds found new keyword-matching defects. **Expected
    saving**: every future audit starts from a count, not an estimate.
    **Generalizes**: the stick every audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
-  clone; ran `git fetch --unshallow origin main` and re-ran against
-  full history.
+  clone; `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Sixteen review rounds (Codex), verified and reflected above:
-  classifier bugs; rule-1/2/3/4/5/6/8 findings; scanner false positives;
-  unmeasured infra-time/token-cost metrics; R101/R104/R165 matching
-  accept keywords despite being diagnostic/non-promotable — why this
-  file reports directional estimates, not a patched regex.
+- Seventeen review rounds (Codex), verified and reflected above:
+  classifier and scanner bugs; rule-1/2/3/4/5/6/8 findings;
+  R101/R104/R165 matching accept keywords despite being
+  diagnostic/non-promotable — why this file reports directional
+  estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes; scanned for
   auditor-directed text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -3,18 +3,18 @@
 ## Verdict
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
-failure falls outside what any rule covers — and this week's measuring stick
-needed two rounds of correction to see that. `scripts/efficiency-audit-metrics.py`
-checked "accepted" before "rejected", matched `decision` keys like
-`*_gate_passed`, and joined results by filename prefix only, missing
-composite campaigns. Reclassified from `status`/`classification`,
-rejected-first, joined via `preregistration`: `qwen38-27b-b70` 12 accepted /
-79 rejected / 26 unclassified / 38 no-result-yet of 157. Separately, the
-lane spent a 30-arm, ~43h stretch (R166-R208) chasing a "phantom token"
-R168 confirmed is history-dependent, not a batch-shape flip — a class none
-of AGENTS.md's eight rules covers. All 5 Flash-Next `status: candidate`
-packages shipped this week carry the same repro-package gaps, none
-publishable.
+failure falls outside them or a passing candidate keeps getting swept past.
+This week's own measuring stick needed three rounds of correction:
+`scripts/efficiency-audit-metrics.py` checked "accepted" before "rejected",
+matched `decision` keys like `*_gate_passed`, and joined by filename prefix
+only, missing composite campaigns. Reclassified, rejected-first, joined via
+`preregistration`: `qwen38-27b-b70` 12 accepted / 79 rejected / 26
+unclassified / 38 no-result-yet of 157. Separately, the lane spent a 30-arm,
+~43h stretch (R166-R208) chasing a "phantom token" R168 confirmed is
+history-dependent, not batch-shape — a class no AGENTS.md rule covers — and
+a depth-5 candidate that passed its gate got swept into two more depths
+before its own ladders finished. All 5 Flash-Next `status: candidate`
+packages this week carry the same repro-package gaps, none publishable.
 
 ## Metrics table
 
@@ -25,80 +25,79 @@ publishable.
 | qwen38-27b-b70 outcomes (reclassified) | accepted 12, rejected 79, no-result-yet 38, unclassified 26, aborted-infra 2 | `status`/`classification`, joined via `preregistration`; see Checks |
 | flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | recomputed |
 | Prereg→result latency | median 0.14h, max 3.28h, n=115 | `/tmp/eff.json` |
-| Infra-event files matched | 68; top: `.../notes/2026-09-06-qwen38-int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
+| Infra-event files matched | 68; top: `.../int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
 
 Caveat: the campaign metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
-`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits and
-results this week under no such filename, so the table misses them.
+`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits this
+week under no such filename, so the table misses them.
 
 ## Where the week went
 
 - **Longest**: 30 non-accepted `qwen38-27b-b70` campaigns, `r166` through
   `r208` (09-03 02:52 → 09-04 21:45). R165's ladder found a token that looked
-  like a greedy flip at cache-c032; R166 reran the prompt fresh and got
-  identical MTP2/MTP0 output — no flip. R168 narrowed it further: "NOT
-  positional, history-bound," tied to the request right after evidence-c031.
-  Ten more single-hypothesis probes followed anyway (state-slot, zero-pages,
+  like a greedy flip at cache-c032; R166 reran fresh and got identical
+  MTP2/MTP0 output — no flip. R168 narrowed it further: "NOT positional,
+  history-bound," tied to the request right after evidence-c031. Ten more
+  single-hypothesis probes followed anyway (state-slot, zero-pages,
   layer0-control, layer-trace, enforce-eager, inductor-knobs;
-  `.../notes/2026-09-03-qwen38-fp8-mtp2-phantom-*.md`) before async
-  scheduling was implicated. Concurrently, a chained overnight sequence
-  (R195-R197 preregistered together, R198-R203 each "queued behind" the
-  last) published depths 3, 4, then 5 as each passed its gate.
-- **Second** (26 arms) and **third** (15 arms), `r63-control`→`r103`: the
-  tail of the R64-R146 GDN bisection, inside this window because AGENTS.md's
-  rule set was recorded mid-incident; R151-R162's census closed it.
+  `.../mtp2-phantom-*.md`) before async scheduling was implicated.
+  Concurrently, a chained sequence (R195-R197 preregistered together,
+  R198-R203 each "queued behind" the last) published depths 3-4; depth 5
+  also passed but was swept past (rule 6, below).
+- **Second/third** (26 + 15 arms, `r63-control`→`r103`): tail of the
+  R64-R146 GDN bisection, in-window only because the rule set was recorded
+  mid-incident; R151-R162's census closed it.
 
 ## Rule compliance
 
-1. Census before bisection: followed (R151-R162 closed MTP0/MTP1).
-   **Not applicable** to the MTP2 phantom (R166-R208) — R168 confirmed it's
-   history-, not shape-dependent; no rule covers it.
+1. Census before bisection: followed (R151-R162 closed MTP0/MTP1). **Not
+   applicable** to the MTP2 phantom (R166-R208) — history-, not
+   shape-dependent per R168; no rule covers it.
 2. Oracle regenerated when kernel changed: followed (`r147-partial.md`).
 3. No speed verdict from one server: no violation matched.
 4. Whole campaign as one preregistered runner: mixed — R195-R203 chained
-   without a human round trip; R166-R190 were one server per
-   preregistration with review between each.
-5. Fast-fail on GPU faults: 68 infra-event files found.
-6. Stop at first passing gate: followed — depths 3-5 published the day
-   their gate passed.
+   without human round trips; R166-R190 were one server per prereg.
+5. Fast-fail on GPU faults: 68 infra-event files matched; runner
+   abort-before-timeout behavior unverified.
+6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
+   (R200), but the lane swept depths 6-7 first; the resulting fault blocked
+   depth 5's own ladders that boot.
 7. Read-only work delegated while GPUs busy: unverifiable.
 8. One lane per host: no shared-host infra events; consistent with
    CURRENT.md's separate-host statement.
 
 ## Top three changes
 
-1. **Change**: extend AGENTS.md with a process control for non-positional,
-   history-dependent flips — build a minimal repro of the triggering state
+1. **Change**: extend AGENTS.md with a control for non-positional,
+   history-dependent flips — a minimal repro of the triggering state
    transition before further single-subsystem probes; rule 1 only covers
-   batch-shape/prompt-length/concurrency flips. **Evidence**: R168
-   established "NOT positional, history-bound" at arm 3; 10 more
-   single-hypothesis probes (R169-R184) followed anyway. **Expected
-   saving**: unmeasured but real — the stretch ran ~43h past the point its
-   own trigger was already narrowed. **Generalizes**: any future
+   batch-shape/prompt-length/concurrency. **Evidence**: R168 established
+   "NOT positional, history-bound" at arm 3; 10 more probes followed
+   anyway. **Expected saving**: unmeasured but real — ~43h past the point
+   the trigger was already narrowed. **Generalizes**: any future
    scheduler/state-bleed bug this shape-focused census can't catch.
 
 2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
-   template once (missing `results/...-r1-attempt` path in
-   `wait-and-run-client.sh`/`run-record-gate.sh`; ~30 `/home/steve/...` plus
-   ~28 `/mnt/usb-models/...` hardcoded paths — the scanner's `/opt/*` hits
-   are mostly deliberate Dockerfile paths, not the defect), then regenerate.
-   **Evidence**: the scanner finds the same gaps in all 5 candidate packages,
-   2026-09-05 through 2026-09-08. **Expected saving**: one fix clears 5
-   paid-for repeats and every future record. **Generalizes**: shared
-   templates propagate their bugs.
+   template once (~30 `/home/steve/...` plus ~28 `/mnt/usb-models/...`
+   hardcoded paths in `supervise-*`/`run-*-client.sh` — the scanner's
+   `/opt/*` and `results/...-r1-attempt` hits are false positives, not the
+   defect), then regenerate. **Evidence**: the scanner finds the same
+   hardcoded-path gaps in all 5 candidate packages, 09-05 to 09-08.
+   **Expected saving**: one fix clears 5 paid-for repeats and every future
+   record. **Generalizes**: shared templates propagate bugs.
 
-3. **Change**: fix the metrics script itself — check "rejected" before
-   "accepted"; classify on `status`/`classification`, not `decision` (whose
+3. **Change**: fix the metrics script — check "rejected" before "accepted";
+   classify on `status`/`classification`, not `decision` (whose
    `*_gate_passed` keys leak into matches); join via `preregistration`, not
-   filename prefix; extend the `data/*prereg*.json` glob to lanes that skip
-   it (`qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
-   `minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70`). **Evidence**:
-   see Verdict; 7 composite campaigns were miscounted before the join fix.
-   **Expected saving**: every audit starts from wrong counts.
-   **Generalizes**: the stick every future audit reads first.
+   filename prefix; extend the glob to lanes that skip it (`qwen35-4b-b70`,
+   `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
+   `laguna-s-2.1-xpu-b70`). **Evidence**: see Verdict; 7 campaigns were
+   miscounted before the join fix. **Expected saving**: every audit starts
+   from wrong counts. **Generalizes**: the stick every future audit reads
+   first.
 
 ## Checks performed
 
@@ -106,15 +105,15 @@ results this week under no such filename, so the table misses them.
   clone (50 commits, ~6h), silently giving a 6h window and 0.0h latencies.
   Ran `git fetch --unshallow origin main` (read-only) and re-ran against the
   full 1185-commit history before writing this report.
-- Ran `tools/public-closure-scanner.py`; verified the 26/12 split and 10/3
-  gap counts against `packages/catalog.json` and the scanner's own JSON.
-- Two rounds of PR review (Codex) found six issues, each verified against
-  primary sources before fixing: accept/reject order bug; `/opt/*`
-  mischaracterization; "published" language for candidates; missing
-  preregistration-field join; `classification`-only terminal fields;
-  R166/R168 batch-position misreading. All fixed and pushed.
+- Ran `tools/public-closure-scanner.py`; verified 26/12 split, 10/3 gaps
+  against `packages/catalog.json` and the scanner's JSON.
+- Three rounds of PR review (Codex), each finding verified against primary
+  sources before fixing: accept/reject order bug; `/opt/*` and
+  `results/...-r1-attempt` false positives; candidate-status language;
+  missing preregistration join; `classification`-only terminal fields;
+  R166/R168 misreading; a real rule-6 violation. Fixed and pushed.
 - Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes under
-  both lanes' `notes/` committed 09-01 to 09-08.
+  both lanes committed 09-01 to 09-08.
 - Scanned commits/notes for text addressed to an auditor/AI; found none.
-- No GPU work launched or simulated; no recipe, result, prereg, note,
+- No GPU work launched/simulated; no recipe, result, prereg, note,
   DO-NOT-REPEAT.md, CURRENT.md, or AGENTS.md edited; nothing merged.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -4,17 +4,18 @@
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate keeps getting swept past.
-This week's own measuring stick needed three rounds of correction:
+This week's own measuring stick needed four rounds of correction:
 `scripts/efficiency-audit-metrics.py` checked "accepted" before "rejected",
 matched `decision` keys like `*_gate_passed`, and joined by filename prefix
-only, missing composite campaigns. Reclassified, rejected-first, joined via
-`preregistration`: `qwen38-27b-b70` 12 accepted / 79 rejected / 26
-unclassified / 38 no-result-yet of 157. Separately, the lane spent a 30-arm,
-~43h stretch (R166-R208) chasing a "phantom token" R168 confirmed is
-history-dependent, not batch-shape — a class no AGENTS.md rule covers — and
-a depth-5 candidate that passed its gate got swept into two more depths
-before its own ladders finished. All 5 Flash-Next `status: candidate`
-packages this week carry the same repro-package gaps, none publishable.
+only, missing composite campaigns and their latency. Reclassified,
+rejected-first, joined via `preregistration`: `qwen38-27b-b70` 12 accepted /
+79 rejected / 26 unclassified / 38 no-result-yet of 157. Separately, the
+lane spent a 30-arm, ~43h stretch (R166-R208) chasing a "phantom token"
+R168 confirmed is history-dependent, not batch-shape — a class no AGENTS.md
+rule covers — and a depth-5 candidate that passed its gate got swept into
+two more depths before its own ladders finished. All 5 Flash-Next
+`status: candidate` packages this week carry the same repro-package gaps,
+none publishable.
 
 ## Metrics table
 
@@ -24,29 +25,28 @@ packages this week carry the same repro-package gaps, none publishable.
 | Campaigns tracked | 165 (qwen38-27b-b70: 157, flash-next: 8) | `/tmp/eff.json` |
 | qwen38-27b-b70 outcomes (reclassified) | accepted 12, rejected 79, no-result-yet 38, unclassified 26, aborted-infra 2 | `status`/`classification`, joined via `preregistration`; see Checks |
 | flash-next outcomes (reclassified) | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | recomputed |
-| Prereg→result latency | median 0.14h, max 3.28h, n=115 | `/tmp/eff.json` |
+| Prereg→result latency | median 0.14h, max 3.28h, n=122 | recomputed post-join; see Checks |
 | Infra-event files matched | 68; top: `.../int4-optimization-night-r261-r268.md` (8) | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates (10 gaps, 16 clean); 12 informational guides (3 gaps, 9 clean) | `/tmp/closure.md` |
 
 Caveat: the campaign metric only sees lanes with a `*prereg*.json` file under
 `data/`; `qwen35-4b-b70`, `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`,
-`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits this
-week under no such filename, so the table misses them.
+`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` had commits under
+no such filename, so the table misses them.
 
 ## Where the week went
 
 - **Longest**: 30 non-accepted `qwen38-27b-b70` campaigns, `r166` through
   `r208` (09-03 02:52 → 09-04 21:45). R165's ladder found a token that looked
-  like a greedy flip at cache-c032; R166 reran fresh and got identical
-  MTP2/MTP0 output — no flip. R168 narrowed it further: "NOT positional,
-  history-bound," tied to the request right after evidence-c031. Ten more
-  single-hypothesis probes followed anyway (state-slot, zero-pages,
-  layer0-control, layer-trace, enforce-eager, inductor-knobs;
-  `.../mtp2-phantom-*.md`) before async scheduling was implicated.
-  Concurrently, a chained sequence (R195-R197 preregistered together,
-  R198-R203 each "queued behind" the last) published depths 3-4; depth 5
-  also passed but was swept past (rule 6, below).
+  like a greedy flip at cache-c032; R166 reran fresh, identical MTP2/MTP0 —
+  no flip. R168: "NOT positional, history-bound." R169, the next arm, found
+  "PHANTOM GONE with --no-async-scheduling" — async implicated by arm 4.
+  Nine more probes (state-slot, zero-pages, layer0-control, layer-trace,
+  enforce-eager, inductor-knobs; `.../mtp2-phantom-*.md`) localized the
+  mechanism inside that path. Concurrently, a chained sequence (R195-R197
+  preregistered together, R198-R203 "queued behind" each last) published
+  depths 3-4; depth 5 also passed but was swept past (rule 6, below).
 - **Second/third** (26 + 15 arms, `r63-control`→`r103`): tail of the
   R64-R146 GDN bisection, in-window only because the rule set was recorded
   mid-incident; R151-R162's census closed it.
@@ -54,50 +54,49 @@ week under no such filename, so the table misses them.
 ## Rule compliance
 
 1. Census before bisection: followed (R151-R162 closed MTP0/MTP1). **Not
-   applicable** to the MTP2 phantom (R166-R208) — history-, not
-   shape-dependent per R168; no rule covers it.
-2. Oracle regenerated when kernel changed: followed (`r147-partial.md`).
-3. No speed verdict from one server: no violation matched.
+   applicable** to the MTP2 phantom — history-, not shape-dependent per
+   R168; no rule covers it.
+2. Oracle regenerated when kernel changed: followed.
+3. No speed verdict from one server: none matched.
 4. Whole campaign as one preregistered runner: mixed — R195-R203 chained
    without human round trips; R166-R190 were one server per prereg.
 5. Fast-fail on GPU faults: 68 infra-event files matched; runner
    abort-before-timeout behavior unverified.
 6. Stop at first passing gate: **violated** — depth 5 cleared the 2% bar
    (R200), but the lane swept depths 6-7 first; the resulting fault blocked
-   depth 5's own ladders that boot.
-7. Read-only work delegated while GPUs busy: unverifiable.
+   its own ladders that boot.
+7. Read-only work delegated: unverifiable.
 8. One lane per host: no shared-host infra events; consistent with
-   CURRENT.md's separate-host statement.
+   CURRENT.md.
 
 ## Top three changes
 
-1. **Change**: extend AGENTS.md with a control for non-positional,
-   history-dependent flips — a minimal repro of the triggering state
-   transition before further single-subsystem probes; rule 1 only covers
-   batch-shape/prompt-length/concurrency. **Evidence**: R168 established
-   "NOT positional, history-bound" at arm 3; 10 more probes followed
-   anyway. **Expected saving**: unmeasured but real — ~43h past the point
-   the trigger was already narrowed. **Generalizes**: any future
+1. **Change**: extend AGENTS.md with rule 1's census discipline for state
+   transitions/scheduling, which it doesn't currently cover (only batch
+   shape). **Evidence**: R168-R169 localized this to async scheduling by arm
+   4, then 9 more arms searched the mechanism inside it one hypothesis at a
+   time — directed but still uncensused. **Expected saving**: unmeasured; a
+   mechanism census could shortcut that tail. **Generalizes**: any future
    scheduler/state-bleed bug this shape-focused census can't catch.
 
 2. **Change**: fix the shared `experiments/qwen38-flash-next-fp8-b70/tools/`
-   template once (~30 `/home/steve/...` plus ~28 `/mnt/usb-models/...`
-   hardcoded paths in `supervise-*`/`run-*-client.sh` — the scanner's
-   `/opt/*` and `results/...-r1-attempt` hits are false positives, not the
-   defect), then regenerate. **Evidence**: the scanner finds the same
-   hardcoded-path gaps in all 5 candidate packages, 09-05 to 09-08.
-   **Expected saving**: one fix clears 5 paid-for repeats and every future
-   record. **Generalizes**: shared templates propagate bugs.
+   template (~30 `/home/steve/...` plus ~28 `/mnt/usb-models/...` hardcoded
+   paths in `supervise-*`/`run-*-client.sh` — the scanner's `/opt/*` and
+   `results/...-r1-attempt` hits are false positives, not the defect), then
+   regenerate. **Evidence**: the scanner finds the same gaps in all 5
+   candidate packages, 09-05 to 09-08. **Expected saving**: one fix clears 5
+   paid-for repeats and every future record. **Generalizes**: shared
+   templates propagate bugs.
 
 3. **Change**: fix the metrics script — check "rejected" before "accepted";
-   classify on `status`/`classification`, not `decision` (whose
-   `*_gate_passed` keys leak into matches); join via `preregistration`, not
-   filename prefix; extend the glob to lanes that skip it (`qwen35-4b-b70`,
-   `qwen35-9b-b70`, `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
-   `laguna-s-2.1-xpu-b70`). **Evidence**: see Verdict; 7 campaigns were
-   miscounted before the join fix. **Expected saving**: every audit starts
-   from wrong counts. **Generalizes**: the stick every future audit reads
-   first.
+   classify on `status`/`classification`, not `decision`; join via
+   `preregistration`, not filename prefix (also feeds the latency sample);
+   extend the glob to lanes that skip it (`qwen35-4b-b70`, `qwen35-9b-b70`,
+   `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
+   `laguna-s-2.1-xpu-b70`). **Evidence**: see Verdict; 7 campaigns and 7
+   latency points were missed before the join fix. **Expected saving**:
+   every audit starts from wrong counts. **Generalizes**: the stick every
+   future audit reads first.
 
 ## Checks performed
 
@@ -107,11 +106,12 @@ week under no such filename, so the table misses them.
   full 1185-commit history before writing this report.
 - Ran `tools/public-closure-scanner.py`; verified 26/12 split, 10/3 gaps
   against `packages/catalog.json` and the scanner's JSON.
-- Three rounds of PR review (Codex), each finding verified against primary
+- Four rounds of PR review (Codex), each finding verified against primary
   sources before fixing: accept/reject order bug; `/opt/*` and
   `results/...-r1-attempt` false positives; candidate-status language;
-  missing preregistration join; `classification`-only terminal fields;
-  R166/R168 misreading; a real rule-6 violation. Fixed and pushed.
+  missing preregistration join (stale latency n too); `classification`-only
+  terminal fields; R166/R168/R169 chronology; a real rule-6 violation.
+  Fixed and pushed.
 - Read AGENTS.md rules, `DO-NOT-REPEAT.md`, `CURRENT.md`, and notes under
   both lanes committed 09-01 to 09-08.
 - Scanned commits/notes for text addressed to an auditor/AI; found none.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and the classifier still can't draw exact boundaries after
-twenty-five correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+twenty-six correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token", history-dependent not
 batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; fifteen single-server results
+its gate got swept into two more depths; seventeen single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable. This audit missed
 `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -28,19 +28,19 @@ were reported as speed verdicts (rule 3). None of 10 gapped
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra time lost | ≥137 min (R277 45 + A61 73 + R278 14 + A57 5); 68 file mentions, rest untimed | `/tmp/eff.json` |
+| Infra time lost | ≥752 min (R277 45+A61 73+R278 14+A57 5+A174 111+A204/A207 504); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
-10 gapped: 5 Flash-Next below, 5 more — 3 qwen35 (shared
+10 gapped: 5 Flash-Next, 5 more — 3 qwen35 (shared
 gaps: int4 README, `qwen35-9b-b70`'s scripts, + 2 broken Qwen3.6-guide
 refs — `staged-package`, `data/quality.json`, neither exists); `qwen38-27b-autoround-int4-b70` (missing_path and
 unreachable-builder both unreliable: 4/7 and 2/4 confirmed artifacts,
 ≤3 and ≤2 real); `qwen38-27b-fp8-vllm-tp2-asrock-b70` (33
 missing_release_asset, 4 host_path_hardcoded).
 
-Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
-file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
+Caveats: (1) the metric only sees `*prereg*.json`-linked campaigns;
+R261/R265b/R273/R277 and others within qwen38-27b-b70 are
 notes-only, undercounting 157; `qwen35-4b-b70`/`qwen35-9b-b70`
 (CURRENT.md:35's active lane; published, one-card lossless; gated on
 clean-host replay (`clean_host_tested: false`, all 3 manifests;
@@ -49,15 +49,18 @@ two-card divergence separate, narrower),
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
 through — treat counts as directional. (3)
-per-accepted document cost (this week only): 153 preregs + 49 notes / 6
+per-accepted document cost (week-only): 153 preregs + 49 notes / 6
 accepted ≈ 34 each (all-time 355+795; caveat 2);
 composite-arm/duplicate-artifact not computed. (4)
 `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
-reproduce these counts.
+reproduce these counts. (5) flash-next `accepted 0` is
+JSON-prereg-only; its day-summary note records ≥2 certified/published
+results it misses (A270 MTP0, A272 MTP1) — narrative-log ingestion is
+change #3's.
 
 Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2; #1
-and #2 both stem from R64-R146, split by R119's 09:15 promotion):
+and #2 both stem from R64-R146, split by R119's 09:15):
 
 1. **~59 arms**, 09-01 11:38→09-02 01:32, `r63-concurrency`→`r118b`.
 2. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16.
@@ -72,23 +75,22 @@ and #2 both stem from R64-R146, split by R119's 09:15 promotion):
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
    servers; the R151-R162 census closed them; **not applicable** to
-   the MTP2 phantom (history-dependent).
+   the phantom (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated on
    the frozen oracle (8/12); R147's regen matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected on
    -1.14% (two R147 servers beat it); R58/R60/R65 rejected on one
    server (R65 despite identity-qualified);
-   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b publish
-   single-server profiles; R203's lone attempt decided turnover.
+   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b/R198/R207
+   publish single-server profiles; R203's lone attempt decided turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
-   separate; R184-186/R190-191/R182 multi-arm; rest singleton.
+   separate; R184-186/R190-191/R182 multi-arm.
 5. Fast-fail on GPU faults: **violated** — R277 faulted, hung to its
-   45-min timeout; 68 files matched.
-6. Stop at first passing gate: **violated** — depth 5 cleared its bar
-   but 6-7 swept first; R186j passed, R186n ran before R187.
+   45-min timeout.
+6. Stop at first passing gate: **violated** — depth 5 cleared its
+   bar but 6-7 swept first; R186j passed, R186n ran before R187.
 7. Read-only work: unverified.
-8. One lane per host: **unverified** — no host field traces the
-   window.
+8. One lane per host: **unverified** — no host field traces it.
 
 ## Top three changes
 
@@ -102,29 +104,29 @@ and #2 both stem from R64-R146, split by R119's 09:15 promotion):
    ~25 container-internal `/opt/...` paths inflating 3); replace the
    README's literal `E=...json` args with real filenames; fix the
    scanner's truncation/`$var`/brace-glob bugs and swallowed `gh
-   release view` failures (MTP1's tarball is published, not missing —
-   `publication-readback.json`: `status: pass`). **Evidence**: path
-   gaps hit all 5; MTP1's build script, int4's
+   release view` failures (MTP1's tarball is published, `status:
+   pass`, not missing). **Evidence**: gaps
+   hit all 5; MTP1's build script, int4's
    `rebuild-w4a16-incremental-r221.sh`, and fixed-k-tp2's preflight
-   provision their tagged image —
-   `image_without_reachable_builder` false on all three checked.
+   provision their tagged image — `image_without_reachable_builder`
+   false on all three.
    **Expected saving**: clears the real gaps. **Generalizes**: don't
    trust scanner counts without verifying, like the classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum; join via `preregistration`; ingest
    result/note-only records via a required artifact; log GPU time
-   lost per infra fault. **Evidence**: twenty-five rounds found new
-   keyword-matching defects. **Expected saving**: every future audit
+   lost per infra fault. **Evidence**: twenty-six rounds found new
+   defects. **Expected saving**: every future audit
    starts from a count, not an estimate. **Generalizes**: the stick
    every audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7`, after
-  `git fetch --unshallow origin main` (the clone was shallow); ran
+  `git fetch --unshallow origin main` (shallow clone); ran
   `tools/public-closure-scanner.py`.
-- Twenty-five review rounds (Codex), verified and reflected above —
+- Twenty-six review rounds (Codex), verified and reflected above —
   why this file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`; scanned for auditor-directed
   text — none.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -4,20 +4,20 @@
 
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
-and this week's keyword classifier can't draw exact boundaries
-even after twenty-four correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+and the classifier still can't draw exact boundaries after
+twenty-five correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
-non-accepted stretches (59/~28 arms, #2 miscounted — Checks) reduce to
-two real incidents:
+non-accepted stretches (59/28/19 arms — Checks) reduce to two
+incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
-census, and a separate R166-on "phantom token" that's history-dependent,
-not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; fourteen single-server results
+census, and a separate R166-on "phantom token", history-dependent not
+batch-shape; no rule covers it. A depth-5 candidate that passed
+its gate got swept into two more depths; fifteen single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
-`status: candidate` packages is publishable (metrics table). This audit
-missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
+`status: candidate` packages is publishable. This audit missed
+`qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 
 ## Metrics table
 
@@ -28,45 +28,45 @@ missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra time lost | ≥132 min (R277 45 + A61 73 + R278 14); 68 file mentions, rest untimed | `/tmp/eff.json` |
+| Infra time lost | ≥137 min (R277 45 + A61 73 + R278 14 + A57 5); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
-10 gapped candidates: 5 Flash-Next (below), 5 more — 3 qwen35 (shared
-gaps: int4 README, `qwen35-9b-b70`'s scripts, + 2 genuinely broken
-refs each from an old Qwen3.6 guide — `staged-package`,
-`data/quality.json`, neither exists); `qwen38-27b-autoround-int4-b70`
-(missing_path unreliable: 4/7 confirmed brace/glob artifacts, ≤3 real,
-unchecked further; + 4 unreachable-builder);
-`qwen38-27b-fp8-vllm-tp2-asrock-b70` (33 missing_release_asset, 4
-host_path_hardcoded).
+10 gapped: 5 Flash-Next below, 5 more — 3 qwen35 (shared
+gaps: int4 README, `qwen35-9b-b70`'s scripts, + 2 broken Qwen3.6-guide
+refs — `staged-package`, `data/quality.json`, neither exists); `qwen38-27b-autoround-int4-b70` (missing_path and
+unreachable-builder both unreliable: 4/7 and 2/4 confirmed artifacts,
+≤3 and ≤2 real); `qwen38-27b-fp8-vllm-tp2-asrock-b70` (33
+missing_release_asset, 4 host_path_hardcoded).
 
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
 notes-only, undercounting 157; `qwen35-4b-b70`/`qwen35-9b-b70`
 (CURRENT.md:35's active lane; published, one-card lossless; gated on
-clean-host replay (`clean_host_tested: false`, all 3 manifests); the
-two-card divergence is separate, narrower),
+clean-host replay (`clean_host_tested: false`, all 3 manifests;
+two-card divergence separate, narrower),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after twenty-four rounds — treat counts as directional. (3)
+through — treat counts as directional. (3)
 per-accepted document cost (this week only): 153 preregs + 49 notes / 6
-accepted ≈ 34 each (355+795 all-time; directional, caveat 2);
+accepted ≈ 34 each (all-time 355+795; caveat 2);
 composite-arm/duplicate-artifact not computed. (4)
 `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
 reproduce these counts.
 
 Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2; #1
-and #3 both stem from R64-R146, split by R119's 09:15 promotion, not
-distinct):
+and #2 both stem from R64-R146, split by R119's 09:15 promotion):
 
 1. **~59 arms**, 09-01 11:38→09-02 01:32, `r63-concurrency`→`r118b`.
-2. **Miscounted**: R187 (09-03 20:02-20:42) passed every gate inside
-   this window, so `r166`→`r208` isn't one 30-arm stretch (MTP2 phantom
-   detail: change #1); not recomputed this round.
-3. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16.
+2. **~28 arms**, 09-02 09:21-15:34, `r120`→`r137b`: row-invariant W8A16.
+3. **~19 arms**, 09-03 02:52→19:35, `r166`→`r186` (per-note dates, not
+   commit order): MTP2 phantom bisection, closed when R187's
+   whole-graph compile passed at 20:02. `r188`-`r208` are R187's
+   own confirmation/depth-extension runs (rule 6, change #1), not
+   bisection — old 30-arm `r166`→`r208` was wrong. May not be
+   3rd-longest — 165 campaigns mostly lack per-arm timestamps.
 
 ## Rule compliance
 
@@ -78,14 +78,14 @@ distinct):
 3. No speed verdict from one server: **violated** — R140 rejected on
    -1.14% (two R147 servers beat it); R58/R60/R65 rejected on one
    server (R65 despite identity-qualified);
-   R57/R139/R179/R195/R196/R150/R189/R260b/R265b publish single-server
-   profiles; R203's lone attempt decided the turnover.
+   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b publish
+   single-server profiles; R203's lone attempt decided turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
    separate; R184-186/R190-191/R182 multi-arm; rest singleton.
 5. Fast-fail on GPU faults: **violated** — R277 faulted, hung to its
    45-min timeout; 68 files matched.
 6. Stop at first passing gate: **violated** — depth 5 cleared its bar
-   but the lane swept 6-7 first; R186j passed, R186n ran before R187.
+   but 6-7 swept first; R186j passed, R186n ran before R187.
 7. Read-only work: unverified.
 8. One lane per host: **unverified** — no host field traces the
    window.
@@ -94,36 +94,37 @@ distinct):
 
 1. **Change**: extend rule 1's census to state/scheduling transitions,
    not just batch shape. **Evidence**: R168-169 found async-off avoids
-   (AGENTS.md's wording) the MTP2 phantom by arm 4; 9 more probes
-   followed. **Expected saving**: unmeasured; a census could shortcut
-   it. **Generalizes**: any scheduler/state-bleed bug a shape-only
-   census can't catch.
+   (AGENTS.md's wording) the MTP2 phantom by arm 4. **Expected
+   saving**: unmeasured; a census could shortcut it. **Generalizes**:
+   any scheduler/state-bleed bug a shape-only census can't catch.
 
 2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not
-   ~25 container-internal `/opt/...` paths inflating 3 of them);
-   replace the README's literal `E=...json` args with real filenames;
-   fix the scanner's truncation/`$var`/brace-glob bugs. **Evidence**:
-   path gaps hit all 5; MTP1's `build-image.sh` already builds the
-   tagged image via `${IMAGE_TAG:-...}` —
-   `image_without_reachable_builder` is also a false positive.
-   **Expected saving**: these clear the real gaps; MTP1's runtime
-   tarball is still missing. **Generalizes**: don't trust scanner
-   counts without verifying, like the metrics classifier.
+   ~25 container-internal `/opt/...` paths inflating 3); replace the
+   README's literal `E=...json` args with real filenames; fix the
+   scanner's truncation/`$var`/brace-glob bugs and swallowed `gh
+   release view` failures (MTP1's tarball is published, not missing —
+   `publication-readback.json`: `status: pass`). **Evidence**: path
+   gaps hit all 5; MTP1's build script, int4's
+   `rebuild-w4a16-incremental-r221.sh`, and fixed-k-tp2's preflight
+   provision their tagged image —
+   `image_without_reachable_builder` false on all three checked.
+   **Expected saving**: clears the real gaps. **Generalizes**: don't
+   trust scanner counts without verifying, like the classifier.
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum; join via `preregistration`; ingest
-   result/note-only records via a required artifact per campaign; log
-   GPU time lost per infra fault. **Evidence**: twenty-four rounds
-   found new keyword-matching defects. **Expected saving**: every
-   future audit starts from a count, not an estimate. **Generalizes**:
-   the stick every audit reads.
+   result/note-only records via a required artifact; log GPU time
+   lost per infra fault. **Evidence**: twenty-five rounds found new
+   keyword-matching defects. **Expected saving**: every future audit
+   starts from a count, not an estimate. **Generalizes**: the stick
+   every audit reads.
 
 ## Checks performed
 
-- `scripts/efficiency-audit-metrics.py --days 7` hit a shallow clone;
-  `git fetch --unshallow origin main` then re-ran it.
-- Ran `tools/public-closure-scanner.py`.
-- Twenty-four review rounds (Codex), verified and reflected above —
+- `scripts/efficiency-audit-metrics.py --days 7`, after
+  `git fetch --unshallow origin main` (the clone was shallow); ran
+  `tools/public-closure-scanner.py`.
+- Twenty-five review rounds (Codex), verified and reflected above —
   why this file reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`; scanned for auditor-directed
   text — none.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a candidate gets swept past —
 and the classifier still can't draw exact boundaries after
-twenty-six correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+twenty-eight correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by R151-R162,
 and a separate R166-on "phantom token", history-dependent not
 batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; eighteen single-server results
+its gate got swept into two more depths; nineteen single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable. This audit missed
 `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -28,7 +28,7 @@ were reported as speed verdicts (rule 3). None of 10 gapped
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra time lost | ≥784 min (R277 45+A61 73+R278 14+A57 5+A174 111+A204/A207 504+R147 32); 68 file mentions, rest untimed | `/tmp/eff.json` |
+| Infra time lost | ≥789 min (R277 45+A61 73+R278 14+A57 5+A174 111+A204/A207 504+R147 32+A243 5); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
@@ -80,7 +80,7 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
 3. No speed verdict from one server: **violated** — R140 rejected at
    -1.14% (two R147 beat it); R58/R60/R65 rejected on one server (R65
    despite identity);
-   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b/R198/R207/A165
+   R57/R139/R179/R195/R196/R150/R189/R260b/R265b/R275b/R198/R207/A165/A282
    publish single-server profiles; R203's lone attempt decided turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
    separate, R184-186/R190-191/R182 multi-arm.
@@ -115,7 +115,7 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum; join via `preregistration`; ingest
    result/note-only records via a required artifact; log GPU time
-   lost per infra fault. **Evidence**: twenty-six rounds found new
+   lost per infra fault. **Evidence**: twenty-eight rounds found new
    defects. **Expected saving**: every future audit starts from a
    count, not an estimate. **Generalizes**: every future audit
    inherits it.
@@ -125,7 +125,7 @@ Three longest non-accepted `qwen38-27b-b70` stretches (caveat 2;
 - `scripts/efficiency-audit-metrics.py --days 7`, after
   `git fetch --unshallow origin main` (shallow clone); ran
   `tools/public-closure-scanner.py`.
-- Twenty-six review rounds (Codex), verified and reflected above —
+- Twenty-eight review rounds (Codex), verified and reflected above —
   why this file reports directional estimates, not a patched regex.
   Word count now via Python `split()` — `wc -w` undercounted
   dashes/arrows under this sandbox's locale.

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after twenty correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after twenty-one correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; ten single-server results
+its gate got swept into two more depths; twelve single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable (metrics table). This audit
 missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -40,15 +40,16 @@ unexamined.
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
 notes-only, undercounting 157; `qwen35-4b-b70`/`qwen35-9b-b70`
-(CURRENT.md:35's active lane; published, one-card lossless, gated on
-an unexplained two-card divergence — `docs/model-effort-index.md`),
+(CURRENT.md:35's active lane; published, one-card lossless; gated on
+clean-host replay (`clean_host_tested: false`, all 3 manifests); the
+two-card divergence is separate, narrower),
 `gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
 `laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after twenty rounds — treat counts as directional. (3)
+through after twenty-one rounds — treat counts as directional. (3)
 per-accepted document cost: 355 preregs + 795 notes / 6 accepted ≈ 192
-each (directional, caveat 2); composite-arm and duplicate-artifact
-counts not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
+each (directional, caveat 2); composite-arm/duplicate-artifact counts
+not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
 reproduce these counts.
 
@@ -65,24 +66,24 @@ distinct):
 ## Rule compliance
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
-   servers; the R151-R162 census closed them in 20 minutes; **not
+   servers; R151-R162's census closed them in 20 minutes; **not
    applicable** to the MTP2 phantom (history-dependent).
 2. Oracle regenerated per kernel change: **violated** — R140 gated
    against the frozen oracle (8/12); R147's regenerated oracle matched
    12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
-   candidate on -1.14% (two R147 servers beat it); R58/R60 declined a
-   second server on a near-miss; R195/R196/R150/R189/R260b/R265b
-   publish single-server profiles; R203's lone depth-7 attempt decided
-   the depth-6-vs-7 turnover.
+   candidate on -1.14% (two R147 servers beat it); R58/R60/R65 rejected
+   on one server (R65 despite identity-qualified);
+   R57/R195/R196/R150/R189/R260b/R265b publish single-server profiles;
+   R203's lone depth-7 attempt decided the depth-6-vs-7 turnover.
 4. Whole campaign as one runner: mixed — R195-197/R200/R202-203
-   separate preregs; R184-186/R190-191/R182 batch multi-arm; R166-183
-   less R182 singleton.
-5. Fast-fail on GPU faults: **violated** — R277 faulted at 04:47 but
-   hung to the 45-min timeout; 68 files matched.
+   separate preregs; R184-186/R190-191/R182 multi-arm; R166-183 less
+   R182 singleton.
+5. Fast-fail on GPU faults: **violated** — R277 faulted at 04:47, hung
+   to the 45-min timeout; 68 files matched.
 6. Stop at first passing gate: **violated** — depth 5 cleared its bar
    but the lane swept 6-7 first (fault blocked those ladders); R186j
-   passed; R186n ran before R187's endpoint.
+   passed, R186n ran before R187's endpoint.
 7. Read-only work: unverified.
 8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
    no host field traces the window.
@@ -99,7 +100,7 @@ distinct):
 
 2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not the
    ~25 container-internal `/opt/...` Dockerfile/entrypoint paths
-   inflating HCTriton/lossless/placement's 80+ counts); replace the
+   inflating HCTriton/lossless/placement's counts); replace the
    README's literal `E=...json` args with real filenames; fix the
    scanner's truncation/`$var`-template bugs; publish MTP1's missing
    runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
@@ -111,9 +112,9 @@ distinct):
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum; join via `preregistration`; ingest
-   result-only and note-only records (R261/R273/R277) by requiring a
+   result-only/note-only records (R261/R273/R277) via a required
    structured artifact per campaign; log GPU time lost per infra
-   fault. **Evidence**: twenty rounds found new keyword-matching
+   fault. **Evidence**: twenty-one rounds found new keyword-matching
    defects. **Expected saving**: every future audit starts from a
    count, not an estimate. **Generalizes**: the stick every audit
    reads.
@@ -123,7 +124,7 @@ distinct):
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
   clone; `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Twenty review rounds (Codex), verified and reflected above:
+- Twenty-one review rounds (Codex), verified and reflected above:
   classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings — why this file
   reports directional estimates, not a patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`; scanned for

--- a/audits/efficiency/2026-09-08.md
+++ b/audits/efficiency/2026-09-08.md
@@ -5,7 +5,7 @@
 The lab is faster where AGENTS.md's rules are followed, no faster where a
 failure falls outside them or a passing candidate gets swept past —
 and this week's keyword classifier can't draw exact boundaries
-even after eighteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
+even after nineteen correction rounds (Checks). `qwen38-27b-b70`: roughly 6
 accepted / 79 rejected / 2 aborted-infra / 38 no-result-yet / 32
 unclassified of 157 (accepted itself uncertain — R165 says "NOT
 PROMOTABLE" despite matching a "pass" keyword). Its three longest
@@ -14,7 +14,7 @@ two real incidents:
 AGENTS.md's own R64-R146 GDN/kernel bisection, closed by the R151-R162
 census, and a separate R166-on "phantom token" that's history-dependent,
 not batch-shape; no rule covers it. A depth-5 candidate that passed
-its gate got swept into two more depths; seven single-server results
+its gate got swept into two more depths; nine single-server results
 were reported as speed verdicts (rule 3). None of 10 gapped
 `status: candidate` packages is publishable (metrics table). This audit
 missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
@@ -28,7 +28,7 @@ missed `qwen35-4b-b70`/`qwen35-9b-b70`, CURRENT.md's active lane.
 | qwen38-27b-b70 outcomes (~) | accepted 6, rejected 79, no-result-yet 38, unclassified 32, aborted-infra 2 | see Checks |
 | flash-next outcomes | accepted 0, rejected 2, no-result-yet 5, unclassified 1 | see Checks |
 | Prereg→result latency | median 0.14h, max 3.28h, n=122 | see Checks |
-| Infra-event file mentions (not time-lost) | 68; top `.../r261-r268.md` (8) | `/tmp/eff.json` |
+| Infra time lost | ≥45 min (R277); 68 file mentions, rest untimed | `/tmp/eff.json` |
 | Longest commit gaps | 10.7h, 6.8h, 6.0h, 4.4h, 4.3h | `/tmp/eff.json` |
 | Closure scan | 26 candidates, 10 gaps; 12 informational, 3 gaps | `/tmp/closure.md` |
 
@@ -40,10 +40,12 @@ unexamined.
 Caveats: (1) the metric only sees campaigns with a `*prereg*.json`
 file; R261/R265b/R273/R277 and others within qwen38-27b-b70 are
 notes-only, undercounting 157; `qwen35-4b-b70`/`qwen35-9b-b70`
-(CURRENT.md:35's active lane), `gemma4-26b-a4b-q8-b70`,
-`minimax-m27-reap-autoround-vllm`, `laguna-s-2.1-xpu-b70` lack any.
+(CURRENT.md:35's active lane; published, one-card lossless, gated on
+an unexplained two-card divergence — `docs/model-effort-index.md`),
+`gemma4-26b-a4b-q8-b70`, `minimax-m27-reap-autoround-vllm`,
+`laguna-s-2.1-xpu-b70` lack any.
 (2) outcomes are keyword matches, not structured; some still slip
-through after eighteen rounds — treat counts as directional. (3)
+through after nineteen rounds — treat counts as directional. (3)
 per-accepted token-cost and composite-arm expansion (protocol
 requirements) were not computed. (4) `/tmp/eff.json`/`/tmp/eff.md`
 aren't committed (one-file limit); rerunning after 2026-09-08 won't
@@ -62,23 +64,23 @@ distinct):
 ## Rule compliance
 
 1. Census before bisection: **violated** — R64-R116 ran fifty-odd
-   servers before the R151-R162 census closed them in 20 minutes; **not
+   servers; the R151-R162 census closed them in 20 minutes; **not
    applicable** to the MTP2 phantom (history-dependent).
-2. Oracle regenerated per kernel change: **violated** — R140 gated the
-   row-invariant kernel against the frozen oracle (8/12); R147's
-   regenerated same-image oracle matched 12/12.
+2. Oracle regenerated per kernel change: **violated** — R140 gated
+   against the frozen oracle (8/12); R147's regenerated same-image
+   oracle matched 12/12.
 3. No speed verdict from one server: **violated** — R140 rejected a
-   candidate on one server's -1.14% (two R147 servers beat it);
-   R60 declined a second server; R195/R196/R150/R189/R260b/R265b
-   publish single-server profiles; R203's lone depth-7 attempt decided
-   the depth-6-vs-7 turnover.
+   candidate on -1.14% (two R147 servers beat it); R60 declined a
+   second server; R195/R196/R150/R189/R260b/R265b publish
+   single-server profiles; R203's lone depth-7 attempt decided the
+   depth-6-vs-7 turnover.
 4. Whole campaign as one preregistered runner: mixed — R195-197/R200/
-   R202-203 are three separate preregs; R184-186/R190-191/R182 batch
-   multi-arm; R166-183 less R182 singleton.
-5. Fast-fail on GPU faults: **violated** — R277 faulted and coredumped
-   at 04:47 but hung to the 45-min timeout; 68 files matched.
-6. Stop at first passing gate: **violated** — depth 5 cleared its 2% bar
-   but the lane swept depths 6-7 first (fault blocked its ladders);
+   R202-203 separate preregs; R184-186/R190-191/R182 batch multi-arm;
+   R166-183 less R182 singleton.
+5. Fast-fail on GPU faults: **violated** — R277 faulted at 04:47 but
+   hung to the 45-min timeout; 68 files matched.
+6. Stop at first passing gate: **violated** — depth 5 cleared its 2%
+   bar but the lane swept 6-7 first (fault blocked those ladders);
    R186j passed; R186n ran before R187's endpoint.
 7. Read-only work delegated: unverified.
 8. One lane per host: **unverified** — CURRENT.md:25/35 is a snapshot;
@@ -98,9 +100,9 @@ distinct):
    ~25 container-internal `/opt/...` Dockerfile/entrypoint paths
    inflating HCTriton/lossless/placement's 80+ counts); replace the
    README's literal `E=...json` args with real filenames; fix the
-   scanner's `=`/`,`-truncation and `$var`-template parsing bugs;
-   publish MTP1's missing runtime tarball. **Evidence**: path gaps hit
-   all 5; MTP1's `build-image.sh` already builds the tagged image via
+   scanner's truncation/`$var`-template parsing bugs; publish MTP1's
+   missing runtime tarball. **Evidence**: path gaps hit all 5; MTP1's
+   `build-image.sh` already builds the tagged image via
    `${IMAGE_TAG:-...}` — `image_without_reachable_builder` is also a
    false positive. **Expected saving**: these fixes clear the real
    gaps; only the tarball is missing. **Generalizes**: don't trust this
@@ -108,21 +110,22 @@ distinct):
 
 3. **Change**: replace the metrics script's keyword match with a
    structured `outcome` enum, not another regex patch; join via
-   `preregistration`; ingest result-only records for the caveat's
-   lanes; log GPU time lost per infra fault. **Evidence**: eighteen
-   rounds found new keyword-matching defects.
-   **Expected saving**: every future audit starts from a count, not an
-   estimate. **Generalizes**: the stick every audit reads.
+   `preregistration`; ingest result-only and note-only records
+   (R261/R273/R277) by requiring a structured artifact per campaign;
+   log GPU time lost per infra fault. **Evidence**: nineteen rounds
+   found new keyword-matching defects. **Expected saving**: every
+   future audit starts from a count, not an estimate. **Generalizes**:
+   the stick every audit reads.
 
 ## Checks performed
 
 - `scripts/efficiency-audit-metrics.py --days 7` first hit a shallow
   clone; `git fetch --unshallow origin main` then re-ran it.
 - Ran `tools/public-closure-scanner.py` on `packages/catalog.json`.
-- Eighteen review rounds (Codex), verified and reflected above:
-  classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings; R101/R104/R165
-  matching accept keywords despite being diagnostic/non-promotable —
-  why this file reports directional estimates, not a patched regex.
+- Nineteen review rounds (Codex), verified and reflected above:
+  classifier/scanner bugs; rule-1/2/3/4/5/6/8 findings; accept-keyword
+  false matches — why this file reports directional estimates, not a
+  patched regex.
 - Read AGENTS.md, `DO-NOT-REPEAT.md`, `CURRENT.md`, notes; scanned for
   auditor-directed text — none.
 - No GPU work run/simulated; no recipe, result, prereg, note, DO-NOT-REPEAT.md,


### PR DESCRIPTION
## Verdict

The lab is faster where AGENTS.md's rules are followed, no faster where a
failure falls outside them or a candidate gets swept past — and the
classifier still can't draw exact boundaries after twenty-eight
correction rounds (Checks). `qwen38-27b-b70`: roughly 6 accepted / 79
rejected / 2 aborted-infra / 38 no-result-yet / 32 unclassified of 157
(accepted itself uncertain — R165 says "NOT PROMOTABLE" despite
matching a "pass" keyword). Its three longest non-accepted stretches
(59/28/19 arms — Checks) reduce to two incidents: AGENTS.md's own
R64-R146 GDN/kernel bisection, closed by R151-R162, and a separate
R166-on "phantom token", history-dependent not batch-shape; no rule
covers it. A depth-5 candidate that passed its gate got swept into two
more depths; nineteen single-server results were reported as speed
verdicts (rule 3). None of 10 gapped `status: candidate` packages is
publishable. This audit missed `qwen35-4b-b70`/`qwen35-9b-b70`,
CURRENT.md's active lane.

## Top three changes

1. **Change**: extend rule 1's census to state/scheduling transitions,
   not just batch shape. **Evidence**: R168-169 found async-off avoids
   (AGENTS.md's wording) the phantom by arm 4. **Expected saving**:
   unmeasured; a census could shortcut it. **Generalizes**: any
   scheduler/state-bleed bug a shape-only census can't catch.

2. **Change**: fix ALL 5 candidates' real hardcoded-host paths (not
   ~25 container-internal `/opt/...` paths inflating 3); replace the
   README's literal `E=...json` args with real filenames; fix the
   scanner's truncation/`$var`/brace-glob bugs and swallowed `gh
   release view` failures (MTP1's tarball is published, `status:
   pass`, not missing). **Evidence**: gaps hit all 5; MTP1's build
   script, int4's `rebuild-w4a16-incremental-r221.sh`, + fixed-k-tp2's
   preflight provision it — `image_without_reachable_builder` false
   on all three. **Expected saving**: clears the real gaps.
   **Generalizes**: don't trust scanner counts without verifying,
   like the classifier.

3. **Change**: replace the metrics script's keyword match with a
   structured `outcome` enum; join via `preregistration`; ingest
   result/note-only records via a required artifact; log GPU time
   lost per infra fault. **Evidence**: twenty-eight rounds found new
   defects. **Expected saving**: every future audit starts from a
   count, not an estimate. **Generalizes**: every future audit
   inherits it.

## Review

Twenty-eight Codex review rounds, 91 findings total, every one
verified against a primary source before fixing. This round (3
findings, commit `03ed1690e`): A282 added to rule 3's single-server
verdicts (its 16-warp map is "closed on the server measurement alone"
per the note; count 18→19); A243's host reset #9 (19:51:42 boot end to
19:57 return, ~5 min) added to infra time lost, now ≥789 min (was
≥784). The third finding — restore a separate "Where the week went"
heading per AUDIT-PROTOCOL.md — I'm declining: the task that spawned
this specific audit run explicitly directed folding that content into
Metrics table without its own heading, an out-of-band instruction not
visible in any committed file, so the report can't cite it, but it's
why that structure is deliberate rather than a defect. That thread
stays open rather than resolved, since I don't have the authority to
treat my own task briefing as superseded by the protocol document it
was written against. Full detail on all 91 findings is in the
review-thread history.

Remaining acknowledged gaps: composite-arm expansion and
duplicate-artifact counts; qwen35's dedicated audit follow-up; whether
recomputed stretch #3 is truly the 3rd-longest; full ingestion of
flash-next's 68 note-based preregistrations (change #3); the
"Where the week went" heading question above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjhPayuu6K7MWuiRfoNqtR