### PR TITLE
community: Qwen3.8-27B FP8 vLLM XPU shape-aliased-prefill GDN state loss (upstream vllm #53051 / PR #53059 adoption)

### DIFF
--- a/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/README.md
+++ b/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/README.md
@@ -1,0 +1,83 @@
+# Qwen3.8-27B FP8 vLLM XPU (R50 lineage): shape-aliased prefill silently skips GDN state writes → degenerate output walls
+
+> **Read [STATUS.md](STATUS.md) first.** This is a `community-reported`
+> contribution: an incident analysis and patch adoption from a production
+> two-B70 host. It is not a lab result and not a promoted recipe.
+
+## What this is
+
+A root-cause match for a degradation the R50/R187 vLLM XPU lane family is
+vulnerable to: after hours of real multi-session uptime, the server emits
+degenerate single-token walls (`!!!!!`, `00000…`, `oooooo…`, `||||…`) while
+health, throughput, and short probes stay clean. Restart cures it; it returns.
+
+**Mechanism (upstream [issue #53051](https://github.com/vllm-project/vllm/issues/53051)):**
+`GPUModelRunner._is_uniform_decode` classifies a batch as uniform decode by
+shape only. With speculative decoding, `uniform_decode_query_len = 1 +
+num_spec_tokens`. Any prefill step that schedules exactly that many tokens per
+request (tiny prompts, chunked-prefill chunk tails, prefix-cache hit tails,
+mixed batches) aliases the uniform-decode shape. The step then dispatches into
+the decode/cudagraph path with capture-time metadata whose GDN
+recurrent-state indices are null/stale, so the kernels' null guards silently
+skip the recurrent-state writes. Zeroed state → degenerate logits walls. The
+victim varies with allocator layout (some runs poison a persistent tensor, e.g.
+`conv1d.weight`, which then stays corrupt while fresh short probes look clean)
+— which explains both the long dwell and why restarts cure it.
+
+**Fix (upstream [PR #53059](https://github.com/vllm-project/vllm/pull/53059), open):**
+after the shape test passes, additionally require every request to be past its
+prompt before calling the batch a uniform decode:
+
+```python
+input_batch = self.input_batch
+return bool(
+    (
+        input_batch.num_computed_tokens_cpu[:num_reqs]
+        >= input_batch.num_prompt_tokens[:num_reqs]
+    ).all()
+)
+```
+
+Full diff: [`reported/vllm-gpu-model-runner-uniform-decode-alias.patch`](reported/vllm-gpu-model-runner-uniform-decode-alias.patch)
+(47 lines; also carries a companion microbatch veto guard, see STATUS Known
+Issues — that part is contributor-added, not upstream).
+
+Regression test: [`reported/test_is_uniform_decode_red_green.py`](reported/test_is_uniform_decode_red_green.py)
+extracts the classifier from both files and runs 14 cases — the 5 aliased
+shapes must fail on stock (RED) and pass on patched (GREEN). Contributor run:
+both PASS.
+
+## Why this lane should care
+
+- The lab's [2026-08-22 chunked-prefill corruption finding](../../experiments/qwen38-27b-b70/notes/2026-08-22-qwen38-longkv2-closure-and-chunk-corruption-finding.md)
+  (`B70_QWEN3!!!!…` after a multi-chunk prefill dose, mitigated by
+  `VLLM_XPU_GDN_SPEC_PERSISTENT_SCRATCH=0`) shows the same end signature and
+  the same GDN-state-write theme from a different trigger. Whether the aliased
+  prefill and the chunk dose are the same mechanism is an open question — see
+  STATUS.
+- The R187 whole-graph compile (`splitting_ops=[]`) may avoid this trigger
+  the same way it avoids the depth-2 phantom (it avoids, does not fix,
+  upstream). A 2-token prompt under the strict harness on both compile modes
+  would settle it.
+- Deployment detail that cost real debugging time: in the R50-lineage image
+  the live module is the **editable install** at
+  `/workspace/vllm/vllm/v1/worker/gpu_model_runner.py`; the `/opt/venv`
+  site-packages copies are shadowed. Patching site-packages does nothing.
+  A bind-mount over the editable path (read-only) + launcher grep assert
+  survives container recreation; keep the stock copy for rollback.
+
+## Incident evidence (contributor host, summarized in STATUS)
+
+- 2026-09-07→09-08: degenerate walls after 6–24 h dwell under real 3–4
+  concurrent-session agent traffic; incident-window screenshots ~00:48–01:02
+  EDT 2026-09-08 show a ~40-line single-character wall and a full-panel zero
+  wall in one session.
+- Post-fix: clean startup/health/alias, exact arithmetic and counting smokes,
+  streaming `!!!!!` detector zero events through soak start. Soak in progress;
+  controlled on-demand reproduction NOT RUN.
+
+## Status
+
+`community-reported` — incident analysis + upstream-fix adoption with a
+RED/GREEN classifier test. No rates are claimed. See STATUS.md for the
+boundary questions that would raise the evidence level.

--- a/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/STATUS.md
+++ b/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/STATUS.md
@@ -1,0 +1,133 @@
+# STATUS — Qwen3.8-27B FP8 vLLM XPU: shape-aliased prefill misdispatch into the spec-decode uniform-decode path (silent GDN state loss → degenerate output)
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `community-reported`; the upstream defect and PR are open items on the upstream tracker, not lab-confirmed |
+| Patch review status | read and executed on the contributor's host; not executed in the reference lab |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no until `B70-tested` |
+
+## Provenance
+
+- Contributor: [`dominick253`](https://github.com/dominick253)
+- Source: this PR
+- Upstream defect: [vllm-project/vllm issue #53051](https://github.com/vllm-project/vllm/issues/53051) ("Prefill misdispatched into spec-decode FULL cudagraph when prompt length == 1 + num_speculative_tokens → silent GDN state loss, garbage output (hybrid/Qwen3-Next models)")
+- Upstream fix (adopted here): [vllm-project/vllm PR #53059](https://github.com/vllm-project/vllm/pull/53059) — "[Bugfix] Reject shape-aliased prefills in uniform-decode classification" by `allenzz-dev` (open, unmerged at capture time)
+- Right-to-submit statement: present in the PR description
+- Third-party material and attribution: vLLM (Apache-2.0, upstream issue/PR credited above); Intel `neural-download/vllm-openai-xpu` image lineage built by this lab's own `repro/qwen38-27b-fp8-vllm-tp2-asrock-b70/` chain; `Qwen/Qwen3.8-27B-FP8` official block-FP8 checkpoint
+
+## Contributor Claim
+
+On a two-B70 production host serving the lab's R50-lineage image
+(`neural-download/vllm-openai-xpu:qwen38-fp8-mtp1-serial-fa-split-gdn-r50`,
+vLLM `0.27.2rc1.dev77+gac7509e2b.xpu`), the service emits degenerate
+single-token repetition walls (`!!!!!`, `00000…`, `oooooo…`, `||||…`) after
+6–24 h of uptime under real multi-session load, while health, throughput, and
+short probes stay clean. Root cause matches upstream issue #53051:
+`GPUModelRunner._is_uniform_decode` classifies a batch as uniform decode by
+shape only; with speculative decoding (`uniform_decode_query_len = 1 +
+num_spec_tokens`), any prefill step scheduling exactly that many tokens per
+request aliases the uniform-decode shape, replays capture-time metadata with
+null/stale GDN state indices, and silently skips recurrent-state writes.
+Applying upstream PR #53059's classifier guard plus a microbatch veto, then
+restarting, cleared the signature on the contributor's host (clean probes and
+soak-start after deployment; longer soak in progress at capture time).
+
+## Relation To This Lab's Records
+
+This looks like the same failure family as the lab's own
+[2026-08-22 chunked-prefill corruption finding](../../experiments/qwen38-27b-b70/notes/2026-08-22-qwen38-longkv2-closure-and-chunk-corruption-finding.md)
+(`B70_QWEN3!!!!…` degeneration after multi-chunk prefill history,
+dose-dependent, mitigated by `VLLM_XPU_GDN_SPEC_PERSISTENT_SCRATCH=0`) and the
+R178–R186 depth-2 phantom-first-token investigation (stale GDN metadata inside
+a compiled piece). They may share the "stale/absent GDN recurrent-state write
+under an aliased or split prefill step" mechanism, but that equivalence is a
+hypothesis, not a measured result: different images (R50 vs the lane's
+sealed/split stage), different trigger shapes (prompt-length aliasing vs
+chunked prefill dose), different workloads. The lab's d5 discriminator
+(persistent scratch off) and the upstream classifier fix are two different
+mitigation points that would both silence a shared root cause.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | 2x Intel Arc Pro B70 (Battlemage G31, PCI `8086:e223` at `0000:03:00.0` and `0000:08:00.0`), 32 GiB each |
+| OS / kernel | Ubuntu 26.04; `7.0.0-30-generic` |
+| GPU driver | `xe` `srcversion 85B7CA089405934276CBAD3` |
+| Engine / image | `neural-download/vllm-openai-xpu:qwen38-fp8-mtp1-serial-fa-split-gdn-r50`, image digest `sha256:dcdbfca2b7904b67dde6625d0b49733f6b76adce2199c2bd948dafca75f211a1`; vLLM `0.27.2rc1.dev77+gac7509e2b.xpu` |
+| Docker | 29.1.3, `--privileged --network host`, `ZE_AFFINITY_MASK=0,1`, `ONEAPI_DEVICE_SELECTOR=level_zero:0,1` |
+| Model repo and revision | `Qwen/Qwen3.8-27B-FP8` (official block-FP8: 66 shards, 1606 tensors, 407 `weight_scale_inv`, 882 `modules_to_not_convert`, 30.87 GB) |
+| Quantization | native block-FP8 weights (`--quantization fp8`), `--kv-cache-dtype fp8_e4m3`, `--mamba-ssm-cache-dtype bfloat16` |
+| Command and env | served via the contributor's launcher (equivalent to the lab's R50 chain): `--dtype float16 --tensor-parallel-size 2 --max-model-len 200000 --max-num-seqs 4 --max-num-batched-tokens 8192 --block-size 64 --gpu-memory-utilization 0.95 --enable-chunked-prefill --enable-prefix-caching --disable-sliding-window --language-model-only --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 --compilation-config '{"cudagraph_mode":"PIECEWISE","cudagraph_capture_sizes":[1],"max_cudagraph_capture_size":1,"splitting_ops":[], …}' --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":1}'` |
+| Speculation policy at incident time | MTP1 (`num_speculative_tokens=1`), so `uniform_decode_query_len=2` |
+| Prompt / output / concurrency | real multi-session agent traffic (3–4 concurrent sessions, mixed prompt lengths, chunked prefills, prefix-cache hits), 512-token probes for the recorder |
+| Metric | incident signature + post-fix smoke, not a rate: `finish_reason=stop`, exact arithmetic (`17*23=391`), exact 1–30 counting, no degeneration |
+| Logs / evidence | streaming recorder + frozen incident folders (contributor host paths, not redistributed): `~/qwen-bang-logs/run-*`; incident-window screenshots 2026-09-08 ~00:48–01:02 EDT showing `oooo…` walls (~40+ lines) and a full-panel zero wall in a dsh IDE-agent session |
+
+## What Was Actually Run (contributor host)
+
+- Production service on the R50 image with MTP1, live agent traffic, 2026-09-07→09-08: degenerate walls observed after 6–24 h dwell; restart cleared them each time.
+- Post-fix (bind-mounted patched `gpu_model_runner.py` over the image's editable install `/workspace/vllm/vllm/v1/worker/gpu_model_runner.py`): clean startup, health, alias, exact arithmetic/counting smokes; a 400-record context probe and the streaming `!!!!!` detector recorded zero events before the next planned restart. Soak in progress; not complete.
+- NOT RUN here: controlled reproduction of the aliased prefill on demand (the incident needs real mixed traffic dwell); the lab's strict 12-prompt identity suite; vision; depth >1 profiles post-fix.
+
+## The Fix (for review, not promoted)
+
+`reported/vllm-gpu-model-runner-uniform-decode-alias.patch` — 47-line diff,
+`_is_uniform_decode` only:
+
+1. Reject the shape-aliased prefill: after the shape test passes, additionally
+   require every request to be past its prompt
+   (`num_computed_tokens_cpu[:num_reqs] >= num_prompt_tokens[:num_reqs]`).
+   This is upstream PR #53059's guard.
+2. Veto microbatching for any step that splits a prefix from its writer
+   (`_allow_microbatching`), because a request admitted on a prefix-cache hit
+   against blocks another same-batch request is only now computing would read
+   unwritten KV if the step were split. (Contributor-added companion guard,
+   same stale-state family; included in the same diff for review.)
+
+`reported/test_is_uniform_decode_red_green.py` — RED/GREEN test that extracts
+`_is_uniform_decode` from the stock and patched files and runs 14 cases:
+stock must misclassify all 5 aliased shapes (2-token prompt at MTP1,
+3-token at MTP2, chunked last chunk, mixed batch, 1-token no-spec) and
+preserve all genuine decode classifications. Contributor run: RED PASS,
+GREEN PASS.
+
+Deployment shape used by the contributor: the R50 image's live module is the
+editable install at `/workspace/vllm/vllm/v1/worker/gpu_model_runner.py`
+(`/opt/venv` site-packages copies are shadowed); the fix is bind-mounted
+read-only over it by the launcher with a grep assert, so it survives container
+recreation. Keep the stock copy for rollback.
+
+## Known Issues
+
+- The upstream PR is open and unmerged at capture time; this packet records
+  adoption, not an upstream endorsement.
+- The contributor's fix file also carries the microbatch veto (2), which is
+  NOT part of upstream #53059; reviewers should treat (1) as the reported fix
+  and (2) as a separate, unproven-on-this-lab guard.
+- No controlled on-demand reproduction exists here; the claim rests on the
+  incident signature matching upstream #53051 plus post-fix stability, which
+  is consistent-but-not-conclusive evidence.
+
+## Open Questions For The Lab
+
+- Does the aliased-prefill trigger reproduce on the lab's R187 sealed lane
+  (MTP depth ≥ 1, piecewise compile) with a 2-token prompt under the strict
+  harness, or does the whole-graph `splitting_ops=[]` line avoid it the way it
+  avoids the depth-2 phantom?
+- Does `VLLM_XPU_GDN_SPEC_PERSISTENT_SCRATCH=0` (the lab's d5 mitigation)
+  also suppress the alias path, or is the alias handled purely in the
+  scheduler/classifier layer?
+- Is the 2026-08-22 chunk-dose corruption the same mechanism (shared stale GDN
+  state write), or an independent kernel-path defect?
+
+## Disposition
+
+Remains `community-reported` documentation. If the lab reproduces the alias
+trigger on its sealed lane and finds the classifier guard effective, this
+belongs in the R187/R50 chain's README as a known upstream defect with the
+chosen mitigation; until then it is a pointer, not a recipe.

--- a/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/reported/test_is_uniform_decode_red_green.py
+++ b/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/reported/test_is_uniform_decode_red_green.py
@@ -1,0 +1,157 @@
+"""RED/GREEN test for the _is_uniform_decode shape-alias fix (vllm PR #53059).
+
+Self-contained: both classifier bodies are extracted verbatim from the R50
+image's vllm/v1/worker/gpu_model_runner.py (stock, sha256 4e0e1aee778bb1f6...)
+and the patched file (sha256 921f0a6fd3403119...). The aliased-prefill cases
+MUST fail on stock (bug present) and pass on patched (fix works).
+
+Run: python3 test_is_uniform_decode_red_green.py   (stdlib + numpy)
+"""
+import textwrap
+import types
+
+import numpy as np
+
+STOCK = r"""
+    def _is_uniform_decode(
+        max_num_scheduled_tokens: int,
+        uniform_decode_query_len: int,
+        num_tokens: int,
+        num_reqs: int,
+        force_uniform_decode: bool | None = None,
+    ) -> bool:
+        '''
+        Checks if it's a decode batch with same amount scheduled tokens
+        across all requests.
+        '''
+        return (
+            (
+                (max_num_scheduled_tokens == uniform_decode_query_len)
+                and (num_tokens == max_num_scheduled_tokens * num_reqs)
+            )
+            if force_uniform_decode is None
+            else force_uniform_decode
+        )
+"""
+
+PATCHED = r"""
+    def _is_uniform_decode(
+        self,
+        max_num_scheduled_tokens: int,
+        uniform_decode_query_len: int,
+        num_tokens: int,
+        num_reqs: int,
+        force_uniform_decode: bool | None = None,
+    ) -> bool:
+        '''
+        Checks if it's a decode batch with same amount scheduled tokens
+        across all requests.
+        '''
+        if force_uniform_decode is not None:
+            return force_uniform_decode
+        if not (
+            max_num_scheduled_tokens == uniform_decode_query_len
+            and num_tokens == max_num_scheduled_tokens * num_reqs
+        ):
+            return False
+        # The shape check alone can misclassify prefills: with spec decode
+        # (uniform_decode_query_len = 1 + num_spec_tokens), any batch of
+        # prompts scheduled with exactly uniform_decode_query_len tokens per
+        # request aliases the uniform-decode shape. Dispatching such a
+        # prefill into a cudagraph captured for uniform decode replays stale
+        # capture-time metadata for backends with persistent buffers (e.g.
+        # GDN), silently skipping prefill state writes and corrupting output
+        # (https://github.com/vllm-project/vllm/issues/53051). A batch is
+        # only uniform decode if every request is already past its prompt.
+        input_batch = self.input_batch
+        return bool(
+            (
+                input_batch.num_computed_tokens_cpu[:num_reqs]
+                >= input_batch.num_prompt_tokens[:num_reqs]
+            ).all()
+        )
+"""
+
+
+def make_self(computed, prompt):
+    """Minimal stand-in for `self` with the input_batch arrays."""
+    return types.SimpleNamespace(input_batch=types.SimpleNamespace(
+        num_computed_tokens_cpu=np.array(computed),
+        num_prompt_tokens=np.array(prompt),
+    ))
+
+
+def run(fn_src, self_obj, **kw):
+    ns = {}
+    exec("import numpy\n" + textwrap.dedent(fn_src), ns)
+    fn = ns["_is_uniform_decode"]
+    if "self" in fn.__code__.co_varnames:
+        return fn(self_obj, **kw)
+    return fn(**kw)
+
+
+CASES = [
+    # (name, computed, prompt, kwargs, stock_expected, patched_expected)
+    ("genuine decode 16x1", [10] * 16, [8] * 16,
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=16, num_reqs=16),
+     True, True),
+    ("shape mismatch 2x1", [10] * 16, [8] * 16,
+     dict(max_num_scheduled_tokens=2, uniform_decode_query_len=1, num_tokens=16, num_reqs=16),
+     False, False),
+    ("total mismatch", [10] * 16, [8] * 16,
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=8, num_reqs=16),
+     False, False),
+    ("genuine spec decode 5-q", [10] * 7, [8] * 7,
+     dict(max_num_scheduled_tokens=5, uniform_decode_query_len=5, num_tokens=30, num_reqs=6),
+     True, True),
+    ("spec shape mismatch", [10] * 7, [8] * 7,
+     dict(max_num_scheduled_tokens=5, uniform_decode_query_len=4, num_tokens=30, num_reqs=6),
+     False, False),
+    ("spec total mismatch", [10] * 7, [8] * 7,
+     dict(max_num_scheduled_tokens=5, uniform_decode_query_len=5, num_tokens=36, num_reqs=6),
+     False, False),
+    # --- THE BUG CASES: aliased prefill shapes ---
+    ("ALIASED 3-token prefill (k=2)", [0], [3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1),
+     True, False),
+    ("ALIASED 2-token prefill (k=1)", [0], [2],
+     dict(max_num_scheduled_tokens=2, uniform_decode_query_len=2, num_tokens=2, num_reqs=1),
+     True, False),
+    ("ALIASED chunked-prefill last chunk", [5], [8],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1),
+     True, False),
+    ("ALIASED mixed decode+prefill", [5, 0], [3, 3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=6, num_reqs=2),
+     True, False),
+    ("ALIASED 1-token prompt no-spec", [0], [1],
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=1, num_reqs=1),
+     True, False),
+    ("same shape, past prompt (decode)", [5], [3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1),
+     True, True),
+    ("force=True (capture path)", [0], [3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1,
+          force_uniform_decode=True),
+     True, True),
+    ("force=False", [10] * 4, [8] * 4,
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=4, num_reqs=4,
+          force_uniform_decode=False),
+     False, False),
+]
+
+red_fails, green_fails = [], []
+for name, comp, prom, kw, stock_exp, patched_exp in CASES:
+    s = run(STOCK, make_self(comp, prom), **kw)
+    p = run(PATCHED, make_self(comp, prom), **kw)
+    ok_s = (s == stock_exp)
+    ok_p = (p == patched_exp)
+    tag = ""
+    if not ok_s:
+        red_fails.append(name); tag += " <<RED-FAIL(stock wrong)"
+    if not ok_p:
+        green_fails.append(name); tag += " <<GREEN-FAIL(patch wrong)"
+    print(f"{name:38} stock={s!r:5}(want {stock_exp!r:5}) patched={p!r:5}(want {patched_exp!r:5}){tag}")
+
+print()
+print(f"RED  (stock must get bug cases WRONG): {'PASS' if not red_fails else 'FAIL ' + str(red_fails)}")
+print(f"GREEN (patched must get all right):    {'PASS' if not green_fails else 'FAIL ' + str(green_fails)}")

--- a/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/reported/vllm-gpu-model-runner-uniform-decode-alias.patch
+++ b/community/dominick253-qwen38-27b-fp8-uniform-decode-alias/reported/vllm-gpu-model-runner-uniform-decode-alias.patch
@@ -1,0 +1,47 @@
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -3975,8 +3975,8 @@
+             **model_kwargs,
+         )
+ 
+-    @staticmethod
+     def _is_uniform_decode(
++        self,
+         max_num_scheduled_tokens: int,
+         uniform_decode_query_len: int,
+         num_tokens: int,
+@@ -3987,13 +3987,28 @@
+         Checks if it's a decode batch with same amount scheduled tokens
+         across all requests.
+         """
+-        return (
++        if force_uniform_decode is not None:
++            return force_uniform_decode
++        if not (
++            max_num_scheduled_tokens == uniform_decode_query_len
++            and num_tokens == max_num_scheduled_tokens * num_reqs
++        ):
++            return False
++        # The shape check alone can misclassify prefills: with spec decode
++        # (uniform_decode_query_len = 1 + num_spec_tokens), any batch of
++        # prompts scheduled with exactly uniform_decode_query_len tokens per
++        # request aliases the uniform-decode shape. Dispatching such a
++        # prefill into a cudagraph captured for uniform decode replays stale
++        # capture-time metadata for backends with persistent buffers (e.g.
++        # GDN), silently skipping prefill state writes and corrupting output
++        # (https://github.com/vllm-project/vllm/issues/53051). A batch is
++        # only uniform decode if every request is already past its prompt.
++        input_batch = self.input_batch
++        return bool(
+             (
+-                (max_num_scheduled_tokens == uniform_decode_query_len)
+-                and (num_tokens == max_num_scheduled_tokens * num_reqs)
+-            )
+-            if force_uniform_decode is None
+-            else force_uniform_decode
++                input_batch.num_computed_tokens_cpu[:num_reqs]
++                >= input_batch.num_prompt_tokens[:num_reqs]
++            ).all()
+         )
+ 
+     def _allow_microbatching(


### PR DESCRIPTION
## Purpose

Community packet (evidence level `community-reported`): root-cause match and upstream-fix adoption for a degradation the R50/R187 vLLM XPU lane family is exposed to — after 6–24 h of real multi-session uptime, the server emits degenerate single-token walls (`!!!!!`, `00000…`, `oooooo…`, `||||…`) while health, throughput, and short probes stay clean; restart cures it.

**Mechanism (upstream [vllm-project/vllm#53051](https://github.com/vllm-project/vllm/issues/53051)):** `GPUModelRunner._is_uniform_decode` classifies uniform decode by shape only. With speculative decoding, `uniform_decode_query_len = 1 + num_spec_tokens`; any prefill step scheduling exactly that many tokens per request (tiny prompts, chunk tails, prefix-cache hit tails, mixed batches) aliases the uniform-decode shape, replays capture-time metadata with null/stale GDN state indices, and silently skips recurrent-state writes → zeroed state → degenerate logits.

**Adopted fix (upstream [vllm-project/vllm#53059](https://github.com/vllm-project/vllm/pull/53059), open, by `allenzz-dev`):** after the shape test passes, require every request to be past its prompt (`num_computed_tokens_cpu[:num_reqs] >= num_prompt_tokens[:num_reqs]`). Deployed on the contributor host as a read-only bind-mount over the image's editable install `/workspace/vllm/vllm/v1/worker/gpu_model_runner.py` (site-packages copies are shadowed — patching them does nothing), with a launcher grep assert.

## What is in the packet

- `community/dominick253-qwen38-27b-fp8-uniform-decode-alias/STATUS.md` — classification, provenance (upstream issue/PR credited), full contributor environment, what was and was not run, known issues, open questions for the lab
- `community/dominick253-qwen38-27b-fp8-uniform-decode-alias/README.md` — the mechanism, the fix, why this lane should care
- `reported/vllm-gpu-model-runner-uniform-decode-alias.patch` — 47-line diff of `_is_uniform_decode` (+ a companion microbatch veto that is contributor-added, NOT upstream, flagged in STATUS)
- `reported/test_is_uniform_decode_red_green.py` — self-contained 14-case RED/GREEN classifier test; contributor run: RED PASS, GREEN PASS

## Incident summary (contributor host, community-reported)

| Field | Value |
| --- | --- |
| Image | `neural-download/vllm-openai-xpu:qwen38-fp8-mtp1-serial-fa-split-gdn-r50` (`sha256:dcdbfca2…`), vLLM `0.27.2rc1.dev77+gac7509e2b.xpu` |
| GPUs | 2x Arc Pro B70 (`8086:e223`, TP2), xe driver `85B7CA089405934276CBAD3`, kernel `7.0.0-30-generic` |
| Model | `Qwen/Qwen3.8-27B-FP8` official block-FP8 (66 shards / 407 `weight_scale_inv`), fp8_e4m3 KV, MTP1 |
| Signature | `!!!!!` / `00000…` / `oooo…` walls after 6–24 h dwell under 3–4 concurrent agent sessions; screenshots 2026-09-08 ~00:48–01:02 EDT |
| Post-fix | clean startup/health/alias, exact arithmetic + counting smokes, streaming `!!!!!` detector zero events through soak start; soak in progress |

No rates are claimed; this is documentation of a root cause and an adopted upstream fix.

## Relation to lab records

Possibly the same failure family as the lab's [2026-08-22 chunked-prefill corruption finding](../tree/main/experiments/qwen38-27b-b70/notes/2026-08-22-qwen38-longkv2-closure-and-chunk-corruption-finding.md) (`B70_QWEN3!!!!…` after a multi-chunk prefill dose, mitigated by `VLLM_XPU_GDN_SPEC_PERSISTENT_SCRATCH=0`) and the R178–R186 depth-2 phantom investigation (stale GDN metadata inside a compiled piece). Shared-mechanism equivalence is stated as a hypothesis, not a result — the STATUS "Open Questions" section lists the experiments that would settle it (2-token prompt under the strict harness on both compile modes; whether the d5 scratch-off mitigation also suppresses the alias path).

## Provenance And Rights

- Base: upstream/main at time of submission (468c2e75)
- Upstream sources: vllm-project/vllm issue #53051 and PR #53059 (credited; Apache-2.0)
- [x] I have the right to submit this material under the repository LICENSE.
- [x] I removed secrets, private data, model weights, and unrelated artifacts. (No LAN IPs, tokens, or credentials in the packet; recorder evidence paths are contributor-host absolute paths described, not uploaded.)
- [x] No lab measurements are claimed; evidence level stays `community-reported`. Nothing moved into `results/`, `repro/`, or `patches/`.

## Safety And Scope

- [x] Community packet only, `STATUS.md` present, `community/` placement per CONTRIBUTING.md.
- [x] The patch is for review, not promoted; the companion microbatch veto is explicitly separated from the upstream fix.
- [x] No runtime trees, services, or GPU work touched.

