### PR TITLE
community: on-demand repro of uniform-decode shape-alias (#53051) on Qwen3.6-35B-A3B + fix confirm

### DIFF
--- a/community/bosd-qwen36-35b-a3b-uniform-decode-alias/README.md
+++ b/community/bosd-qwen36-35b-a3b-uniform-decode-alias/README.md
@@ -1,0 +1,106 @@
+# Uniform-decode shape-alias (vllm #53051) — on-demand repro on Qwen3.6-35B-A3B + fix confirm
+
+This packet corroborates [`community/dominick253-qwen38-27b-fp8-uniform-decode-alias/`](../dominick253-qwen38-27b-fp8-uniform-decode-alias/)
+(PR #45) from a **second, independent Arc Pro B70 host**, and turns its
+"degenerate walls after 6–24 h dwell" into a **deterministic on-demand
+reproduction that takes seconds** — then confirms the upstream fix clears it.
+
+## Why this lane cares
+
+`GPUModelRunner._is_uniform_decode` classifies a batch as uniform decode by
+**shape only**:
+
+```
+max_num_scheduled_tokens == uniform_decode_query_len
+    and num_tokens == max_num_scheduled_tokens * num_reqs
+```
+
+With speculative decoding, `uniform_decode_query_len = 1 + num_spec_tokens`. So
+any **prefill** step that schedules exactly that many tokens per request — a
+tiny prompt, a chunk tail, a prefix-cache-hit tail, a mixed batch — *aliases*
+the uniform-decode shape. Dispatched into a cudagraph captured for uniform
+decode, it replays capture-time metadata with null/stale **GDN** recurrent-state
+indices, silently skips the state write, and the zeroed state produces
+degenerate single-token logits (`!!!!!`, `0000`, `oooo`).
+
+**Qwen3.6-35B-A3B is a GDN model.** Its `config.json` `layer_types` interleaves
+`linear_attention` (gated delta net) with `full_attention` every 4th layer
+(`full_attention_interval: 4`). Served under vLLM-XPU with MTP2
+(`num_speculative_tokens=2` → `uniform_decode_query_len=3`), it runs the buggy
+classifier and is exposed to exactly this defect. The lane's existing
+`patch_mtp_boundary.py` guards a *different* GDN+spec edge (a partial final
+speculative group at the max-len boundary), not this prompt-length alias.
+
+## The on-demand trigger (the novel bit)
+
+The original packet noted it had **no controlled on-demand reproduction** — the
+incident needed real mixed-traffic dwell. This host gets it in one request:
+
+On an otherwise idle server, a **fresh request whose prompt tokenizes to exactly
+`1 + num_spec_tokens` tokens** has, on its prefill step (`num_reqs=1`):
+
+- `max_num_scheduled_tokens == 1+num_spec_tokens == uniform_decode_query_len`, and
+- `num_tokens == (1+num_spec_tokens) * 1`,
+
+so stock `_is_uniform_decode` returns `True` for a **prefill** → misdispatch →
+zeroed GDN state → garbage first token. Neighboring prompt lengths do not alias
+and stay clean. At MTP2 the alias length is **3 tokens**.
+
+`reported/alias-harness.py` measures the effect: it picks real K-token prompts
+via the server's `/tokenize`, fires 30 greedy (`temperature=0`) completions per
+shape, and flags degenerate single-token walls.
+
+## Result (this host)
+
+30 greedy repeats per shape, `qwen36-35b-moe`, MTP2:
+
+| prompt shape | tokens | **stock** | **patched (#53059)** |
+| --- | --- | --- | --- |
+| **alias** (`1+1`, = 1+spec) | 3 | **18/30 = 60%** `!!!!!` walls | **0/30** |
+| short (`Hi`) | 1 | 10/30 = 33% | **0/30** |
+| control (`Hi.`) | 2 | 0/30 | 0/30 |
+| control (long) | 13 | 0/30 | 0/30 |
+
+Corruption is isolated to `prompt_len == uniform_decode_query_len`. Post-fix,
+arithmetic is correct (`17*23=391`) and the server's own SpecDecoding metrics
+still report mean acceptance length **2.25–2.31** (~65% draft acceptance) — the
+guard rejects only aliased prefills; genuine decodes keep the MTP fast path.
+
+Full tables and raw run JSON: [`reported/repro-results.md`](reported/repro-results.md).
+
+## The fix
+
+Upstream [vllm #53059](https://github.com/vllm-project/vllm/pull/53059)
+(`allenzz-dev`): after the shape test passes, additionally require every request
+to be **past its prompt**
+(`input_batch.num_computed_tokens_cpu[:n] >= input_batch.num_prompt_tokens[:n]`).
+`_is_uniform_decode` becomes an instance method; the sole call site already uses
+`self.`, so no call-site change is needed.
+
+`reported/patch_uniform_decode_alias.py` applies exactly that guard as an
+entry-time monkeypatch, in the same idiom as this lane's existing
+`patch_mtp_*.py` (locate via importlib, MARKER-idempotent, fail-loud). It is an
+alternative *deployment shape* to the R50 bind-mount; the classifier change is
+identical to #53059.
+
+## Reproduce
+
+```bash
+# against any vLLM-XPU server running a GDN model with spec decode:
+python3 reported/alias-harness.py \
+  --base http://localhost:8000/v1 --model <served-name> \
+  --spec-tokens <num_speculative_tokens> --iters 30 --tag stock
+# apply patch_uniform_decode_alias.py at container entry, restart, then:
+python3 reported/alias-harness.py ... --tag patched
+```
+
+Stock shows a nonzero rate at the `1+spec`-token shape and zero elsewhere;
+patched shows zero everywhere. PR #45's `test_is_uniform_decode_red_green.py`
+(stdlib + numpy) also passes RED/GREEN here.
+
+## Attribution
+
+Root cause and lane: `dominick253` (PR #45). Fix: upstream vllm #53059
+(`allenzz-dev`), issue #53051. This packet: independent B70-host on-demand
+reproduction + fix confirmation by `bosd`. `community-reported` — not a
+reference-lab run.

--- a/community/bosd-qwen36-35b-a3b-uniform-decode-alias/STATUS.md
+++ b/community/bosd-qwen36-35b-a3b-uniform-decode-alias/STATUS.md
@@ -1,0 +1,123 @@
+# Qwen3.6-35B-A3B (GDN hybrid, MTP2): on-demand reproduction of the uniform-decode shape-alias corruption + fix confirmation on a second B70 host
+
+## Classification
+
+| Field | Value |
+| --- | --- |
+| Evidence level | `community-reported` |
+| Patch review status | read and executed here (on the contributor's own B70 host, not the reference lab) |
+| Tested in reference lab | no |
+| Safe to merge as documentation | yes |
+| Eligible for `repro/` or `results/` | no until `B70-tested` in the reference lab |
+
+## Provenance
+
+- Contributor: [`bosd`](https://github.com/bosd) (independent 2× Arc Pro B70 host; not the reference lab)
+- Source PR or URL: this packet builds directly on [PR #45](https://github.com/steveseguin/b70-optimization-lab/pull/45) (`dominick253`, `community/dominick253-qwen38-27b-fp8-uniform-decode-alias/`)
+- Commits: harness + patch authored for this packet; classifier fix is upstream, unchanged.
+- Right-to-submit statement present: yes — I have the right to submit this material under the repository LICENSE; it contains no weights, secrets, tokens, or LAN identifiers.
+- Third-party material and attribution:
+  - vLLM (Apache-2.0): upstream issue [#53051](https://github.com/vllm-project/vllm/issues/53051) and fix PR [#53059](https://github.com/vllm-project/vllm/pull/53059) by `allenzz-dev` — credited; the applied guard is theirs.
+  - `dominick253` PR #45 — the root-cause identification and the lane this corroborates.
+  - Model `Qwen/Qwen3.6-35B-A3B` (GPTQ-Int4 MTP-preserved community requant); image `docker.io/vllm/vllm-openai-xpu`.
+
+## Claim
+
+On an independent 2× Arc Pro B70 host, dominick253's uniform-decode shape-alias
+mechanism (#53051) reproduces **on demand** on a *different* GDN model —
+Qwen3.6-35B-A3B (hybrid linear-attention/GDN) served under vLLM-XPU with MTP2 —
+using a single greedy 3-token prompt: **18/30 (60%) degenerate `!!!!!` walls on
+stock, 0/30 after the #53059 guard**, with no multi-hour dwell required.
+
+## Contributor Environment
+
+| Field | Value |
+| --- | --- |
+| GPU model / count / VRAM | 2× Intel Arc Pro B70, 32 GiB each; **one** card used for this service (`ZE_AFFINITY_MASK=2`) |
+| OS / kernel | Fedora Linux 44 (Server Edition); `7.1.8-200.fc44.x86_64` |
+| GPU driver (`i915` / `xe`) and version | `xe` |
+| compute-runtime / level-zero | level-zero loader `1.28.2`, intel-opencl-icd `26.18.38308.1` (in image) |
+| Engine / image and exact version | `docker.io/vllm/vllm-openai-xpu@sha256:2c427ef477da092eb6f2cdbbbd24950b5fa171565b916db69d4c7bb10e68ca97`, vLLM `0.26.1rc1.dev457+gc810e5ee9`, torch `2.13.0+xpu` |
+| Model repo and revision | `Qwen3.6-35B-A3B` GPTQ-Int4 MTP-preserved community requant; arch `Qwen3_5MoeForConditionalGeneration`, `config.json` `layer_types` = `linear_attention` (GDN) interleaved with `full_attention` every 4th layer (`full_attention_interval: 4`) — GDN-bearing |
+| Quantization (weights / KV / activations) | weights GPTQ Int4 (`--quantization gptq`); `--dtype float16` |
+| Command and environment variables | `vllm serve /model --quantization gptq --dtype float16 --max-model-len 40960 --gpu-memory-utilization 0.90 --port 8000 --max-num-seqs 32 --max-num-batched-tokens 8192 --no-enable-prefix-caching --served-model-name qwen36-35b-moe --language-model-only --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"mtp","num_speculative_tokens":2}'`; env `ZE_AFFINITY_MASK=2 VLLM_XPU_ENABLE_XPU_GRAPH=1 PYTORCH_ALLOC_CONF=expandable_segments:True`. Two pre-existing local MTP patches also load at entry (`patch_mtp_nightly.py`, `patch_mtp_boundary.py` — the latter handles a *different* GDN+spec edge: a partial final speculative group at the max-len boundary, not this prompt-length alias). |
+| Prompt / output / context lengths, concurrency | greedy `temperature=0, seed=12345`, `max_tokens` 12–24; single-stream; **30 repeats per prompt shape**; prompts selected by exact token count via the server's `/tokenize` |
+| Cache and speculation policy | `--no-enable-prefix-caching`; MTP method `mtp`, `num_speculative_tokens=2` → `uniform_decode_query_len = 3` |
+| Metric definition, repeats, dispersion, TTFT | metric = **degenerate-output rate** over 30 greedy repeats; degenerate = an ≥8-char single-token run (`(.)\1{7,}`) or a ≥70% dominant non-alphanumeric char; TTFT not measured (correctness reproduction, not a throughput claim) |
+| Logs / JSON / durable links | `reported/repro-results.md` (full stock/patched tables + raw run JSON); harness `reported/alias-harness.py`; fix `reported/patch_uniform_decode_alias.py` |
+
+## What Was Actually Run Here
+
+Everything in this packet ran on the **contributor's** 2× B70 host, *not* the
+reference lab.
+
+1. `reported/alias-harness.py` against the live unpatched service (MTP2): fired
+   30 greedy `temperature=0` completions for each of four prompt shapes chosen
+   by exact token count — the 3-token alias (`1+1`), 1-token (`Hi`), 2-token
+   (`Hi.`), and a 13-token control.
+2. Applied the #53059 classifier guard as an entry-time monkeypatch
+   (`reported/patch_uniform_decode_alias.py`, same idiom as the lane's existing
+   `patch_mtp_*.py`), restarted, and re-ran the identical harness.
+3. Post-fix functional smokes (`17*23=391`, coherent generation) and confirmed
+   spec-decode was still active from the server's own SpecDecoding metrics.
+4. Ran PR #45's self-contained `test_is_uniform_decode_red_green.py` (stdlib +
+   numpy) on CPU: RED PASS / GREEN PASS.
+
+**Not run here:** the reference-lab R187/R50 sealed lane; the multi-hour
+production soak; MTP depth > 2; the FP8 Qwen3.8-27B incident image itself
+(this host reproduced the *mechanism* on a different GDN model, MTP2).
+
+## Findings
+
+**Confirmed (on this host):**
+
+- The alias reproduces **deterministically and on demand** with a single fresh
+  greedy 3-token prompt at MTP2, no dwell required: stock **18/30 (60%)**
+  `!!!!!` walls at the 3-token alias point, versus **0/30** at the 2-token and
+  13-token controls — corruption is isolated to `prompt_len == uniform_decode_query_len`.
+- The 1-token prompt also degraded on stock (10/30, 33%) and cleared to 0/30
+  post-fix, so that instability was the same path, not a separate short-prompt
+  artifact.
+- The #53059 guard eliminates it: **all four shapes 0/30 post-fix**, arithmetic
+  correct, and the server's SpecDecoding metrics still report mean acceptance
+  length 2.25–2.31 (~65% draft acceptance) — the guard rejects only aliased
+  prefills; genuine uniform decodes keep the fast path.
+- PR #45's CPU classifier test passes both directions.
+
+**Hypothesis (not established here):**
+
+- That this is the *same* mechanism as the contributor's multi-hour FP8
+  Qwen3.8-27B incident. This host reproduced the mechanism on a *different*
+  GDN model (Qwen3.6-35B-A3B) at MTP2 and a different image/vLLM version; the
+  shared root cause (shape-only `_is_uniform_decode`) is identical, but a
+  cross-image equivalence is inference, not measurement.
+
+## Known Issues
+
+- The reproduction is on Qwen3.6-35B-A3B / MTP2, not the FP8 Qwen3.8-27B / MTP1
+  incident image; it corroborates the mechanism and the fix, not the specific
+  incident's rate.
+- Evidence is `community-reported`: a second-community-host B70 result, not a
+  reference-lab run. Only the maintainer can raise it to `B70-tested`.
+- The applied form is an entry-time monkeypatch of the site-packages module
+  (matching this lane's existing `patch_mtp_*.py` deployment), not the R50
+  bind-mount-over-editable-install shape; both target the live serve module.
+
+## Open Questions For The Contributor
+
+Answered by this packet, relative to #45's open questions:
+
+- **#45 open-Q1 (does a short prompt trigger the alias on demand, or does the
+  whole-graph line avoid it?):** on this host's PIECEWISE-default MTP2 setup, a
+  3-token prompt triggers it deterministically (60%). Whether the reference
+  lane's `splitting_ops=[]` whole-graph config avoids it remains for the lab.
+- **Still open:** does `VLLM_XPU_GDN_SPEC_PERSISTENT_SCRATCH=0` (the lab's d5
+  mitigation) also suppress this alias path? Not tested here.
+
+## Disposition
+
+A runnable, on-demand reproduction harness plus fix confirmation from an
+independent B70 host, offered to raise #45's uniform-decode-alias finding from
+"observed after 6–24 h dwell" to "reproduces in seconds with one 3-token
+prompt." It stays `community-reported` until the maintainer runs it on the
+reference lane; the harness is written to make that a single command.

--- a/community/bosd-qwen36-35b-a3b-uniform-decode-alias/reported/alias-harness.py
+++ b/community/bosd-qwen36-35b-a3b-uniform-decode-alias/reported/alias-harness.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""alias-harness — on-demand reproduction of the vLLM-XPU shape-aliased-prefill
+GDN state-loss bug (upstream vllm #53051), the lab's open question #1.
+
+Theory: with spec decode, uniform_decode_query_len = 1 + num_spec_tokens.
+A *fresh* request whose prompt tokenizes to exactly that many tokens has, on its
+prefill step (idle server, num_reqs=1): max_num_scheduled_tokens == that value ==
+uniform_decode_query_len AND num_tokens == value*num_reqs -> stock _is_uniform_decode
+returns True -> prefill misdispatched into the spec-decode uniform-decode cudagraph
+-> stale/null GDN recurrent-state indices -> zeroed state -> degenerate logits.
+
+So: send greedy (temp 0) completions whose prompts tokenize to exactly K tokens,
+for K in {alias point, controls}, and measure the degenerate-output rate.
+Degenerate = a single-token repetition wall (!!!!!, 0000, oooo, ||||, etc).
+
+Uses the OpenAI-compatible endpoint + vLLM's /tokenize to *measure* prompt token
+counts and pick real K-token prompts (no tokenizer dependency locally).
+
+Usage:
+  python3 alias-harness.py --base http://localhost:PORT/v1 --model NAME \
+      --spec-tokens 1 --iters 30 [--tag stock|patched]
+"""
+import argparse, json, re, sys, time, urllib.request, urllib.error
+
+def _post(url, payload, timeout=120):
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(),
+                                 headers={"Content-Type": "application/json",
+                                          "Authorization": "Bearer sk-local"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.load(r)
+
+def _get(url, timeout=30):
+    req = urllib.request.Request(url, headers={"Authorization": "Bearer sk-local"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.load(r)
+
+# Degenerate = >=8 of the same char in a row, or a run that is >=70% one char,
+# for the "wall" signatures. Whitespace-only excluded.
+WALL = re.compile(r"(.)\1{7,}")
+def is_degenerate(txt):
+    t = txt.strip()
+    if not t:
+        return True, "empty"
+    m = WALL.search(t)
+    if m:
+        return True, f"repeat:{m.group(1)!r}x{len(m.group(0))}"
+    # dominant-char check
+    from collections import Counter
+    c = Counter(t)
+    ch, n = c.most_common(1)[0]
+    if len(t) >= 12 and n / len(t) >= 0.7 and not ch.isalnum():
+        return True, f"dominant:{ch!r}={n}/{len(t)}"
+    return False, ""
+
+def tokcount(base, model, text):
+    try:
+        r = _post(base.rsplit("/v1", 1)[0] + "/tokenize",
+                  {"model": model, "prompt": text}, timeout=30)
+        return r.get("count") or len(r.get("tokens", []))
+    except Exception:
+        return None
+
+def find_k_token_prompt(base, model, k, pool):
+    """Return a prompt string that tokenizes to exactly k tokens, or None."""
+    for s in pool:
+        if tokcount(base, model, s) == k:
+            return s
+    return None
+
+# candidate short strings; we measure their real token counts on the server
+POOL = ["Hi", "Hi.", "ok", "OK!", "1", "12", "1+1", "2+2", "cat", "the",
+        "Hello", "Hello!", "Yes", "No", "A B", "x y z", "one two",
+        "Count:", "Q:", "sum 3 4", "print hi", "def f", "a", "an apple",
+        "The quick brown fox jumps over the lazy dog and then keeps running"]
+
+def run_shape(base, model, label, prompt, iters, max_tokens=24):
+    bad = 0; samples = []
+    for i in range(iters):
+        try:
+            r = _post(base + "/completions",
+                      {"model": model, "prompt": prompt, "max_tokens": max_tokens,
+                       "temperature": 0, "seed": 12345}, timeout=120)
+            out = r["choices"][0]["text"]
+        except Exception as e:
+            out = f"<ERROR {e}>"
+        deg, why = is_degenerate(out)
+        if deg:
+            bad += 1
+            if len(samples) < 3:
+                samples.append((why, out[:60]))
+    return {"label": label, "prompt": repr(prompt), "iters": iters,
+            "degenerate": bad, "rate": round(bad / iters, 3), "samples": samples}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True)
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--spec-tokens", type=int, default=1,
+                    help="num_speculative_tokens the server runs (MTP depth)")
+    ap.add_argument("--iters", type=int, default=30)
+    ap.add_argument("--tag", default="")
+    args = ap.parse_args()
+    base = args.base.rstrip("/")
+
+    model = args.model
+    if not model:
+        model = _get(base + "/models")["data"][0]["id"]
+    print(f"# target={base} model={model} spec_tokens={args.spec_tokens} tag={args.tag}")
+
+    alias_k = 1 + args.spec_tokens               # the aliasing prompt length
+    controls = sorted({1, 2, 3, alias_k} - {alias_k})  # neighbors that must NOT alias
+
+    shapes = []
+    pa = find_k_token_prompt(base, model, alias_k, POOL)
+    if pa is None:
+        print(f"!! could not find a {alias_k}-token prompt in POOL; check /tokenize", file=sys.stderr)
+    else:
+        shapes.append((f"ALIAS k={alias_k} (=1+spec)", pa))
+    for k in controls:
+        pc = find_k_token_prompt(base, model, k, POOL)
+        if pc:
+            shapes.append((f"control k={k}", pc))
+    # a long normal prompt (never aliases: max_num_scheduled_tokens != alias_k)
+    long_p = POOL[-1]
+    shapes.append((f"control long ({tokcount(base, model, long_p)}tok)", long_p))
+
+    results = []
+    for label, prompt in shapes:
+        res = run_shape(base, model, label, prompt, args.iters)
+        results.append(res)
+        print(f"{res['label']:28} prompt={res['prompt']:30} "
+              f"degenerate={res['degenerate']:>3}/{res['iters']} rate={res['rate']}"
+              + ("  e.g. " + str(res['samples'][0]) if res['samples'] else ""))
+
+    out = {"base": base, "model": model, "spec_tokens": args.spec_tokens,
+           "tag": args.tag, "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+           "results": results}
+    print("\n=== JSON ===")
+    print(json.dumps(out))
+
+if __name__ == "__main__":
+    main()

--- a/community/bosd-qwen36-35b-a3b-uniform-decode-alias/reported/patch_uniform_decode_alias.py
+++ b/community/bosd-qwen36-35b-a3b-uniform-decode-alias/reported/patch_uniform_decode_alias.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Reject shape-aliased prefills in uniform-decode classification.
+
+Adopts upstream vllm-project/vllm PR #53059 (fix for issue #53051) for the
+XPU GDN lane. GPUModelRunner._is_uniform_decode classifies a batch as uniform
+decode by shape only; with spec decode (uniform_decode_query_len = 1 +
+num_spec_tokens), any prefill scheduling exactly that many tokens per request
+aliases the uniform-decode shape, is dispatched into the uniform-decode
+cudagraph, and replays capture-time metadata with null/stale GDN state indices
+-> recurrent-state write silently skipped -> zeroed state -> degenerate
+single-token walls (!!!!!, 0000, oooo) after real multi-session dwell.
+
+Fix: after the shape test passes, additionally require every request to be past
+its prompt (num_computed_tokens_cpu[:n] >= num_prompt_tokens[:n]). Needs `self`,
+so the method stops being a staticmethod; the sole call site already uses
+`self._is_uniform_decode(...)`, so no call-site change is required.
+
+Idempotent + fail-loud, same contract as patch_mtp_nightly.py / patch_boundary.py.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+MARKER = "B70_UNIFORM_DECODE_ALIAS_GUARD"
+
+OLD = '''    @staticmethod
+    def _is_uniform_decode(
+        max_num_scheduled_tokens: int,
+        uniform_decode_query_len: int,
+        num_tokens: int,
+        num_reqs: int,
+        force_uniform_decode: bool | None = None,
+    ) -> bool:
+        """
+        Checks if it's a decode batch with same amount scheduled tokens
+        across all requests.
+        """
+        return (
+            (
+                (max_num_scheduled_tokens == uniform_decode_query_len)
+                and (num_tokens == max_num_scheduled_tokens * num_reqs)
+            )
+            if force_uniform_decode is None
+            else force_uniform_decode
+        )
+'''
+
+NEW = '''    def _is_uniform_decode(
+        self,
+        max_num_scheduled_tokens: int,
+        uniform_decode_query_len: int,
+        num_tokens: int,
+        num_reqs: int,
+        force_uniform_decode: bool | None = None,
+    ) -> bool:
+        """
+        Checks if it's a decode batch with same amount scheduled tokens
+        across all requests.
+        """
+        # B70_UNIFORM_DECODE_ALIAS_GUARD (vllm #53051 / PR #53059): the shape
+        # test alone misclassifies prefills that alias the spec-decode shape
+        # (uniform_decode_query_len = 1 + num_spec_tokens). Dispatching such a
+        # prefill into the uniform-decode cudagraph replays stale metadata with
+        # null GDN state indices, silently skipping the recurrent-state write
+        # and corrupting output. A batch is only uniform decode if every
+        # request is already past its prompt.
+        if force_uniform_decode is not None:
+            return force_uniform_decode
+        if not (
+            max_num_scheduled_tokens == uniform_decode_query_len
+            and num_tokens == max_num_scheduled_tokens * num_reqs
+        ):
+            return False
+        input_batch = self.input_batch
+        return bool(
+            (
+                input_batch.num_computed_tokens_cpu[:num_reqs]
+                >= input_batch.num_prompt_tokens[:num_reqs]
+            ).all()
+        )
+'''
+
+
+def main() -> None:
+    spec = importlib.util.find_spec("vllm.v1.worker.gpu_model_runner")
+    if spec is None or not spec.origin:
+        sys.exit("[alias-patch] gpu_model_runner module not found")
+    path = spec.origin
+    src = open(path).read()
+
+    if MARKER in src:
+        print(f"[alias-patch] already patched: {path}")
+        return
+    if OLD not in src:
+        sys.exit(f"[alias-patch] anchor not found — _is_uniform_decode changed in {path}")
+
+    new_src = src.replace(OLD, NEW, 1)
+    if new_src.count(MARKER) != 1:
+        sys.exit("[alias-patch] replacement produced wrong marker count")
+    open(path, "w").write(new_src)
+    # verify it re-imports cleanly enough to at least byte-compile
+    compile(new_src, path, "exec")
+    print(f"[alias-patch] patched {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/community/bosd-qwen36-35b-a3b-uniform-decode-alias/reported/repro-results.md
+++ b/community/bosd-qwen36-35b-a3b-uniform-decode-alias/reported/repro-results.md
@@ -1,0 +1,51 @@
+# Reproduction results — Qwen3.6-35B-A3B, MTP2, single B70
+
+Host: independent 2× Arc Pro B70 (one card, `ZE_AFFINITY_MASK=2`), Fedora 44,
+kernel 7.1.8, vLLM `0.26.1rc1.dev457+gc810e5ee9` (`vllm-openai-xpu@2c427ef`),
+model served as `qwen36-35b-moe`, `--speculative-config {"method":"mtp","num_speculative_tokens":2}`.
+Harness: `alias-harness.py`, 30 greedy (`temperature=0, seed=12345`) repeats per shape.
+Degenerate = `(.)\1{7,}` run or ≥70% dominant non-alphanumeric char.
+
+## Stock (unpatched `_is_uniform_decode`)
+
+```
+ALIAS k=3 (=1+spec)   prompt='1+1'   degenerate=18/30 rate=0.60   e.g. repeat:'!'x24
+control k=1           prompt='Hi'    degenerate=10/30 rate=0.333  e.g. repeat:'!'x24
+control k=2           prompt='Hi.'   degenerate= 0/30 rate=0.0
+control long (13tok)  prompt=<13tok> degenerate= 0/30 rate=0.0
+```
+
+raw:
+
+```json
+{"base": "http://localhost:8000/v1", "model": "qwen36-35b-moe", "spec_tokens": 2, "tag": "stock", "ts": "2026-09-09T12:35:35", "results": [{"label": "ALIAS k=3 (=1+spec)", "prompt": "'1+1'", "iters": 30, "degenerate": 18, "rate": 0.6, "samples": [["repeat:'!'x24", "!!!!!!!!!!!!!!!!!!!!!!!!"], ["repeat:'!'x24", "!!!!!!!!!!!!!!!!!!!!!!!!"], ["repeat:'!'x24", "!!!!!!!!!!!!!!!!!!!!!!!!"]]}, {"label": "control k=1", "prompt": "'Hi'", "iters": 30, "degenerate": 10, "rate": 0.333, "samples": [["repeat:'!'x24", "!!!!!!!!!!!!!!!!!!!!!!!!"], ["repeat:'!'x24", "!!!!!!!!!!!!!!!!!!!!!!!!"], ["repeat:'!'x24", "!!!!!!!!!!!!!!!!!!!!!!!!"]]}, {"label": "control k=2", "prompt": "'Hi.'", "iters": 30, "degenerate": 0, "rate": 0.0, "samples": []}, {"label": "control long (13tok)", "prompt": "'The quick brown fox jumps over the lazy dog and then keeps running'", "iters": 30, "degenerate": 0, "rate": 0.0, "samples": []}]}
+```
+
+## Patched (upstream #53059 guard applied at entry)
+
+```
+ALIAS k=3 (=1+spec)   prompt='1+1'   degenerate= 0/30 rate=0.0
+control k=1           prompt='Hi'    degenerate= 0/30 rate=0.0
+control k=2           prompt='Hi.'   degenerate= 0/30 rate=0.0
+control long (13tok)  prompt=<13tok> degenerate= 0/30 rate=0.0
+```
+
+raw:
+
+```json
+{"base": "http://localhost:8000/v1", "model": "qwen36-35b-moe", "spec_tokens": 2, "tag": "patched", "ts": "2026-09-09T12:40:08", "results": [{"label": "ALIAS k=3 (=1+spec)", "prompt": "'1+1'", "iters": 30, "degenerate": 0, "rate": 0.0, "samples": []}, {"label": "control k=1", "prompt": "'Hi'", "iters": 30, "degenerate": 0, "rate": 0.0, "samples": []}, {"label": "control k=2", "prompt": "'Hi.'", "iters": 30, "degenerate": 0, "rate": 0.0, "samples": []}, {"label": "control long (13tok)", "prompt": "'The quick brown fox jumps over the lazy dog and then keeps running'", "iters": 30, "degenerate": 0, "rate": 0.0, "samples": []}]}
+```
+
+## Post-fix functional / regression checks
+
+- `17*23=` → `391` (correct)
+- 3-token `1+1` → coherent tokens (was `!!!!!`)
+- Server SpecDecoding metrics (journal): mean acceptance length **2.25–2.31**,
+  ~65% draft acceptance — MTP spec-decode still active; the guard rejects only
+  aliased prefills.
+
+## CPU classifier test
+
+PR #45's `test_is_uniform_decode_red_green.py` (stdlib + numpy) run here:
+**RED PASS / GREEN PASS** (stock misclassifies all 5 aliased shapes; patched
+rejects them and preserves all genuine decodes).


### PR DESCRIPTION
## Purpose

Community packet (`community-reported`) that **corroborates [PR #45](https://github.com/steveseguin/b70-optimization-lab/pull/45)** (`community/dominick253-qwen38-27b-fp8-uniform-decode-alias/`) from a **second, independent Arc Pro B70 host**, and turns its "degenerate `!!!!!` walls after 6–24 h of real dwell" into a **deterministic on-demand reproduction that takes seconds** — then confirms upstream [vllm #53059](https://github.com/vllm-project/vllm/pull/53059) clears it.

The original packet explicitly noted it had **no controlled on-demand reproduction** (the incident needed real mixed-traffic dwell). This one provides it, and answers #45's open question #1 on this host.

## The mechanism, on a different GDN model

`GPUModelRunner._is_uniform_decode` classifies uniform decode by **shape only**. With spec decode, `uniform_decode_query_len = 1 + num_spec_tokens`, so a **prefill** scheduling exactly that many tokens/request aliases the uniform-decode shape → uniform-decode cudagraph → stale metadata with null **GDN** state indices → skipped recurrent-state write → zeroed state → degenerate logits (#53051).

**Qwen3.6-35B-A3B is GDN-bearing** — `config.json` `layer_types` interleaves `linear_attention` (gated delta net) with `full_attention` every 4th layer. Served under vLLM-XPU with **MTP2** (`uniform_decode_query_len=3`), it runs the buggy classifier. (The lane's existing `patch_mtp_boundary.py` guards a *different* GDN+spec edge — a partial final speculative group at the max-len boundary — not this prompt-length alias.)

## On-demand trigger

On an idle server, a fresh request whose prompt tokenizes to exactly `1 + num_spec_tokens` tokens has, on its prefill (`num_reqs=1`): `max_num_scheduled_tokens == uniform_decode_query_len` and `num_tokens == (1+num_spec_tokens)`, so stock `_is_uniform_decode` returns `True` for a **prefill** → misdispatch → zeroed GDN state → garbage. At MTP2 the alias length is **3 tokens**.

## Result (this host, 30 greedy `temperature=0` repeats/shape)

| prompt shape | tokens | **stock** | **patched (#53059)** |
| --- | --- | --- | --- |
| **alias** (`1+1`, = 1+spec) | 3 | **18/30 = 60%** `!!!!!` walls | **0/30** |
| short (`Hi`) | 1 | 10/30 = 33% | **0/30** |
| control (`Hi.`) | 2 | 0/30 | 0/30 |
| control (long) | 13 | 0/30 | 0/30 |

Corruption isolated to `prompt_len == uniform_decode_query_len`. Post-fix: `17*23=391`, and the server's SpecDecoding metrics still report mean acceptance length **2.25–2.31** (~65% draft acceptance) — the guard rejects only aliased prefills; genuine decodes keep the MTP fast path. PR #45's CPU `test_is_uniform_decode_red_green.py` also passes RED/GREEN here.

## What is in the packet

- `STATUS.md` — classification (`community-reported`), full environment, what was and was not run, findings vs hypotheses, #45's open questions.
- `README.md` — mechanism as it applies to Qwen3.6-35B-A3B, the on-demand trigger, result, fix.
- `reported/alias-harness.py` — the on-demand reproduction harness (picks exact-K-token prompts via `/tokenize`, measures degenerate rate). **The asset the original packet lacked.**
- `reported/patch_uniform_decode_alias.py` — upstream #53059's guard as an entry-time monkeypatch (alternative deployment shape to the R50 bind-mount; classifier change identical).
- `reported/repro-results.md` — stock/patched tables + raw run JSON + regression checks.

## Environment

2× Intel Arc Pro B70 (one card, `ZE_AFFINITY_MASK=2`), Fedora 44 / kernel 7.1.8, `xe`, level-zero 1.28.2; `vllm/vllm-openai-xpu@sha256:2c427ef…` vLLM `0.26.1rc1.dev457+gc810e5ee9`, torch 2.13.0+xpu; Qwen3.6-35B-A3B GPTQ-Int4 MTP-preserved; `--speculative-config {"method":"mtp","num_speculative_tokens":2}`, `--no-enable-prefix-caching`.

## Scope / rights

- `community/` placement per CONTRIBUTING.md; `STATUS.md` from the template; evidence stays **`community-reported`** (independent B70-host result, not a reference-lab run — only the maintainer can raise it to `B70-tested`).
- Reproduces the *mechanism* on Qwen3.6-35B-A3B / MTP2, not the FP8 Qwen3.8-27B / MTP1 incident image; cross-image equivalence is stated as hypothesis, not measurement.
- No runtime trees, services, weights, secrets, or LAN identifiers. Classifier fix is upstream #53059 (`allenzz-dev`, Apache-2.0), unchanged; root cause and lane credited to `dominick253` (#45).
- I have the right to submit this under the repository LICENSE.