### PR TITLE
Efficiency audit 2026-09-10

### DIFF
--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,14 +1,12 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03–10 UTC; clock-times below are commit-local (EDT).
+Window: 2026-09-03–10 UTC; clock-times below are EDT.
 
-**Correction, same PR (#48), seven review rounds:** prior fixes — shallow-
-clone misread, self-inflating commit counts, three rule violations, an
-unverifiable 33-asset claim, EDT timestamps, CPU-time-as-downtime,
-dropped latency stats, an inflated 88-path gap, a wrong "accepted 0".
-This round: an R204 contradiction, a conflated PR #45/phase-guard
-identity, an incomplete outcome table, top-3 items missing required
-saving/generalization language. See Checks performed.
+**Correction, same PR (#48), eight review rounds:** many prior fixes (see
+PR history). This round: publication needed its own fresh-server check,
+since R195/R196's own decision line said "pass -> publish" with no
+multi-server condition; token/attention cost metrics were missing. See
+Checks performed.
 
 ## Verdict
 
@@ -19,8 +17,8 @@ profile," and a passing depth-5 candidate got its endpoint queued behind
 a further sweep (a fault then blocked it anyway). Separately: Sep 8's
 qwen3.5 census was skipped by reasoning from a patch; R167-R186 was
 human-reviewed, not one unattended runner; a runner's fast-fail checks
-only after the fact. Infra tax is real but unquantified (985s of MiniMax
-CPU time, not elapsed downtime) — the pattern that cost three days once.
+only after the fact. Infra tax is real but unquantified (985s MiniMax
+CPU time, not downtime) — the pattern that cost three days once.
 
 ## Metrics table
 
@@ -29,10 +27,11 @@ CPU time, not elapsed downtime) — the pattern that cost three days once.
 | Commits in window | 864 (claude 844, codex 18, other 2) | `origin/main` | Stable |
 | Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | Yes |
 | Longest bounded / trailing gap | 10.7h / 29.5h | `git log` | Frozen, EDT |
-| Preregistrations / matched / latency | 30 / 10 / 0.16h med, 3.28h max | eff.json | Floor (stem-matching) |
+| Preregs / matched / latency | 30 / 10 / 0.16h med, 3.28h max | eff.json | Floor (stem-matching) |
 | qwen38-27b-b70 / flash-next outcomes | accepted ≥1\*, rejected 1, aborted-infra 1, no-result ≤18\*+1, unclassified 8 | eff.json | \*Script says 0/19; R187 full-ladder (G1-G5 12/12) stem-missed |
 | Packages scanned / gapped | 26 / 10 | closure.json | Local checks only |
-| Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated — container-internal paths included |
+| Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated by container-internal paths |
+| Preregs:accepted / duplicated artifacts | 30:≥1 / not checked | eff.json | Real ratio lower (stem-mismatches) |
 
 ## Where the week went
 
@@ -43,14 +42,13 @@ depth chain — R195/R196 (depth 2/3) share one boot (`88f0984f`,
 "unrepeated") yet the note declares "depth 3 is the fastest lossless
 single-user profile," published; R200 (depth 5) passed its ">2%" gate,
 but R202/R203's depth-6/7 sweep was preregistered first, ahead of depth
-5's own endpoint (R204); a fault during depth-7's weight staging (caught
-only by postflight) halted device work, so R204 never ran at all.
-11:04→21:45: largest bounded lull. Sep 8 05:00–Sep 9 00:45: qwen3.5
-divergence narrows toward "a dozen tie sites"; a maintainer GDN phase
-guard — not PR #45's own fix, which failed screens — validates on two
-fresh servers; PR #45 merges as acknowledgment, promotion still gated on
-a soak. MiniMax hits four faults, a driver-wedge reboot. Then a 29.5h
-silence to this audit's start.
+5's own endpoint (R204); a fault during depth-7's weight staging halted
+device work, so R204 never ran at all. 11:04→21:45: largest bounded lull.
+Sep 8 05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie
+sites"; a maintainer GDN phase guard — not PR #45's own fix, which failed
+screens — validates on two fresh servers; PR #45 merges as
+acknowledgment, promotion still gated on a soak. MiniMax hits four
+faults, a driver-wedge reboot. Then a 29.5h silence to this audit's start.
 `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
 Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
 
@@ -60,10 +58,10 @@ of 26 candidates. `missing_release_asset` needs `gh`, absent here, so 33
 Flash-Next MTP1 packages are **unverified**. `host_path_hardcoded`
 over-counts too: 22 of hctriton's 88 hits are its own Dockerfile, plus
 more from in-image `container-serve.sh`-style scripts — legitimately
-fixed, not host paths. Real ones remain, e.g.
-`/home/steve/llm-optimizations` in `tools/*.sh`. MTP0 carries 63 raw hits
-plus 5 missing config paths; `asrock-b70`'s only flagged gap is 4. Four
-AutoRound packages share dead README links plus hardcoded paths.
+fixed. Real ones remain, e.g. `/home/steve/llm-optimizations` in
+`tools/*.sh`. MTP0 carries 63 raw hits plus 5 missing config paths;
+`asrock-b70`'s only flagged gap is 4. AutoRound packages share dead
+README links plus their own paths.
 
 ## Rule compliance
 
@@ -72,7 +70,7 @@ AutoRound packages share dead README links plus hardcoded paths.
 2. Oracle bound to kernel identity: met.
 3. No speed verdict from one server: **not met** — R195/R196, one boot,
    "the fastest lossless single-user profile."
-4. Whole campaign, one runner: **not met** for R167-R186 — human-reviewed
+4. Whole campaign, one runner: **not met** — R167-R186 human-reviewed
    step by step.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
@@ -83,31 +81,30 @@ AutoRound packages share dead README links plus hardcoded paths.
 
 ## Top three changes
 
-1. **Gate both launch and publication on a completed campaign's own
-   decision line**, plus a pre-launch census check for rule 1. Evidence:
-   R202/R203 preregistered ahead of depth-5's endpoint; R195/R196
-   published a same-boot ranking. Saving: catches the pattern that cost
-   three days once. Generalizes to every chain.
+1. **Gate launch on a campaign's own decision line, and gate publication
+   independently on ≥2 distinct `boot_id`s** — R195/R196's own decision
+   line said "pass -> publish" with no multi-server condition, so a
+   launch gate alone wouldn't catch it. Add a pre-launch census check for
+   rule 1. Evidence: R202/R203 preregistered ahead of depth-5's endpoint;
+   R195/R196 published a same-boot ranking. Saving: catches the pattern
+   that cost three days once. Generalizes to every chain and publish.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
    shallow-clone guard, tail-gap/UTC fixes, match by campaign id, run
-   against `origin/main`. Evidence: seven rounds to get these numbers
-   right. Saving: correct numbers first pass. Generalizes to every week
-   it runs.
+   against `origin/main`. Evidence: eight rounds to get right numbers.
+   Saving: correct on the first pass. Generalizes to every run.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
    `missing_release_asset` with authenticated `gh`; exclude Dockerfile/
    in-container scripts from `host_path_hardcoded`. Evidence: this report
-   cited both raw counts as confirmed gaps first. Saving: stops chasing
-   false gaps. Generalizes to every package scanned.
+   cited both as confirmed gaps first. Saving: stops chasing false gaps.
+   Generalizes to every package.
 
 ## Checks performed
 
-- Ran `scripts/efficiency-audit-metrics.py --days 7` against a clean
-  `origin/main` worktree, and `tools/public-closure-scanner.py`.
-- Read AGENTS.md speed/publication rules, `CURRENT.md`, the notes cited.
-- Read the scanner's `release_assets()`/`HOST_RE`/`CONTAINER_PATHS` after
-  Codex flagged them; confirmed `gh` isn't installed here.
-- Verified every other claim against the named file after Codex named it:
-  `boot_id`s, R173/R171, R200/R202/R203 timestamps/fault status,
-  MiniMax's CPU-vs-elapsed time, R187's full-ladder result, `CURRENT.md`'s
-  PR #45/phase-guard split.
-- No file addressed this auditor; comments verified before acting.
+- Ran `scripts/efficiency-audit-metrics.py --days 7` (clean `origin/main`
+  worktree) and `tools/public-closure-scanner.py`.
+- Read AGENTS.md rules, `CURRENT.md`, the notes cited.
+- Read `release_assets()`/`HOST_RE`; `gh` isn't installed here.
+- Verified every other claim against its named source after Codex named
+  it: `boot_id`s, R173/R171, R200/R202/R203, MiniMax's CPU time, R187's
+  result, `CURRENT.md`'s PR #45 split, R195/R196's decision text.
+- No file addressed this auditor; comments were verified, not trusted.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,17 +1,15 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03–10 UTC; narrative clock-times below are commit-local
-(EDT).
+Window: 2026-09-03–10 UTC; clock-times below are commit-local (EDT).
 
-**Correction, same PR (#48), five review rounds:** prior rounds fixed a
+**Correction, same PR (#48), six review rounds:** prior rounds fixed a
 shallow-clone misread, a missed tail gap, a wrongly "compliant" runner, an
-undersold closure gap, mis-bucketed dates, a matches conflation,
-self-inflating commit counts, three rule violations. This pass: **`gh`
-isn't installed here, so every `missing_release_asset` finding (the
-33-asset "worst gap" included) was unverified** — closure findings now
-use only checks `gh`'s absence can't corrupt, plus unlabeled EDT
-timestamps, CPU-time misreported as downtime, a fix that misses
-publication. See Checks performed.
+undersold closure gap, mis-bucketed dates, self-inflating commit counts,
+three rule violations, an unverifiable 33-asset claim, EDT timestamps,
+CPU-time-as-downtime, a fix missing publication. This pass: "accepted 0"
+is also wrong (a real accepted campaign, stem-missed); the 88-path gap
+double-counts container paths; latency stats got dropped in a trim. See
+Checks performed.
 
 ## Verdict
 
@@ -33,10 +31,11 @@ three days once, still unfixed.
 | Commits in window | 864 (claude 844, codex 18, other 2) | `origin/main` | Stable |
 | Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | Yes |
 | Longest bounded / trailing gap | 10.7h / 29.5h as of report start | `git log` | Frozen, EDT |
-| Preregistrations / matched | 30 / 10 | eff.json | 10 is a floor |
-| qwen38-27b-b70 outcomes | accepted 0, rejected 1, aborted-infra 1, no-result 19, unclassified 8 | eff.json | Per protocol |
+| Preregistrations / matched | 30 / 10 | eff.json | Floor (stem-matching) |
+| Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same floor |
+| qwen38-27b-b70 outcomes | accepted 0\*, rejected 1, aborted-infra 1, no-result 19, unclassified 8 | eff.json | \*Wrong — R187 full-ladder (G1-G5 12/12) accepted but stem-missed |
 | Packages scanned / gapped | 26 / 10 | closure.json | Local checks only |
-| Worst *verified* closure gap | 88 hardcoded paths (`...mtp1-hctriton`) | closure.json | `missing_release_asset` needs `gh`, unavailable |
+| Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated — includes container-internal paths |
 
 ## Where the week went
 
@@ -50,27 +49,28 @@ its ">2%" gate, but R202/R203's depth-6/7 sweep was preregistered first,
 ahead of depth 5's own endpoint (R204); a fault during depth-7's weight
 staging (caught only by postflight) halted device work for the night, so
 R204 never ran regardless. 11:04→21:45: largest bounded lull. Sep 8
-05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie sites" —
-GEMM leg inferred, not run; PR #45's GDN fix validated on two fresh
-servers, merged; MiniMax hits four faults, a driver-wedge reboot. Then a
-29.5h silence to this audit's own start.
+05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie sites";
+PR #45's GDN fix validated on two fresh servers, merged; MiniMax hits four
+faults, a driver-wedge reboot. Then a 29.5h silence to this audit's start.
 `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
 Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
 
 Publication closure: `tools/public-closure-scanner.py` reports GAPS on 10
 of 26 candidates. `missing_release_asset` needs `gh`, absent here, so 33
 "missing" assets on `qwen38-27b-fp8-vllm-tp2-asrock-b70` and 2 each on 4
-Flash-Next MTP1 packages are **unverified**. By verified checks alone:
-those 4 packages carry 82-88 hardcoded host paths each; MTP0 carries 63
-plus 5 missing config paths; `asrock-b70`'s only verified gap is 4
-hardcoded paths. Four AutoRound packages share dead README links plus
-hardcoded paths of their own.
+Flash-Next MTP1 packages are **unverified**. `host_path_hardcoded` also
+over-counts: 22 of hctriton's 88 hits are its own Dockerfile, plus more
+from `container-serve.sh`-style in-image scripts — legitimately fixed,
+not host paths. Real ones remain, just uncounted precisely, e.g.
+`/home/steve/llm-optimizations` in its `tools/*.sh`. MTP0 carries 63 raw
+hits plus 5 missing config paths; `asrock-b70`'s only flagged gap is 4.
+Four AutoRound packages share dead README links plus hardcoded paths.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** — qwen3.5 GEMM sweep never run,
-   "incomplete" (`probes/w4a16-gemm-row-invariance.py:14`).
-2. Oracle bound to kernel identity: compliant.
+1. Census before bisection: **not met** — qwen3.5 GEMM sweep never run
+   (`probes/w4a16-gemm-row-invariance.py:14`).
+2. Oracle bound to kernel identity: met.
 3. No speed verdict from one server: **not met** — R195/R196, one boot,
    "the fastest lossless single-user profile."
 4. Whole campaign, one runner: **not met** for R167-R186 — each step read
@@ -78,7 +78,7 @@ hardcoded paths of their own.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
 6. Stop at first passing gate: **not met** — R204 ran after, not instead
-   of, the R202/R203 sweep past R200's gate.
+   of, R202/R203's sweep past R200's gate.
 7. Read-only work delegated while GPUs busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
@@ -88,27 +88,24 @@ hardcoded paths of their own.
    decision line.** Evidence: R202/R203 preregistered ahead of depth-5's
    endpoint (a launch gate catches this); R195/R196's same-boot pair was
    published as a ranking (needs a separate publish-time fresh-server
-   check). Add a pre-launch census check too, for rule 1 (Sep 8's gap was
-   a missing step, not an ignored gate).
+   check). Add a pre-launch census check too, for rule 1.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
-   shallow-clone guard, tail-gap and UTC-date fixes, campaign-vs-matched
-   counts, measured against `origin/main`.
-3. **Verify `missing_release_asset` with authenticated `gh`**, and fix
-   what doesn't need it: the Flash-Next family's 63-88 hardcoded host
-   paths from one shared template. This report cited a 33-asset "gap" for
-   a week before catching it was a missing-CLI artifact.
+   shallow-clone guard, tail-gap/UTC fixes, match by campaign id, run
+   against `origin/main`.
+3. **Fix the closure scanner's two count-inflating bugs**: verify
+   `missing_release_asset` with authenticated `gh`, not an empty-on-error
+   result, and exclude Dockerfile/in-container scripts from
+   `host_path_hardcoded`. This report cited both raw counts as confirmed
+   gaps before catching they were partly scanner artifacts.
 
 ## Checks performed
 
 - Ran `scripts/efficiency-audit-metrics.py --days 7` against a clean
-  `origin/main` worktree and `tools/public-closure-scanner.py`.
-- Read AGENTS.md speed/publication rules, `CURRENT.md`, the notes cited
-  above.
-- Read `release_assets()` in the scanner after Codex flagged it: shells to
-  `gh release view`, returns empty on any exception; confirmed `gh` isn't
-  installed here.
+  `origin/main` worktree, and `tools/public-closure-scanner.py`.
+- Read AGENTS.md speed/publication rules, `CURRENT.md`, the notes cited.
+- Read the scanner's `release_assets()` and `HOST_RE`/`CONTAINER_PATHS`
+  after Codex flagged them; confirmed `gh` isn't installed here.
 - Verified every other claim against the named file after Codex named it:
   `boot_id`s, R173/R171, R200/R202/R203 timestamps, MiniMax's CPU-vs-
-  elapsed time, UTC offsets, closure counts by type.
-- No file addressed this auditor; comments were external data, verified
-  first.
+  elapsed time, UTC offsets, the R187 full-ladder result.
+- No file addressed this auditor; comments verified before acting.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,17 +1,16 @@
 # Efficiency audit — 2026-09-10
 
-Window 2026-09-03–10 UTC, clock-times EDT.
+Window 2026-09-03–10 UTC; clock-times EDT.
 
-**Correction, same PR (#48), eleven review rounds.** This round: R204
-actually ran and published (was wrongly called "never ran"), dropping
-the R187 depth chain from the three longest stretches; qwen3.5
-conflated two unrelated lanes; closure gaps now precede efficiency
-findings, per package.
+**Correction, same PR (#48), twelve review rounds.** This round:
+`eff.json`/`closure.json` aren't committed (one file only, per scope);
+the metrics script windows off `datetime.now()`, so figures can't be
+regenerated — a noted limitation, not fixed by adding files.
 
 ## Verdict
 
 The lab moved fast (864 commits, 7 days) but its speed rules kept
-losing out: five of eight violated, not one. Two share a root cause on
+losing: five of eight violated, not one. Two share a root cause on
 Sep 4: a same-boot pair published as "the fastest...profile," and a
 passing depth-5 candidate had its endpoint queued behind a further
 sweep and an overnight fault, publishing next morning regardless.
@@ -34,57 +33,56 @@ unquantified (985s MiniMax CPU time, not downtime).
 
 ## Where the week went
 
-Publication closure (protocol: precedes efficiency findings): GAPS on
-10/26 candidates. 3 Qwen3.5 packages (5 missing_path each, hardcoded
+Publication closure (precedes efficiency findings per protocol): GAPS
+on 10/26 candidates. 3 Qwen3.5 packages (5 missing_path each, hardcoded
 paths, unreachable builders); autoround-int4 (7 missing_path, 4
 unreachable builders); asrock-b70 R187 recipe (33 missing_release_asset
-— needs `gh`, unverified — plus 4 hardcoded); 4
-Flash-Next MTP1 packages (82-88 hardcoded each, inflated by container
-paths, plus 2 missing_path and 2 unverified missing_release_asset each);
-MTP0 (5 missing_path, 63 hardcoded).
+— needs `gh`, unverified — plus 4 hardcoded); 4 Flash-Next MTP1
+packages (82-88 hardcoded each, inflated by container paths, plus 2
+missing_path/2 unverified missing_release_asset each); MTP0 (5
+missing_path, 63 hardcoded).
 
 Three longest arm-stretches ending without an accepted result:
 
 1. **Sep 3 08:59–20:49 (11.8h), R167-R186 phantom chain.** Bisecting
-   which of four candidate mechanisms causes the defect, each hypothesis
-   built on the prior result (R173's prereg quotes R171 verbatim); ends
-   at R186n-b, no result file. Rule 4 would shorten it — human-reviewed
+   which of four mechanisms causes the defect, each hypothesis built on
+   the prior result (R173's prereg quotes R171 verbatim); ends at
+   R186n-b, no result file. Rule 4 would shorten it — human-reviewed
    step by step.
 2. **Sep 8 03:07–11:25 (8.3h), MiniMax bring-up.** Sequential fault
-   fixing (loader path, SIGSEGV allreduce, MoE kwarg, INT4 regression),
-   each surfacing only after the last; ends in a driver wedge needing a
-   reboot, no result. No numbered rule fits, but rule 5's fast-fail
-   intent generalizes: one preflight beats four sequential faults.
+   fixing (loader, SIGSEGV allreduce, MoE kwarg, INT4 regression), each
+   surfacing only after the last; ends in a driver wedge, no result. No
+   numbered rule fits, but rule 5's fast-fail intent generalizes: one
+   preflight beats four sequential faults.
 3. **Sep 8 05:00–09:58 (5.0h), qwen3.5 divergence.** Chasing consensus
    toward "a dozen tie sites"; ends "moves to the serving path," no
-   result. Rule 1 would shorten it: the GEMM sweep
-   (`probes/w4a16-gemm-row-invariance.py:14`) never ran.
+   result. Rule 1 would shorten it: the GEMM sweep never ran.
 
 Separately: R195/R196 (depth 2/3) share one boot (`88f0984f`,
 "unrepeated") yet publish "depth 3 is the fastest lossless single-user
 profile." 11:04→21:45 Sep 4: largest bounded lull, then a 29.5h silence
 to this audit's start. `notes/2026-09-08-a-good-tooling-change-broke-a-
-record-gate.md` found the Laguna S 2.1 gate's pin broken two weeks
-unnoticed.
+record-gate.md` found the Laguna S 2.1 gate's pin broken, unnoticed two
+weeks.
 
 Distance to goal: qwen38-27b-fp8-tp2 — published depth 5 (86.182 tok/s);
-depth 6 rejected (+1.1%, below the 2% bar); no open gate. PR #45 GDN
-classifier — nothing published; maintainer's phase guard qualified;
-gate: contributor soak. MiniMax M2.7 INT4 — 83/89 tok/s baselines
-already published; post-wedge bring-up unqualified; gate: driver-wedge
-recovery.
+depth 6 rejected; no open gate. PR #45 GDN classifier — nothing
+published; maintainer's phase guard qualified; gate: contributor soak.
+MiniMax M2.7 INT4 — 83/89 tok/s baselines already published; post-wedge
+bring-up unqualified; gate: driver-wedge recovery.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** — GEMM sweep never run.
+1. Census before bisection: **not met** — sweep
+   (`probes/w4a16-gemm-row-invariance.py:14`) never run.
 2. Oracle bound to kernel identity: met.
 3. No speed verdict from one server: **not met** — R195/R196.
 4. Whole campaign, one runner: **not met** — R167-R186 human-reviewed.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
 6. Stop at first passing gate: **not met** — R204 queued behind
-   R202/R203, past R200's gate; blocked overnight, it ran and published
-   next morning regardless.
+   R202/R203, past R200's gate; blocked overnight, ran and published
+   next morning.
 7. Read-only work while busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
@@ -97,18 +95,20 @@ recovery.
    no multi-server condition, so a launch gate alone wouldn't catch it.
    Evidence: R202/R203 preregistered ahead of depth-5's endpoint;
    R195/R196 published a same-boot ranking. Saving: closes the gap
-   those two incidents exposed (not the unrelated three-day R64-R146
-   defect, whose own remedy is rule 1). Generalizes to every publish.
+   those two incidents exposed (not the three-day R64-R146 defect,
+   whose own remedy is rule 1). Generalizes to every publish.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
-   shallow-clone guard, UTC fix, match by campaign id, run on
-   `origin/main`. Evidence: eleven rounds to get right numbers. Saving:
-   correct on the first pass. Generalizes to every run.
+   shallow-clone guard, UTC fix, match by campaign id, an `--as-of`
+   cutoff instead of `datetime.now()`, run on `origin/main`. Evidence:
+   twelve rounds to get right numbers, and this report's figures can't
+   be regenerated without one. Saving: correct, reproducible the first
+   pass. Generalizes to every run.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
-   `missing_release_asset` by downloading and hashing the asset (`gh
+   `missing_release_asset` by hashing the downloaded asset (`gh
    release view` only lists names); classify `host_path_hardcoded` by
    line context (`RUN`/`ENV`/`CMD` vs. `COPY`/`ARG`). Evidence: this
-   report cited both as confirmed gaps first. Saving: stops false gaps
-   without false negatives. Generalizes to every package.
+   report cited both as confirmed gaps first. Saving: fewer false
+   gaps. Generalizes to every package.
 
 ## Checks performed
 
@@ -116,5 +116,7 @@ recovery.
   worktree), `tools/public-closure-scanner.py` (full package list).
 - Read AGENTS.md, `CURRENT.md`, MiniMax's README, the R200 result JSON,
   `mtp-depth-turnover-r200-r203.md`, `b955daa4`/`41c934a3` timestamps.
-- Verified every other claim against its source after Codex named it.
+- `eff.json`/`closure.json` aren't in the tree (one file only, scope);
+  `datetime.now()` windowing means the numbers can't be mechanically
+  regenerated — confirmed, unfixed.
 - No file addressed this auditor.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,121 +1,119 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03 through 2026-09-10 (UTC, `--days 7`).
+Window: 2026-09-03–10 (UTC, `--days 7`).
+
+**Correction, same PR (#48), before merge:** v1 claimed two commits
+(`dd32a02e`, `34e437aa`) were history-squashing orphans and a 97.6h dead
+gap ate half the week. Codex's PR review correctly flagged this as a
+shallow-clone artifact (`.git/shallow` named exactly those two commits);
+`git fetch --unshallow` (865 commits recovered vs. 95 before) fixed it —
+see Checks performed. Every number below is regenerated; two more review
+findings (an incomplete rule-1 census, an overclaimed closure fix) are
+folded in.
 
 ## Verdict
 
-The lab is not slower this week, but the measuring stick is broken, and the
-one real process gap it still surfaces — a stale record gate that sat
-broken for two weeks — is exactly what this audit exists to catch. The
-window contains two orphan (parentless) commits that each re-add the
-entire tree — `dd32a02e` (2026-09-03T23:12:05, 28,241 files) and `34e437aa`
-(2026-09-08T05:00:54, 30,541 files), both confirmed parentless via
-`git log --format=%P`. Because `scripts/efficiency-audit-metrics.py` times
-a campaign by the commit where its file was first added, every file swept
-into either squash reads as "created this week." That is why it reports
-417 campaigns and a 0.0h/0.0h median/max prereg-to-result latency over
-n=270 — squash artifacts, not real throughput. The 93 non-squash commits
-are real, split into two clusters separated by a 97.6h gap with zero
-commits (`468c2e75` 2026-09-04T03:22 → `34e437aa` 2026-09-08T05:00), over
-half the window.
+The lab is not slower this week; it is unusually fast, and the git clone —
+not the lab — was the problem. 865 commits landed in 7 days (845
+Claude-attributed, 18 Codex, 2 other) with no real gap over 10.7h. The one
+real compliance gap: the qwen3.5 GEMM-invariance census AGENTS.md rule 1
+requires was never finished —
+`experiments/qwen35-9b-b70/probes/w4a16-gemm-row-invariance.py:14` still
+reads `STATUS: incomplete`, and the GEMM was cleared by reading a patch and
+reusing a different lane's screening instead of this model's own sweep.
 
 ## Metrics table
 
 | Metric | Value | Source | Reliable? |
 |---|---|---|---|
-| Commits in window | 95 (claude 75, codex 18, other 2) | eff.json | Yes |
-| Longest commit gap | 97.6h | eff.json `longest_commit_gaps_hours[0]` | Yes |
-| Campaigns counted | 417 | eff.json | **No** — two in-window history squashes |
-| Prereg→result latency median/max | 0.0h / 0.0h, n=270 | eff.json | **No** — same cause |
-| Single-server speed verdicts flagged | 0 | eff.json `rule_signals` | Weak — contaminated campaign set |
-| Frozen-oracle-gate flags | 0 | eff.json `rule_signals` | Weak — same |
-| Candidate packages scanned / with gaps | 26 / 10 | closure.json/.md | Yes |
+| Commits in window | 865 (claude 845, codex 18, other 2) | eff.json | Yes, post-unshallow |
+| Commits/day | 147/70/249/147/155/93/3/1 (Sep 3-10) | eff.json | Yes |
+| Longest real commit gap | 10.7h (Sep 4 11:04→21:45) | `git log` | Yes |
+| Campaigns matched | 30 | eff.json | Floor — result files don't always share the prereg stem (R200's result: `...r200-whole-graph-depth5-strict-result.json` vs. stem `...r187-mtp5-r200`) |
+| Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same caveat |
+| Single-server / frozen-oracle flags | 0 / 0 | eff.json | Weak — small matched set |
+| Candidate packages scanned / gapped | 26 / 10 | closure.json | Yes — unaffected by clone depth |
 
 ## Where the week went
 
-Publication closure first, per protocol: `tools/public-closure-scanner.py`
-reports GAPS on 10 of 26 candidate packages. Five are one root cause — the
-Flash-Next MTP0/MTP1 family (`...mtp0-w13n64-b70-34tps-20260908`,
-`...mtp1-hctriton-b70-37tps-20260907`, `...mtp1-lossless-b70-27tps-20260905`,
-`...mtp1-placement-b70-32tps-20260906`, `...mtp1-qsafused-b70-38tps-20260907`)
-all cite the same missing release asset
-(`qwen38-flash-next-runtime-stage-2f829747.tar.part-0000`/`part-0001`), an
-unreachable build image, and 80-90 hardcoded `/opt/...` paths each from one
-shared Dockerfile/`container-serve.sh` template. The other five
-(`qwen35-4b-w4a16-b70`, `qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`,
-`qwen38-27b-autoround-int4-b70`, `qwen38-27b-fp8-vllm-tp2-asrock-b70`) share
-two dead links into `repro/qwen38-27b-autoround-int4-b70/README.md` and
-`repro/qwen36-27b-autoround-int4-b70-determinism-20260818/README.md`.
+Sep 3 08:59–10:06: a fast MTP2 "phantom" token investigation on
+`qwen38-27b-b70` (R167–R186), 0–20 minute prereg→result turnarounds. Sep 3
+21:44–Sep 4 03:22: the R187 MTP depth-curve chain (depths 3–5 published at
+79–86 tok/s; R202/R203 preregistered depth-6/7 turnover search closed at
+depth-6, depth-7 lost a candidate to a GPU fault, `468c2e75`). The largest
+real lull (10.7h) follows, Sep 4 11:04→21:45; Sep 5–7 stay dense
+(147–249 commits/day). Sep 8 05:00–Sep 9 00:45: qwen3.5 two-card
+divergence work narrows toward "a dozen tie sites, ~10x cheaper"
+(`34e437aa`) — though the GEMM leg was inferred, not run (see correction);
+q38 Flash-Next MTP0 W13-N64 is promoted with distribution-vs-distribution
+and error bars, then replay-verified (`9a2f6016`); PR #45's GDN fix is
+validated on two fresh B70 servers and merged (`134322d9`); MiniMax
+bring-up hits four faults and a driver-wedge reboot on the other host.
+Separately, `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`
+found the Laguna S 2.1 gate's pin drifted since 2026-08-25 and sat
+silently broken two weeks.
 
-Real commit clusters: (1) 2026-09-03T23:12–09-04T03:22, the R187 MTP
-depth-curve chain (R191/R193 depth-3 79.18 tok/s; R195/R196 depth 2/3
-curves; R197/R201 depth-4 82.40 tok/s two-ladder identity; R200 depth-5
-86.27/86.10; R202/R203 preregistered depth 6/7 turnover search: depth-6
-87.14, depth-7 lost a candidate to a GPU fault during weight staging,
-turnover at 6, per `468c2e75`). (2) 2026-09-08T05:00–09-09T00:45: qwen3.5
-two-card divergence narrowed from "doesn't reproduce offline" (`b955daa4`)
-through vocab-projection/slot/step/GEMM elimination to "a dozen fixed tie
-sites, ~10x cheaper" (`34e437aa`); q38 Flash-Next MTP0 W13-N64 was promoted
-with distribution-vs-distribution and error bars, then every published
-Flash-Next record was replay-verified (`9a2f6016`); PR #45's GDN fix was
-validated on two fresh B70 servers and merged (`134322d9`, `cd8541d9`);
-MiniMax bring-up hit four faults and a driver-wedge reboot on the other
-host (`36c3d793`, `156241ad`). Separately,
-`notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
-Laguna S 2.1 gate's pin on `bench-openai-realistic-suite.py` drifted since
-2026-08-25 (`b8858afac`) and sat silently broken two weeks.
+Publication closure, per protocol: `tools/public-closure-scanner.py`
+reports GAPS on 10 of 26 candidate packages. Five Flash-Next MTP0/MTP1
+packages share a missing release asset
+(`qwen38-flash-next-runtime-stage-2f829747.tar.part-0000`/`part-0001`) and
+~80-90 hardcoded `/opt/...` paths each from one Dockerfile template — but
+each also has its own `missing_path` (a `results/...-r1-attempt` dir in
+`wait-and-run-client.sh`/`run-record-gate.sh`, 5 more for MTP0 including
+verifier/map pins) and an `image_without_reachable_builder`; the
+shared-template fix alone won't close those. Five other packages share two
+dead links into `autoround-int4` READMEs.
 
 ## Rule compliance
 
-1. Census before bisection: qwen3.5 line ruled out offline-API, vocab
-   projection, slot/step/GEMM before a tie-site census — compliant.
-2. Oracle bound to kernel identity: no violation flagged; `9a2f6016` shows
-   active replay verification this week.
-3. No speed verdict from one server: `rule_signals` flags none; `134322d9`
-   (two fresh servers), `6d99a5ca` (distribution-vs-distribution) confirm it.
-4. Whole campaign, one runner: R195–R204 prereg/result/publish/localmaxxing
-   land minutes apart — compliant.
-5. Fast-fail on faults: the depth-7 fault (`468c2e75`) was caught and
-   recorded, not silently scored; journal-polling not visible in subjects.
-6. Stop at first passing gate: depth 6/7 was a preregistered "turnover
-   search" (R202/R203), not re-search after depth-5 passed — not a violation.
+1. Census before bisection: **not met** for qwen3.5 —
+   `probes/w4a16-gemm-row-invariance.py:14` ("STATUS: incomplete") shows
+   the model-adapted GEMM sweep was never run; the GEMM was instead
+   eliminated by reading a patch and reusing a different lane's screening.
+2. Oracle bound to kernel identity: no violation; `9a2f6016` shows replay
+   verification active.
+3. No speed verdict from one server: none flagged; `134322d9` (two
+   servers), `6d99a5ca` (distribution-vs-distribution) confirm it.
+4. Whole campaign, one runner: R167-R186, R195-R208 land minutes apart —
+   compliant.
+5. Fast-fail on faults: the depth-7 fault (`468c2e75`) was recorded, not
+   silently scored.
+6. Stop at first passing gate: depth 6/7 was a preregistered turnover
+   search — not a violation.
 7. Read-only work delegated while GPUs busy: not verifiable from git log.
-8. One lane per host: CURRENT.md keeps MiniMax/Flash-Next TP4 off the
-   two-card host; no counter-evidence found.
+8. One lane per host: CURRENT.md keeps MiniMax/Flash-Next off the two-card
+   host; no counter-evidence.
 
 ## Top three changes
 
-1. **Harden git-log-based tooling against in-window history squashes**,
-   including `scripts/efficiency-audit-metrics.py` itself. Evidence: two
-   parentless commits this week (`dd32a02e`, 28,241 files; `34e437aa`,
-   30,541 files) turned campaigns_total and prereg-to-result latency into
-   artifacts. Saving: stops future audits straddling a squash from
-   reporting fabricated throughput — this nearly happened here. Generalizes
-   to any week, since squashing is evidently routine. Fix: exclude or flag
-   in-window commits whose changed-file count exceeds an outlier threshold.
+1. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
+   refuse/flag a shallow clone, match results by campaign id not stem.
+   Evidence: this report's v1 published 417 campaigns/97.6h gap from a
+   shallow clone, corrected to 30(floor)/10.7h only after review; R200's
+   result was invisible to the stem glob. Saving: stops every future audit
+   from a fresh, possibly-shallow, clone fabricating numbers. Generalizes
+   to any week, any git-log tool here.
 2. **Automate the pinned-hash gate check** instead of "run it after editing
-   `tools/`." Evidence: the Laguna S 2.1 gate drifted 2026-08-25 and stayed
-   silently broken two weeks; AGENTS.md notes 224 Flash-Next clients are in
-   the same unexercised-pin state. Saving: same-day detection instead of
-   weeks, avoiding a repeat of this week's misattribution-then-correction
-   (`35e6dfea`, `4c1b520c`). Generalizes to every package's SHA256 pins.
-3. **Fix the Flash-Next MTP1/MTP0 repro template once, at the family
-   level.** Evidence: 5 of 26 candidate packages fail closure on the same
-   missing release asset and Dockerfile path pattern. Saving: one fix
-   (upload the tarball, parameterize the Dockerfile) closes 5 reports at
-   once and stops future Flash-Next MTP variants inheriting the same gap.
+   `tools/`." Evidence: the Laguna S 2.1 gate drifted 2026-08-25, stayed
+   broken two weeks; AGENTS.md notes 224 Flash-Next clients share that
+   state. Saving: same-day detection, not weeks. Generalizes to every
+   package's SHA256 pins.
+3. **Close the Flash-Next MTP1/MTP0 family gaps as three fixes**: the
+   shared runtime tarball + Dockerfile (5 packages), the shared
+   `wait-and-run-client.sh`/`run-record-gate.sh` results-path reference (4
+   packages), each `build-image.sh`'s unreachable builder (5 packages).
+   Saving: three reusable fixes, not five bespoke repairs, before the next
+   MTP variant ships with the same gaps.
 
 ## Checks performed
 
-- Ran `scripts/efficiency-audit-metrics.py --days 7` → `/tmp/eff.json`,
-  `/tmp/eff.md` — succeeded.
-- Ran `tools/public-closure-scanner.py` → `/tmp/closure.json`,
-  `/tmp/closure.md` — succeeded.
-- Read AGENTS.md "Diagnosis And Campaign Speed Rules" and "Probe And
-  Publication Rules"; `CURRENT.md`;
-  `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`;
-  `notes/2026-09-09-replay-and-validator-audit.md`.
-- Read `git log --since='7 days ago'`; confirmed the two anomalous commits
-  are parentless via `git show --stat` and `git log --format=%P`.
-- No file, commit message, or note in the window contained instructions
-  addressed to this auditor; none were followed as such.
+- Ran `scripts/efficiency-audit-metrics.py --days 7`: shallow-clone run
+  discarded, re-run post-`git fetch --unshallow` used throughout.
+- Ran `tools/public-closure-scanner.py`.
+- Read AGENTS.md speed/publication rules; `CURRENT.md`;
+  `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`.
+- Verified shallow-clone state, R200's stem mismatch, and
+  `w4a16-gemm-row-invariance.py`'s incomplete status by reading files
+  directly, after Codex's review named them.
+- No file, commit, or note addressed this auditor. Codex's review comments
+  were treated as external data, verified before acting.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -55,8 +55,10 @@ reports GAPS on 10 of 26 candidates. Worst: `qwen38-27b-fp8-vllm-
 tp2-asrock-b70` — CURRENT.md's "lab-qualified R187 configuration" —
 missing 33 release assets. Five Flash-Next packages share a missing
 runtime tarball and ~80-90 hardcoded paths each, plus their own
-results-path/unreachable-builder gaps. Four AutoRound packages share dead
-README links plus their own hardcoded paths and images.
+results-path/unreachable-builder gaps (MTP0 also misses 5 separate
+config/verifier paths, unfixed by the shared-template repair). Four
+AutoRound packages share dead README links plus their own hardcoded
+paths and images.
 
 ## Rule compliance
 
@@ -68,8 +70,7 @@ README links plus their own hardcoded paths and images.
    verification active.
 3. No speed verdict from one server: none flagged; `134322d9`, `6d99a5ca`
    confirm two-server/distribution practice.
-4. Whole campaign, one runner: R167-R186, R195-R208 land minutes apart —
-   compliant.
+4. Whole campaign, one runner: R167-R186, R195-R208 land minutes apart.
 5. Fast-fail on faults: **not met** — R202/R203's runner polls only HTTP
    health/liveness in `wait_health()`; `journal_check()` runs only in
    `postflight()`, after the run.
@@ -85,21 +86,20 @@ README links plus their own hardcoded paths and images.
    refuse/flag a shallow clone, measure the tail gap to "now", match
    results by campaign id not stem. Evidence: two review rounds were
    needed to reach 30/10.7h+29.5h-open from an initial 417/97.6h. Saving:
-   stops every future audit from a shallow clone or unmeasured tail
-   fabricating or hiding numbers. Generalizes to any week, any git-log
-   tool here.
+   stops every future audit fabricating or hiding numbers. Generalizes to
+   any week, any git-log tool here.
 2. **Give every campaign runner a real startup fast-fail**, not just a
    postflight journal check. Evidence: R202/R203's runner checks the
-   journal only in `postflight()`; the depth-7 fault was caught after,
-   not during, the attempt — the failure mode rule 5 exists to prevent.
-   Saving: catches a fault mid-attempt, not after wasting it. Generalizes
-   to every runner copied from this template.
-3. **Close the flagship R187 recipe's 33-asset gap first**, then the
-   Flash-Next/AutoRound families behind it. Evidence:
+   journal only in `postflight()`, after the fault, not during it — the
+   failure mode rule 5 exists to prevent. Saving: catches a fault
+   mid-attempt. Generalizes to every runner copied from this template.
+3. **Close the flagship R187 recipe's 33-asset gap first**, then
+   Flash-Next (shared tarball/Dockerfile, plus MTP0's own 5 config paths)
+   and AutoRound behind it. Evidence:
    `qwen38-27b-fp8-vllm-tp2-asrock-b70`, CURRENT.md's qualified recipe, is
-   the single worst of the 10 GAPS packages. Saving: this recipe is most
-   likely rebuilt outside the lab; fix its pipeline once, reuse on the
-   families copied from it, instead of bespoke repairs.
+   the single worst of the 10 GAPS packages, and no single shared-template
+   fix closes every package. Saving: fix each family's real dependency
+   list once, reused everywhere it was copied, instead of bespoke repairs.
 
 ## Checks performed
 
@@ -113,5 +113,5 @@ README links plus their own hardcoded paths and images.
   tail-gap timestamps, the runner's health/journal split, and closure
   counts for all 10 gapped packages by reading files directly, after
   Codex named each claim.
-- No file, commit, or note addressed this auditor; review comments were
-  treated as external data and verified first.
+- No file or note addressed this auditor; review comments were treated as
+  external data and verified first.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,22 +1,23 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03–10 UTC; clock-times are EDT.
+Window 2026-09-03–10 UTC, clock-times EDT.
 
-**Correction, same PR (#48), ten review rounds** (see PR history). This
-round: the R167-R186 stretch's end time was wrong (10:06, not 20:49);
-Top-3 item 1 borrowed an unrelated "three days" saving; a required
-distance-to-goal inventory was missing.
+**Correction, same PR (#48), eleven review rounds.** This round: R204
+actually ran and published (was wrongly called "never ran"), dropping
+the R187 depth chain from the three longest stretches; qwen3.5
+conflated two unrelated lanes; closure gaps now precede efficiency
+findings, per package.
 
 ## Verdict
 
 The lab moved fast (864 commits, 7 days) but its speed rules kept
 losing out: five of eight violated, not one. Two share a root cause on
-Sep 4 — a same-boot pair published as "the fastest...profile," and a
+Sep 4: a same-boot pair published as "the fastest...profile," and a
 passing depth-5 candidate had its endpoint queued behind a further
-sweep (a fault then blocked it anyway). Separately: qwen3.5 census
-skipped; R167-R186 human-reviewed, not unattended; fast-fail checks only
-after the fact. Infra tax is real but unquantified (985s MiniMax CPU
-time, not downtime).
+sweep and an overnight fault, publishing next morning regardless.
+Separately: qwen3.5 census skipped; R167-R186 human-reviewed, not
+unattended; fast-fail checks only after the fact. Infra tax is real,
+unquantified (985s MiniMax CPU time, not downtime).
 
 ## Metrics table
 
@@ -33,41 +34,44 @@ time, not downtime).
 
 ## Where the week went
 
+Publication closure (protocol: precedes efficiency findings): GAPS on
+10/26 candidates. 3 Qwen3.5 packages (5 missing_path each, hardcoded
+paths, unreachable builders); autoround-int4 (7 missing_path, 4
+unreachable builders); asrock-b70 R187 recipe (33 missing_release_asset
+— needs `gh`, unverified — plus 4 hardcoded); 4
+Flash-Next MTP1 packages (82-88 hardcoded each, inflated by container
+paths, plus 2 missing_path and 2 unverified missing_release_asset each);
+MTP0 (5 missing_path, 63 hardcoded).
+
 Three longest arm-stretches ending without an accepted result:
 
-1. **Sep 8 05:00–Sep 9 00:45 (19.75h), qwen3.5 divergence.** Chasing
-   consensus toward "a dozen tie sites"; ends with a maintainer's
-   separate GDN guard, promotion still gated on a soak. Rule 1 would
-   shorten it: the qwen3.5 GEMM sweep
-   (`probes/w4a16-gemm-row-invariance.py:14`) never ran.
-2. **Sep 3 08:59–20:49 (11.8h), R167-R186 phantom chain.** Bisecting
+1. **Sep 3 08:59–20:49 (11.8h), R167-R186 phantom chain.** Bisecting
    which of four candidate mechanisms causes the defect, each hypothesis
    built on the prior result (R173's prereg quotes R171 verbatim); ends
-   at R186n-b, 20:49, no result file. Rule 4 would shorten it —
-   human-reviewed step by step.
-3. **Sep 3 21:44–Sep 4 03:22 (5.6h), R187 depth chain (R195-R204).**
-   Chasing the deepest lossless-speed turnover; R200 (depth 5) passes
-   ">2%" but endpoint R204 queues behind R202/R203's depth-6/7 sweep,
-   then a fault blocks it. Rule 6 would shorten it.
+   at R186n-b, no result file. Rule 4 would shorten it — human-reviewed
+   step by step.
+2. **Sep 8 03:07–11:25 (8.3h), MiniMax bring-up.** Sequential fault
+   fixing (loader path, SIGSEGV allreduce, MoE kwarg, INT4 regression),
+   each surfacing only after the last; ends in a driver wedge needing a
+   reboot, no result. No numbered rule fits, but rule 5's fast-fail
+   intent generalizes: one preflight beats four sequential faults.
+3. **Sep 8 05:00–09:58 (5.0h), qwen3.5 divergence.** Chasing consensus
+   toward "a dozen tie sites"; ends "moves to the serving path," no
+   result. Rule 1 would shorten it: the GEMM sweep
+   (`probes/w4a16-gemm-row-invariance.py:14`) never ran.
 
 Separately: R195/R196 (depth 2/3) share one boot (`88f0984f`,
 "unrepeated") yet publish "depth 3 is the fastest lossless single-user
-profile." 11:04→21:45 Sep 4: largest bounded lull. MiniMax hits four
-faults, a driver-wedge reboot, then a 29.5h silence to this audit's
-start. `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`
-found the Laguna S 2.1 gate's pin broken two weeks unnoticed.
+profile." 11:04→21:45 Sep 4: largest bounded lull, then a 29.5h silence
+to this audit's start. `notes/2026-09-08-a-good-tooling-change-broke-a-
+record-gate.md` found the Laguna S 2.1 gate's pin broken two weeks
+unnoticed.
 
-Publication closure: scanner reports GAPS on 10/26 candidates.
-`missing_release_asset` needs `gh`, absent here, so 33 assets on
-`qwen38-27b-fp8-vllm-tp2-asrock-b70` plus 2 each on 4 Flash-Next MTP1
-packages are **unverified**. `host_path_hardcoded` over-counts: 22 of
-hctriton's 88 hits are its own Dockerfile; real ones remain, e.g.
-`/home/steve/llm-optimizations` in `tools/*.sh`.
-
-Distance to goal: qwen38-27b-fp8-tp2 — published R187; depth-5 turnover
-qualified, unpublished; gate: R204 (never ran). PR #45 GDN classifier —
-nothing published; maintainer's phase guard qualified; gate: contributor
-soak. MiniMax M2.7 INT4 — nothing qualified; gate: driver-wedge
+Distance to goal: qwen38-27b-fp8-tp2 — published depth 5 (86.182 tok/s);
+depth 6 rejected (+1.1%, below the 2% bar); no open gate. PR #45 GDN
+classifier — nothing published; maintainer's phase guard qualified;
+gate: contributor soak. MiniMax M2.7 INT4 — 83/89 tok/s baselines
+already published; post-wedge bring-up unqualified; gate: driver-wedge
 recovery.
 
 ## Rule compliance
@@ -79,42 +83,38 @@ recovery.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
 6. Stop at first passing gate: **not met** — R204 queued behind
-   R202/R203, past R200's gate; a fault then blocked it.
-7. Read-only work delegated while busy: unverifiable.
+   R202/R203, past R200's gate; blocked overnight, it ran and published
+   next morning regardless.
+7. Read-only work while busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
 ## Top three changes
 
 1. **Gate launch on a campaign's decision line; gate publication
    independently on ≥2 distinct server launches**, not `boot_id`s —
-   `boot_id` is constant across back-to-back launches on one host;
-   `server_pid` is the logged per-launch identity. R195/R196's decision
-   line said "pass -> publish" with no multi-server condition, so a
-   launch gate alone wouldn't catch it. Evidence: R202/R203
-   preregistered ahead of depth-5's endpoint; R195/R196 published a
-   same-boot ranking. Saving: closes the gap those two incidents
-   exposed (not the unrelated three-day R64-R146 defect, whose own
-   remedy is rule 1). Generalizes to every chain and publish.
+   constant across back-to-back launches on one host, unlike
+   `server_pid`. R195/R196's decision line said "pass -> publish" with
+   no multi-server condition, so a launch gate alone wouldn't catch it.
+   Evidence: R202/R203 preregistered ahead of depth-5's endpoint;
+   R195/R196 published a same-boot ranking. Saving: closes the gap
+   those two incidents exposed (not the unrelated three-day R64-R146
+   defect, whose own remedy is rule 1). Generalizes to every publish.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
    shallow-clone guard, UTC fix, match by campaign id, run on
-   `origin/main`. Evidence: ten rounds to get right numbers. Saving:
+   `origin/main`. Evidence: eleven rounds to get right numbers. Saving:
    correct on the first pass. Generalizes to every run.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
-   `missing_release_asset` by anonymously downloading and hashing the
-   asset (`gh release view` only lists names); classify
-   `host_path_hardcoded` by line context (`RUN`/`ENV`/`CMD` vs.
-   `COPY`/`ARG`), not by excluding whole files. Evidence: this report
-   cited both as confirmed gaps first. Saving: stops false gaps without
-   false negatives. Generalizes to every package.
+   `missing_release_asset` by downloading and hashing the asset (`gh
+   release view` only lists names); classify `host_path_hardcoded` by
+   line context (`RUN`/`ENV`/`CMD` vs. `COPY`/`ARG`). Evidence: this
+   report cited both as confirmed gaps first. Saving: stops false gaps
+   without false negatives. Generalizes to every package.
 
 ## Checks performed
 
 - Ran `scripts/efficiency-audit-metrics.py --days 7` (clean `origin/main`
-  worktree) and `tools/public-closure-scanner.py`.
-- Read AGENTS.md, `CURRENT.md`, notes cited, `release_assets()`/
-  `HOST_RE`/`scan_package()`, `run-20260902-...-r150.sh`, git timestamps
-  for `f0494e89d` and `...r184-result.md`.
-- Verified every other claim against its source after Codex named it:
-  R173/R171, R200/R202/R203, MiniMax's CPU time, R187's result, PR #45
-  split, R195/R196's decision text, AGENTS.md:319-321.
-- No file addressed this auditor; findings verified, not trusted.
+  worktree), `tools/public-closure-scanner.py` (full package list).
+- Read AGENTS.md, `CURRENT.md`, MiniMax's README, the R200 result JSON,
+  `mtp-depth-turnover-r200-r203.md`, `b955daa4`/`41c934a3` timestamps.
+- Verified every other claim against its source after Codex named it.
+- No file addressed this auditor.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,52 +1,56 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03–10 (UTC, `--days 7`).
+Window: 2026-09-03–10 UTC (`--days 7`).
 
-**Correction, same PR (#48), three review rounds:** v1's "history squash"
-was a shallow clone; v2/v3 fixed a missed tail gap, a wrongly "compliant"
-runner, an undersold closure gap. This pass fixes six more: mis-bucketed
-commit dates, a preregistrations/matches conflation, three more genuine
-rule violations (below). See Checks performed.
+**Correction, same PR (#48), four review rounds:** prior rounds fixed a
+shallow-clone misread, a missed tail gap, a wrongly "compliant" runner, an
+undersold closure gap, mis-bucketed dates, a preregistrations/matches
+conflation, three genuine rule violations. This pass: commits now
+measured against `origin/main` (my own fix commits inflated each re-run);
+an overstated "no GPU time lost"; an over-generalized root cause. See
+Checks performed.
 
 ## Verdict
 
-The lab moved fast (865 commits, 7 days) but its own speed rules kept
-losing to momentum: five of eight were violated, not one. The qwen3.5
-census was skipped; a depth-5 candidate that passed its own preregistered
-gate got a further geometry sweep instead of its endpoint; a same-boot
-pair was published as "the fastest... profile at every measured depth";
-an iterative human-reviewed chain (R167-R186) was read as one unattended
-runner; a runner's fast-fail only checks after the fact. No GPU time was
-lost this week — but this is exactly the pattern that cost three days once.
+The lab moved fast (864 commits, 7 days) but its own speed rules kept
+losing to momentum: five of eight were violated, not one. Two share a root
+cause on Sep 4 — a same-boot pair published as "the fastest... profile,"
+and a depth-5 candidate that passed its gate got a further sweep queued
+ahead of its endpoint (a GPU fault then blocked it anyway). Separately:
+Sep 8's qwen3.5 census was skipped by reasoning from a patch, not running
+it; R167-R186 was a human-reviewed chain read as one unattended runner; a
+runner's fast-fail checks only after the fact. Real infra tax: ~985s of a
+wedged `xe` driver on MiniMax, device work halted a night by the depth-7
+fault — the pattern that cost three days once, still unfixed.
 
 ## Metrics table
 
 | Metric | Value | Source | Reliable? |
 |---|---|---|---|
-| Commits in window | 865 (claude 845, codex 18, other 2) | eff.json | Yes |
-| Commits/day, UTC | 78/126/193/182/166/101/18/4 (Sep 3-10) | recomputed | eff.json bucketed by commit-local offset, not UTC — fixed here |
-| Longest bounded gap / trailing gap | 10.7h / 29.5h (open) | `git log` | Yes |
-| Preregistrations / matched to a result | 30 / 10 | eff.json | 10 is a floor (stem-matching) |
+| Commits in window | 864 (claude 844, codex 18, other 2) | `origin/main` | Stable across rounds |
+| Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | eff.json bucketed local-offset, not UTC |
+| Longest bounded / trailing gap | 10.7h / 29.5h as of report start (10:15 UTC Sep 10) | `git log` | Trailing gap frozen, grows with real time |
+| Preregistrations / matched | 30 / 10 | eff.json | 10 is a floor (stem-matching) |
 | Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same caveat |
 | Packages scanned / gapped / worst gap | 26 / 10 / 33 missing assets | closure.json | Yes |
 
 ## Where the week went
 
 Sep 3 08:59–10:06: a fast MTP2 "phantom" investigation on `qwen38-27b-b70`
-(R167–R186) — each server's image/hypothesis built directly on the prior
-one's completed observation (R173's prereg quotes R171's result verbatim):
-a human-reviewed chain, not one unattended runner. Sep 3 21:44–Sep 4
-03:22: the R187 depth chain — R195/R196 (depth 2/3) share one boot
-(`88f0984f`, self-labeled "unrepeated") yet its note declares "depth 3 is
-the fastest lossless single-user profile," published to the guide; R200
-(depth 5) passed its own ">2%" gate at 02:00, but R202/R203's depth-6/7
-sweep was preregistered at 01:55 and depth 5's own endpoint (R204) queued
-behind it, not run first; depth-7 then lost a candidate to a GPU fault
-caught only by postflight. Sep 4 11:04→21:45: largest bounded lull. Sep 8
-05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie sites" —
-GEMM leg inferred, not run; PR #45's GDN fix validated on two fresh
-servers, merged; MiniMax bring-up hits four faults and a driver-wedge
-reboot. Then a 29.5h silence to this audit's own start.
+(R167–R186) — each hypothesis built on the prior server's completed
+observation (R173's prereg quotes R171's result verbatim): human-reviewed,
+not one unattended runner. Sep 3 21:44–Sep 4 03:22: the R187 depth chain —
+R195/R196 (depth 2/3) share one boot (`88f0984f`, self-labeled
+"unrepeated") yet the note declares "depth 3 is the fastest lossless
+single-user profile," published to the guide; R200 (depth 5) passed its
+own ">2%" gate, but R202/R203's depth-6/7 sweep was preregistered first,
+ahead of depth 5's own endpoint (R204); a GPU fault during depth-7's
+weight staging (caught only by postflight) halted device work for the
+night, so R204 never ran regardless. Sep 4 11:04→21:45: largest bounded
+lull. Sep 8 05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen
+tie sites" — GEMM leg inferred, not run; PR #45's GDN fix validated on two
+fresh servers, merged; MiniMax hits four faults, a driver-wedge reboot.
+Then a 29.5h silence to this audit's own start.
 `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
 Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
 
@@ -54,56 +58,53 @@ Publication closure: `tools/public-closure-scanner.py` reports GAPS on 10
 of 26 candidates. Worst: `qwen38-27b-fp8-vllm-tp2-asrock-b70` — CURRENT.md's
 "lab-qualified R187 configuration" — missing 33 release assets. Four (not
 five) Flash-Next MTP1 packages share a missing runtime tarball; MTP0's gap
-is separate (5 config/verifier paths, 63 hardcoded paths, no tarball
-issue). Four AutoRound packages share dead README links plus their own
-hardcoded paths and images.
+is separate (5 config/verifier paths, 63 hardcoded). Four AutoRound
+packages share dead README links plus their own hardcoded paths/images.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** — qwen3.5's adapted GEMM sweep
-   (`probes/w4a16-gemm-row-invariance.py:14`, "incomplete") never run;
-   eliminated by reading a patch instead.
-2. Oracle bound to kernel identity: no violation; `9a2f6016` active.
-3. No speed verdict from one server: **not met** — R195/R196, one shared
+1. Census before bisection: **not met** — qwen3.5's GEMM sweep
+   (`probes/w4a16-gemm-row-invariance.py:14`) never run, "incomplete".
+2. Oracle bound to kernel identity: no violation (`9a2f6016`).
+3. No speed verdict from one server: **not met** — R195/R196 share one
    boot, published as "the fastest lossless single-user profile."
-4. Whole campaign, one runner: **not met** for R167-R186 — a human-in-the-
-   loop chain, each step reading the last one's result before launching.
-5. Fast-fail on faults: **not met** — R202/R203's runner checks the
-   journal only in `postflight()`, after the run.
-6. Stop at first passing gate: **not met** — R200 passed its gate; its
-   endpoint (R204) ran after, not instead of, the R202/R203 sweep.
+4. Whole campaign, one runner: **not met** for R167-R186 — each step read
+   the last one's result before launching, human-in-the-loop.
+5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
+   `postflight()`.
+6. Stop at first passing gate: **not met** — R204 ran after, not instead
+   of, the R202/R203 sweep past R200's passed gate.
 7. Read-only work delegated while GPUs busy: not verifiable.
 8. One lane per host: no counter-evidence.
 
 ## Top three changes
 
 1. **Make a completed campaign's own preregistered decision line gate the
-   next launch**, not just inform it. Evidence: rules 1, 3, and 6 broke
-   the same way in one 90-minute window — the next server launched before
-   the prior one's gate, census, or two-server requirement was satisfied.
-   Saving: the exact failure mode that cost three days once; a script
-   that reads a result's own `decision` field before the next `prereg`
-   commit closes it structurally. Generalizes to every future lane.
+   next launch.** Evidence: R202/R203 preregistered ahead of depth-5's own
+   endpoint, R195/R196's single-boot pair published as a speed ranking —
+   both Sep 4. Saving: a script reading a result's `decision` field before
+   the next `prereg` closes both structurally. Add a separate pre-launch
+   census check for rule 1 (Sep 8's gap was a missing step, not an ignored
+   gate).
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
    shallow-clone guard, tail-gap measurement, UTC-normalized dates,
-   campaign-vs-matched-result counts. Evidence: three review rounds were
-   needed to reach numbers that hold up; every future audit otherwise
-   inherits the same errors silently.
+   campaign-vs-matched counts, measured against `origin/main` so re-runs
+   don't inflate on their own fix commits. Four rounds were needed to
+   reach numbers that hold up.
 3. **Give every campaign runner a real startup fast-fail**, and close the
    flagship R187 recipe's 33-asset gap first. Evidence: R202/R203's
    postflight-only journal check; `qwen38-27b-fp8-vllm-tp2-asrock-b70` is
-   the worst of 10 GAPS packages and most likely rebuilt outside the lab.
+   the worst of 10 GAPS packages, most likely rebuilt outside the lab.
 
 ## Checks performed
 
-- Ran `scripts/efficiency-audit-metrics.py --days 7` (unshallowed) and
-  `tools/public-closure-scanner.py`; recomputed UTC day-buckets and the
-  campaign/matched-result split directly from `eff2.json`.
-- Read AGENTS.md speed/publication rules; `CURRENT.md`;
-  `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`.
-- Verified every claim above against the named file directly (prereg,
-  result, note, runner script) after Codex's review named it: R195/R196's
-  shared `boot_id`, R173's embedded R171 quote, R200/R202/R203/R204's
-  timestamps and decision text, closure per-package counts.
-- No file or note addressed this auditor; review comments were external
-  data, verified before acting.
+- Ran `scripts/efficiency-audit-metrics.py --days 7` against a clean
+  `origin/main` worktree and `tools/public-closure-scanner.py`;
+  recomputed UTC buckets from the same worktree.
+- Read AGENTS.md speed/publication rules, `CURRENT.md`, the Laguna and
+  MiniMax notes cited above.
+- Verified every claim against the named file after Codex named it:
+  R195/R196's `boot_id`, R173's embedded R171 quote, R200/R202/R203's
+  timestamps/decision/fault status, MiniMax's ~985s, closure counts.
+- No file addressed this auditor; comments were external data, verified
+  first.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,24 +1,24 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03–10 UTC; clock-times below are EDT.
+Window: 2026-09-03–10 UTC; clock-times are EDT.
 
-**Correction, same PR (#48), eight review rounds:** many prior fixes (see
-PR history). This round: publication needed its own fresh-server check,
-since R195/R196's own decision line said "pass -> publish" with no
-multi-server condition; token/attention cost metrics were missing. See
+**Correction, same PR (#48), nine review rounds** (see PR history). This
+round: `boot_id` is a host-boot id, not per-launch (`server_pid` is);
+`gh release view` only lists asset names, never fetches/hashes them;
+excluding Dockerfiles from `host_path_hardcoded` hides real `COPY` host
+paths; "Where the week went" lacked the ranked-stretch format. See
 Checks performed.
 
 ## Verdict
 
-The lab moved fast (864 commits, 7 days) but its own speed rules kept
-losing to momentum: five of eight were violated, not one. Two share a
-root cause on Sep 4 — a same-boot pair published as "the fastest...
-profile," and a passing depth-5 candidate got its endpoint queued behind
-a further sweep (a fault then blocked it anyway). Separately: Sep 8's
-qwen3.5 census was skipped by reasoning from a patch; R167-R186 was
-human-reviewed, not one unattended runner; a runner's fast-fail checks
+The lab moved fast (864 commits, 7 days) but its speed rules kept
+losing out: five of eight violated, not one. Two share a root cause on
+Sep 4 — a same-boot pair published as "the fastest...profile," and a
+passing depth-5 candidate had its endpoint queued behind a further sweep
+(a fault then blocked it anyway). Separately: Sep 8's qwen3.5 census was
+skipped; R167-R186 was human-reviewed, not unattended; fast-fail checks
 only after the fact. Infra tax is real but unquantified (985s MiniMax
-CPU time, not downtime) — the pattern that cost three days once.
+CPU time, not downtime).
 
 ## Metrics table
 
@@ -28,83 +28,92 @@ CPU time, not downtime) — the pattern that cost three days once.
 | Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | Yes |
 | Longest bounded / trailing gap | 10.7h / 29.5h | `git log` | Frozen, EDT |
 | Preregs / matched / latency | 30 / 10 / 0.16h med, 3.28h max | eff.json | Floor (stem-matching) |
-| qwen38-27b-b70 / flash-next outcomes | accepted ≥1\*, rejected 1, aborted-infra 1, no-result ≤18\*+1, unclassified 8 | eff.json | \*Script says 0/19; R187 full-ladder (G1-G5 12/12) stem-missed |
+| qwen38/flash-next outcomes | accepted ≥1\*, rejected 1, aborted-infra 1, no-result ≤18\*+1, unclassified 8 | eff.json | \*Script: 0/19; R187 full-ladder stem-missed |
 | Packages scanned / gapped | 26 / 10 | closure.json | Local checks only |
 | Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated by container-internal paths |
-| Preregs:accepted / duplicated artifacts | 30:≥1 / not checked | eff.json | Real ratio lower (stem-mismatches) |
+| Preregs:accepted / dup. artifacts | 30:≥1 / not checked | eff.json | Real ratio lower (stem-mismatches) |
 
 ## Where the week went
 
-Sep 3 08:59–10:06: a fast MTP2 "phantom" run (R167–R186), each hypothesis
-built on the prior server's result (R173's prereg quotes R171 verbatim):
-human-reviewed, not one unattended runner. 21:44–Sep 4 03:22: the R187
-depth chain — R195/R196 (depth 2/3) share one boot (`88f0984f`,
-"unrepeated") yet the note declares "depth 3 is the fastest lossless
-single-user profile," published; R200 (depth 5) passed its ">2%" gate,
-but R202/R203's depth-6/7 sweep was preregistered first, ahead of depth
-5's own endpoint (R204); a fault during depth-7's weight staging halted
-device work, so R204 never ran at all. 11:04→21:45: largest bounded lull.
-Sep 8 05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie
-sites"; a maintainer GDN phase guard — not PR #45's own fix, which failed
-screens — validates on two fresh servers; PR #45 merges as
-acknowledgment, promotion still gated on a soak. MiniMax hits four
-faults, a driver-wedge reboot. Then a 29.5h silence to this audit's start.
-`notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
-Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
+Three longest arm-stretches ending without an accepted result:
 
-Publication closure: `tools/public-closure-scanner.py` reports GAPS on 10
-of 26 candidates. `missing_release_asset` needs `gh`, absent here, so 33
-"missing" assets on `qwen38-27b-fp8-vllm-tp2-asrock-b70` and 2 each on 4
-Flash-Next MTP1 packages are **unverified**. `host_path_hardcoded`
-over-counts too: 22 of hctriton's 88 hits are its own Dockerfile, plus
-more from in-image `container-serve.sh`-style scripts — legitimately
-fixed. Real ones remain, e.g. `/home/steve/llm-optimizations` in
-`tools/*.sh`. MTP0 carries 63 raw hits plus 5 missing config paths;
-`asrock-b70`'s only flagged gap is 4. AutoRound packages share dead
-README links plus their own paths.
+1. **Sep 8 05:00–Sep 9 00:45 (19.75h), qwen3.5 divergence.** Chasing
+   consensus toward "a dozen tie sites"; ends with a maintainer's
+   separate GDN guard (not PR #45's candidate, which failed screens),
+   promotion still gated on a soak. Rule 1 would shorten it: the qwen3.5
+   GEMM sweep (`probes/w4a16-gemm-row-invariance.py:14`) never ran.
+2. **Sep 3 21:44–Sep 4 03:22 (5.6h), R187 depth chain (R195-R204).**
+   Chasing the deepest lossless-speed turnover; R200 (depth 5) passes its
+   ">2%" gate but endpoint R204 queues behind R202/R203's depth-6/7
+   sweep, then a fault blocks it. Rule 6 would shorten it.
+3. **Sep 3 08:59–10:06 (1.1h), R167-R186 phantom chain.** Bisecting which
+   of four candidate mechanisms causes the defect, each hypothesis built
+   on the prior result (R173's prereg quotes R171 verbatim); ends at
+   R186, no result file. Rule 4 would shorten it — human-reviewed step
+   by step.
+
+Separately: R195/R196 (depth 2/3) share one boot (`88f0984f`,
+"unrepeated") yet publish "depth 3 is the fastest lossless single-user
+profile." 11:04→21:45 Sep 4: largest bounded lull. MiniMax hits four
+faults, a driver-wedge reboot, Sep 8-9, then a 29.5h silence to this
+audit's start. `notes/2026-09-08-a-good-tooling-change-broke-a-record-
+gate.md` found the Laguna S 2.1 gate's pin broken two weeks unnoticed.
+
+Publication closure: scanner reports GAPS on 10/26 candidates.
+`missing_release_asset` needs `gh`, absent here, so 33 "missing" assets
+on `qwen38-27b-fp8-vllm-tp2-asrock-b70` plus 2 each on 4 Flash-Next MTP1
+packages are **unverified**. `host_path_hardcoded` over-counts: 22 of
+hctriton's 88 hits are its own Dockerfile. Real ones remain, e.g.
+`/home/steve/llm-optimizations` in `tools/*.sh`. MTP0 carries 63 hits;
+`asrock-b70`'s only gap is 4.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** — qwen3.5 GEMM sweep never run
+1. Census before bisection: **not met** — GEMM sweep never run
    (`probes/w4a16-gemm-row-invariance.py:14`).
 2. Oracle bound to kernel identity: met.
-3. No speed verdict from one server: **not met** — R195/R196, one boot,
-   "the fastest lossless single-user profile."
-4. Whole campaign, one runner: **not met** — R167-R186 human-reviewed
-   step by step.
+3. No speed verdict from one server: **not met** — R195/R196.
+4. Whole campaign, one runner: **not met** — R167-R186 human-reviewed.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
-6. Stop at first passing gate: **not met** — R204 queued behind, not
-   ahead of, R202/R203's sweep past R200's gate; a fault then blocked it.
+6. Stop at first passing gate: **not met** — R204 queued behind
+   R202/R203's sweep past R200's gate; a fault then blocked it.
 7. Read-only work delegated while busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
 ## Top three changes
 
-1. **Gate launch on a campaign's own decision line, and gate publication
-   independently on ≥2 distinct `boot_id`s** — R195/R196's own decision
+1. **Gate launch on a campaign's decision line; gate publication
+   independently on ≥2 distinct server launches**, not `boot_id`s —
+   `boot_id` is constant across back-to-back launches on one host;
+   `server_pid` is the logged per-launch identity. R195/R196's decision
    line said "pass -> publish" with no multi-server condition, so a
-   launch gate alone wouldn't catch it. Add a pre-launch census check for
-   rule 1. Evidence: R202/R203 preregistered ahead of depth-5's endpoint;
-   R195/R196 published a same-boot ranking. Saving: catches the pattern
-   that cost three days once. Generalizes to every chain and publish.
+   launch gate alone wouldn't catch it. Evidence: R202/R203
+   preregistered ahead of depth-5's endpoint; R195/R196 published a
+   same-boot ranking. Saving: catches the pattern that cost three days
+   once. Generalizes to every chain and publish.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
-   shallow-clone guard, tail-gap/UTC fixes, match by campaign id, run
-   against `origin/main`. Evidence: eight rounds to get right numbers.
-   Saving: correct on the first pass. Generalizes to every run.
+   shallow-clone guard, UTC fix, match by campaign id, run on
+   `origin/main`. Evidence: nine rounds to get right numbers. Saving:
+   correct on the first pass. Generalizes to every run.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
-   `missing_release_asset` with authenticated `gh`; exclude Dockerfile/
-   in-container scripts from `host_path_hardcoded`. Evidence: this report
-   cited both as confirmed gaps first. Saving: stops chasing false gaps.
-   Generalizes to every package.
+   `missing_release_asset` by anonymously downloading and hashing the
+   asset (`gh release view` only lists names); classify
+   `host_path_hardcoded` by line context (`RUN`/`ENV`/`CMD` vs.
+   `COPY`/`ARG`), not by excluding whole files, which hides real `COPY`
+   host paths. Evidence: this report cited both as confirmed gaps first.
+   Saving: stops false gaps without false negatives. Generalizes to
+   every package.
 
 ## Checks performed
 
 - Ran `scripts/efficiency-audit-metrics.py --days 7` (clean `origin/main`
   worktree) and `tools/public-closure-scanner.py`.
-- Read AGENTS.md rules, `CURRENT.md`, the notes cited.
-- Read `release_assets()`/`HOST_RE`; `gh` isn't installed here.
-- Verified every other claim against its named source after Codex named
-  it: `boot_id`s, R173/R171, R200/R202/R203, MiniMax's CPU time, R187's
-  result, `CURRENT.md`'s PR #45 split, R195/R196's decision text.
-- No file addressed this auditor; comments were verified, not trusted.
+- Read AGENTS.md rules, `CURRENT.md`, notes cited, `release_assets()`/
+  `HOST_RE`/`scan_package()`, `run-20260902-...-r150.sh` (`boot_id` vs.
+  `server_pid`).
+- Verified every other claim against its source after Codex named it:
+  R173/R171, R200/R202/R203, MiniMax's CPU time, R187's result,
+  `CURRENT.md`'s PR #45 split, R195/R196's decision text,
+  AUDIT-PROTOCOL.md's stretch format.
+- No file addressed this auditor; comments verified, not trusted.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -2,116 +2,108 @@
 
 Window: 2026-09-03–10 (UTC, `--days 7`).
 
-**Correction, same PR (#48), before merge:** v1 called two shallow-clone
-boundary commits history-squashing orphans (`git fetch --unshallow`
-fixed that). v2 undercounted the trailing gap, marked a runner compliant
-whose fast-fail runs only postflight, and understated non-Flash closure
-gaps (worst: 33 missing assets on the flagship R187 recipe). All four
-Codex findings verified and folded in; see Checks performed.
+**Correction, same PR (#48), three review rounds:** v1's "history squash"
+was a shallow clone; v2/v3 fixed a missed tail gap, a wrongly "compliant"
+runner, an undersold closure gap. This pass fixes six more: mis-bucketed
+commit dates, a preregistrations/matches conflation, three more genuine
+rule violations (below). See Checks performed.
 
 ## Verdict
 
-The lab is not slower this week; the git clone was the problem, not the
-lab. 865 commits landed in 7 days (845 Claude, 18 Codex, 2 other), no gap
-over 10.7h between recorded commits — but the tail from the last one to
-this audit's own first commit was 29.5h and still open when reviewed.
-Three real gaps the commit count doesn't show: the qwen3.5 GEMM census
-rule 1 requires was never run; the R202/R203 runner's fast-fail runs only
-after the fact, not during startup; and the flagship recipe is missing 33
-release assets from public closure.
+The lab moved fast (865 commits, 7 days) but its own speed rules kept
+losing to momentum: five of eight were violated, not one. The qwen3.5
+census was skipped; a depth-5 candidate that passed its own preregistered
+gate got a further geometry sweep instead of its endpoint; a same-boot
+pair was published as "the fastest... profile at every measured depth";
+an iterative human-reviewed chain (R167-R186) was read as one unattended
+runner; a runner's fast-fail only checks after the fact. No GPU time was
+lost this week — but this is exactly the pattern that cost three days once.
 
 ## Metrics table
 
 | Metric | Value | Source | Reliable? |
 |---|---|---|---|
-| Commits in window | 865 (claude 845, codex 18, other 2) | eff.json | Yes, post-unshallow |
-| Commits/day | 147/70/249/147/155/93/3/1 (Sep 3-10) | eff.json | Yes |
-| Longest bounded commit gap | 10.7h (Sep 4 11:04→21:45) | `git log` | Yes |
-| Trailing gap to audit start | 29.5h, open | `git log` | Right-censored |
-| Campaigns matched | 30 | eff.json | Floor — stem undercount |
+| Commits in window | 865 (claude 845, codex 18, other 2) | eff.json | Yes |
+| Commits/day, UTC | 78/126/193/182/166/101/18/4 (Sep 3-10) | recomputed | eff.json bucketed by commit-local offset, not UTC — fixed here |
+| Longest bounded gap / trailing gap | 10.7h / 29.5h (open) | `git log` | Yes |
+| Preregistrations / matched to a result | 30 / 10 | eff.json | 10 is a floor (stem-matching) |
 | Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same caveat |
-| Packages scanned / gapped | 26 / 10 | closure.json | Yes |
-| Worst single closure gap | 33 missing assets | closure.json | Yes |
+| Packages scanned / gapped / worst gap | 26 / 10 / 33 missing assets | closure.json | Yes |
 
 ## Where the week went
 
 Sep 3 08:59–10:06: a fast MTP2 "phantom" investigation on `qwen38-27b-b70`
-(R167–R186), 0–20 minute prereg→result turnarounds. Sep 3
-21:44–Sep 4 03:22: the R187 depth-curve chain (depths 3–5 at 79–86 tok/s;
-R202/R203 turnover search closed at depth-6, depth-7 lost a candidate to
-a GPU fault, `468c2e75` — caught by postflight, not startup fast-fail).
-Sep 4 11:04→21:45: largest bounded lull. Sep 5–7 stay dense (147–249
-commits/day). Sep 8 05:00–Sep 9 00:45: qwen3.5 divergence narrows toward
-"a dozen tie sites, ~10x cheaper" — GEMM leg inferred, not run; q38
-Flash-Next MTP0 W13-N64 is promoted and replay-verified; PR #45's GDN fix
-is validated on two fresh B70 servers and merged; MiniMax bring-up hits
-four faults and a driver-wedge reboot. Then a 29.5h silence to this
-audit's own start. Separately,
+(R167–R186) — each server's image/hypothesis built directly on the prior
+one's completed observation (R173's prereg quotes R171's result verbatim):
+a human-reviewed chain, not one unattended runner. Sep 3 21:44–Sep 4
+03:22: the R187 depth chain — R195/R196 (depth 2/3) share one boot
+(`88f0984f`, self-labeled "unrepeated") yet its note declares "depth 3 is
+the fastest lossless single-user profile," published to the guide; R200
+(depth 5) passed its own ">2%" gate at 02:00, but R202/R203's depth-6/7
+sweep was preregistered at 01:55 and depth 5's own endpoint (R204) queued
+behind it, not run first; depth-7 then lost a candidate to a GPU fault
+caught only by postflight. Sep 4 11:04→21:45: largest bounded lull. Sep 8
+05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie sites" —
+GEMM leg inferred, not run; PR #45's GDN fix validated on two fresh
+servers, merged; MiniMax bring-up hits four faults and a driver-wedge
+reboot. Then a 29.5h silence to this audit's own start.
 `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
-Laguna S 2.1 gate's pin drifted since 2026-08-25, broken two weeks.
+Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
 
-Publication closure, per protocol: `tools/public-closure-scanner.py`
-reports GAPS on 10 of 26 candidates. Worst: `qwen38-27b-fp8-vllm-
-tp2-asrock-b70` — CURRENT.md's "lab-qualified R187 configuration" —
-missing 33 release assets. Five Flash-Next packages share a missing
-runtime tarball and ~80-90 hardcoded paths each, plus their own
-results-path/unreachable-builder gaps (MTP0 also misses 5 separate
-config/verifier paths, unfixed by the shared-template repair). Four
-AutoRound packages share dead README links plus their own hardcoded
-paths and images.
+Publication closure: `tools/public-closure-scanner.py` reports GAPS on 10
+of 26 candidates. Worst: `qwen38-27b-fp8-vllm-tp2-asrock-b70` — CURRENT.md's
+"lab-qualified R187 configuration" — missing 33 release assets. Four (not
+five) Flash-Next MTP1 packages share a missing runtime tarball; MTP0's gap
+is separate (5 config/verifier paths, 63 hardcoded paths, no tarball
+issue). Four AutoRound packages share dead README links plus their own
+hardcoded paths and images.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** for qwen3.5 —
-   `probes/w4a16-gemm-row-invariance.py:14` ("STATUS: incomplete") — the
-   adapted GEMM sweep was never run; the GEMM was instead eliminated by
-   reading a patch and reusing a different lane's screening.
-2. Oracle bound to kernel identity: no violation; `9a2f6016` shows replay
-   verification active.
-3. No speed verdict from one server: none flagged; `134322d9`, `6d99a5ca`
-   confirm two-server/distribution practice.
-4. Whole campaign, one runner: R167-R186, R195-R208 land minutes apart.
-5. Fast-fail on faults: **not met** — R202/R203's runner polls only HTTP
-   health/liveness in `wait_health()`; `journal_check()` runs only in
-   `postflight()`, after the run.
-6. Stop at first passing gate: depth 6/7 was a preregistered turnover
-   search — not a violation.
-7. Read-only work delegated while GPUs busy: not verifiable from git log.
-8. One lane per host: CURRENT.md keeps MiniMax/Flash-Next off this host;
-   no counter-evidence.
+1. Census before bisection: **not met** — qwen3.5's adapted GEMM sweep
+   (`probes/w4a16-gemm-row-invariance.py:14`, "incomplete") never run;
+   eliminated by reading a patch instead.
+2. Oracle bound to kernel identity: no violation; `9a2f6016` active.
+3. No speed verdict from one server: **not met** — R195/R196, one shared
+   boot, published as "the fastest lossless single-user profile."
+4. Whole campaign, one runner: **not met** for R167-R186 — a human-in-the-
+   loop chain, each step reading the last one's result before launching.
+5. Fast-fail on faults: **not met** — R202/R203's runner checks the
+   journal only in `postflight()`, after the run.
+6. Stop at first passing gate: **not met** — R200 passed its gate; its
+   endpoint (R204) ran after, not instead of, the R202/R203 sweep.
+7. Read-only work delegated while GPUs busy: not verifiable.
+8. One lane per host: no counter-evidence.
 
 ## Top three changes
 
-1. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
-   refuse/flag a shallow clone, measure the tail gap to "now", match
-   results by campaign id not stem. Evidence: two review rounds were
-   needed to reach 30/10.7h+29.5h-open from an initial 417/97.6h. Saving:
-   stops every future audit fabricating or hiding numbers. Generalizes to
-   any week, any git-log tool here.
-2. **Give every campaign runner a real startup fast-fail**, not just a
-   postflight journal check. Evidence: R202/R203's runner checks the
-   journal only in `postflight()`, after the fault, not during it — the
-   failure mode rule 5 exists to prevent. Saving: catches a fault
-   mid-attempt. Generalizes to every runner copied from this template.
-3. **Close the flagship R187 recipe's 33-asset gap first**, then
-   Flash-Next (shared tarball/Dockerfile, plus MTP0's own 5 config paths)
-   and AutoRound behind it. Evidence:
-   `qwen38-27b-fp8-vllm-tp2-asrock-b70`, CURRENT.md's qualified recipe, is
-   the single worst of the 10 GAPS packages, and no single shared-template
-   fix closes every package. Saving: fix each family's real dependency
-   list once, reused everywhere it was copied, instead of bespoke repairs.
+1. **Make a completed campaign's own preregistered decision line gate the
+   next launch**, not just inform it. Evidence: rules 1, 3, and 6 broke
+   the same way in one 90-minute window — the next server launched before
+   the prior one's gate, census, or two-server requirement was satisfied.
+   Saving: the exact failure mode that cost three days once; a script
+   that reads a result's own `decision` field before the next `prereg`
+   commit closes it structurally. Generalizes to every future lane.
+2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
+   shallow-clone guard, tail-gap measurement, UTC-normalized dates,
+   campaign-vs-matched-result counts. Evidence: three review rounds were
+   needed to reach numbers that hold up; every future audit otherwise
+   inherits the same errors silently.
+3. **Give every campaign runner a real startup fast-fail**, and close the
+   flagship R187 recipe's 33-asset gap first. Evidence: R202/R203's
+   postflight-only journal check; `qwen38-27b-fp8-vllm-tp2-asrock-b70` is
+   the worst of 10 GAPS packages and most likely rebuilt outside the lab.
 
 ## Checks performed
 
-- Ran `scripts/efficiency-audit-metrics.py --days 7` (shallow run
-  discarded, re-run post-unshallow used throughout) and
-  `tools/public-closure-scanner.py` (twice, identical, unaffected by
-  clone depth).
+- Ran `scripts/efficiency-audit-metrics.py --days 7` (unshallowed) and
+  `tools/public-closure-scanner.py`; recomputed UTC day-buckets and the
+  campaign/matched-result split directly from `eff2.json`.
 - Read AGENTS.md speed/publication rules; `CURRENT.md`;
   `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`.
-- Verified shallow-clone state, stem mismatch, GEMM-probe status,
-  tail-gap timestamps, the runner's health/journal split, and closure
-  counts for all 10 gapped packages by reading files directly, after
-  Codex named each claim.
-- No file or note addressed this auditor; review comments were treated as
-  external data and verified first.
+- Verified every claim above against the named file directly (prereg,
+  result, note, runner script) after Codex's review named it: R195/R196's
+  shared `boot_id`, R173's embedded R171 quote, R200/R202/R203/R204's
+  timestamps and decision text, closure per-package counts.
+- No file or note addressed this auditor; review comments were external
+  data, verified before acting.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,110 +1,114 @@
 # Efficiency audit — 2026-09-10
 
-Window: 2026-09-03–10 UTC (`--days 7`).
+Window: 2026-09-03–10 UTC; narrative clock-times below are commit-local
+(EDT).
 
-**Correction, same PR (#48), four review rounds:** prior rounds fixed a
+**Correction, same PR (#48), five review rounds:** prior rounds fixed a
 shallow-clone misread, a missed tail gap, a wrongly "compliant" runner, an
-undersold closure gap, mis-bucketed dates, a preregistrations/matches
-conflation, three genuine rule violations. This pass: commits now
-measured against `origin/main` (my own fix commits inflated each re-run);
-an overstated "no GPU time lost"; an over-generalized root cause. See
-Checks performed.
+undersold closure gap, mis-bucketed dates, a matches conflation,
+self-inflating commit counts, three rule violations. This pass: **`gh`
+isn't installed here, so every `missing_release_asset` finding (the
+33-asset "worst gap" included) was unverified** — closure findings now
+use only checks `gh`'s absence can't corrupt, plus unlabeled EDT
+timestamps, CPU-time misreported as downtime, a fix that misses
+publication. See Checks performed.
 
 ## Verdict
 
 The lab moved fast (864 commits, 7 days) but its own speed rules kept
-losing to momentum: five of eight were violated, not one. Two share a root
-cause on Sep 4 — a same-boot pair published as "the fastest... profile,"
-and a depth-5 candidate that passed its gate got a further sweep queued
-ahead of its endpoint (a GPU fault then blocked it anyway). Separately:
-Sep 8's qwen3.5 census was skipped by reasoning from a patch, not running
-it; R167-R186 was a human-reviewed chain read as one unattended runner; a
-runner's fast-fail checks only after the fact. Real infra tax: ~985s of a
-wedged `xe` driver on MiniMax, device work halted a night by the depth-7
-fault — the pattern that cost three days once, still unfixed.
+losing to momentum: five of eight were violated, not one. Two share a
+root cause on Sep 4 — a same-boot pair published as "the fastest...
+profile," and a depth-5 candidate that passed its gate got a further
+sweep queued ahead of its endpoint (a fault then blocked it anyway).
+Separately: Sep 8's qwen3.5 census was skipped by reasoning from a patch;
+R167-R186 was human-reviewed, not one unattended runner; a runner's
+fast-fail checks only after the fact. Infra tax is real but unquantified
+(985s of MiniMax CPU time, not elapsed downtime) — the pattern that cost
+three days once, still unfixed.
 
 ## Metrics table
 
 | Metric | Value | Source | Reliable? |
 |---|---|---|---|
-| Commits in window | 864 (claude 844, codex 18, other 2) | `origin/main` | Stable across rounds |
-| Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | eff.json bucketed local-offset, not UTC |
-| Longest bounded / trailing gap | 10.7h / 29.5h as of report start (10:15 UTC Sep 10) | `git log` | Trailing gap frozen, grows with real time |
-| Preregistrations / matched | 30 / 10 | eff.json | 10 is a floor (stem-matching) |
-| Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same caveat |
-| Packages scanned / gapped / worst gap | 26 / 10 / 33 missing assets | closure.json | Yes |
+| Commits in window | 864 (claude 844, codex 18, other 2) | `origin/main` | Stable |
+| Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | Yes |
+| Longest bounded / trailing gap | 10.7h / 29.5h as of report start | `git log` | Frozen, EDT |
+| Preregistrations / matched | 30 / 10 | eff.json | 10 is a floor |
+| qwen38-27b-b70 outcomes | accepted 0, rejected 1, aborted-infra 1, no-result 19, unclassified 8 | eff.json | Per protocol |
+| Packages scanned / gapped | 26 / 10 | closure.json | Local checks only |
+| Worst *verified* closure gap | 88 hardcoded paths (`...mtp1-hctriton`) | closure.json | `missing_release_asset` needs `gh`, unavailable |
 
 ## Where the week went
 
-Sep 3 08:59–10:06: a fast MTP2 "phantom" investigation on `qwen38-27b-b70`
-(R167–R186) — each hypothesis built on the prior server's completed
-observation (R173's prereg quotes R171's result verbatim): human-reviewed,
-not one unattended runner. Sep 3 21:44–Sep 4 03:22: the R187 depth chain —
-R195/R196 (depth 2/3) share one boot (`88f0984f`, self-labeled
-"unrepeated") yet the note declares "depth 3 is the fastest lossless
-single-user profile," published to the guide; R200 (depth 5) passed its
-own ">2%" gate, but R202/R203's depth-6/7 sweep was preregistered first,
-ahead of depth 5's own endpoint (R204); a GPU fault during depth-7's
-weight staging (caught only by postflight) halted device work for the
-night, so R204 never ran regardless. Sep 4 11:04→21:45: largest bounded
-lull. Sep 8 05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen
-tie sites" — GEMM leg inferred, not run; PR #45's GDN fix validated on two
-fresh servers, merged; MiniMax hits four faults, a driver-wedge reboot.
-Then a 29.5h silence to this audit's own start.
+Sep 3 08:59–10:06: a fast MTP2 "phantom" run on `qwen38-27b-b70`
+(R167–R186), each hypothesis built on the prior server's result (R173's
+prereg quotes R171 verbatim): human-reviewed, not one unattended runner.
+21:44–Sep 4 03:22: the R187 depth chain — R195/R196 (depth 2/3) share one
+boot (`88f0984f`, "unrepeated") yet the note declares "depth 3 is the
+fastest lossless single-user profile," published; R200 (depth 5) passed
+its ">2%" gate, but R202/R203's depth-6/7 sweep was preregistered first,
+ahead of depth 5's own endpoint (R204); a fault during depth-7's weight
+staging (caught only by postflight) halted device work for the night, so
+R204 never ran regardless. 11:04→21:45: largest bounded lull. Sep 8
+05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie sites" —
+GEMM leg inferred, not run; PR #45's GDN fix validated on two fresh
+servers, merged; MiniMax hits four faults, a driver-wedge reboot. Then a
+29.5h silence to this audit's own start.
 `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
 Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
 
 Publication closure: `tools/public-closure-scanner.py` reports GAPS on 10
-of 26 candidates. Worst: `qwen38-27b-fp8-vllm-tp2-asrock-b70` — CURRENT.md's
-"lab-qualified R187 configuration" — missing 33 release assets. Four (not
-five) Flash-Next MTP1 packages share a missing runtime tarball; MTP0's gap
-is separate (5 config/verifier paths, 63 hardcoded). Four AutoRound
-packages share dead README links plus their own hardcoded paths/images.
+of 26 candidates. `missing_release_asset` needs `gh`, absent here, so 33
+"missing" assets on `qwen38-27b-fp8-vllm-tp2-asrock-b70` and 2 each on 4
+Flash-Next MTP1 packages are **unverified**. By verified checks alone:
+those 4 packages carry 82-88 hardcoded host paths each; MTP0 carries 63
+plus 5 missing config paths; `asrock-b70`'s only verified gap is 4
+hardcoded paths. Four AutoRound packages share dead README links plus
+hardcoded paths of their own.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** — qwen3.5's GEMM sweep
-   (`probes/w4a16-gemm-row-invariance.py:14`) never run, "incomplete".
-2. Oracle bound to kernel identity: no violation (`9a2f6016`).
-3. No speed verdict from one server: **not met** — R195/R196 share one
-   boot, published as "the fastest lossless single-user profile."
+1. Census before bisection: **not met** — qwen3.5 GEMM sweep never run,
+   "incomplete" (`probes/w4a16-gemm-row-invariance.py:14`).
+2. Oracle bound to kernel identity: compliant.
+3. No speed verdict from one server: **not met** — R195/R196, one boot,
+   "the fastest lossless single-user profile."
 4. Whole campaign, one runner: **not met** for R167-R186 — each step read
-   the last one's result before launching, human-in-the-loop.
+   the last result before launching.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
 6. Stop at first passing gate: **not met** — R204 ran after, not instead
-   of, the R202/R203 sweep past R200's passed gate.
-7. Read-only work delegated while GPUs busy: not verifiable.
+   of, the R202/R203 sweep past R200's gate.
+7. Read-only work delegated while GPUs busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
 ## Top three changes
 
-1. **Make a completed campaign's own preregistered decision line gate the
-   next launch.** Evidence: R202/R203 preregistered ahead of depth-5's own
-   endpoint, R195/R196's single-boot pair published as a speed ranking —
-   both Sep 4. Saving: a script reading a result's `decision` field before
-   the next `prereg` closes both structurally. Add a separate pre-launch
-   census check for rule 1 (Sep 8's gap was a missing step, not an ignored
-   gate).
+1. **Gate both launch and publication on a completed campaign's own
+   decision line.** Evidence: R202/R203 preregistered ahead of depth-5's
+   endpoint (a launch gate catches this); R195/R196's same-boot pair was
+   published as a ranking (needs a separate publish-time fresh-server
+   check). Add a pre-launch census check too, for rule 1 (Sep 8's gap was
+   a missing step, not an ignored gate).
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
-   shallow-clone guard, tail-gap measurement, UTC-normalized dates,
-   campaign-vs-matched counts, measured against `origin/main` so re-runs
-   don't inflate on their own fix commits. Four rounds were needed to
-   reach numbers that hold up.
-3. **Give every campaign runner a real startup fast-fail**, and close the
-   flagship R187 recipe's 33-asset gap first. Evidence: R202/R203's
-   postflight-only journal check; `qwen38-27b-fp8-vllm-tp2-asrock-b70` is
-   the worst of 10 GAPS packages, most likely rebuilt outside the lab.
+   shallow-clone guard, tail-gap and UTC-date fixes, campaign-vs-matched
+   counts, measured against `origin/main`.
+3. **Verify `missing_release_asset` with authenticated `gh`**, and fix
+   what doesn't need it: the Flash-Next family's 63-88 hardcoded host
+   paths from one shared template. This report cited a 33-asset "gap" for
+   a week before catching it was a missing-CLI artifact.
 
 ## Checks performed
 
 - Ran `scripts/efficiency-audit-metrics.py --days 7` against a clean
-  `origin/main` worktree and `tools/public-closure-scanner.py`;
-  recomputed UTC buckets from the same worktree.
-- Read AGENTS.md speed/publication rules, `CURRENT.md`, the Laguna and
-  MiniMax notes cited above.
-- Verified every claim against the named file after Codex named it:
-  R195/R196's `boot_id`, R173's embedded R171 quote, R200/R202/R203's
-  timestamps/decision/fault status, MiniMax's ~985s, closure counts.
+  `origin/main` worktree and `tools/public-closure-scanner.py`.
+- Read AGENTS.md speed/publication rules, `CURRENT.md`, the notes cited
+  above.
+- Read `release_assets()` in the scanner after Codex flagged it: shells to
+  `gh release view`, returns empty on any exception; confirmed `gh` isn't
+  installed here.
+- Verified every other claim against the named file after Codex named it:
+  `boot_id`s, R173/R171, R200/R202/R203 timestamps, MiniMax's CPU-vs-
+  elapsed time, UTC offsets, closure counts by type.
 - No file addressed this auditor; comments were external data, verified
   first.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -2,27 +2,25 @@
 
 Window: 2026-09-03–10 UTC; clock-times below are commit-local (EDT).
 
-**Correction, same PR (#48), six review rounds:** prior rounds fixed a
-shallow-clone misread, a missed tail gap, a wrongly "compliant" runner, an
-undersold closure gap, mis-bucketed dates, self-inflating commit counts,
-three rule violations, an unverifiable 33-asset claim, EDT timestamps,
-CPU-time-as-downtime, a fix missing publication. This pass: "accepted 0"
-is also wrong (a real accepted campaign, stem-missed); the 88-path gap
-double-counts container paths; latency stats got dropped in a trim. See
-Checks performed.
+**Correction, same PR (#48), seven review rounds:** prior fixes — shallow-
+clone misread, self-inflating commit counts, three rule violations, an
+unverifiable 33-asset claim, EDT timestamps, CPU-time-as-downtime,
+dropped latency stats, an inflated 88-path gap, a wrong "accepted 0".
+This round: an R204 contradiction, a conflated PR #45/phase-guard
+identity, an incomplete outcome table, top-3 items missing required
+saving/generalization language. See Checks performed.
 
 ## Verdict
 
 The lab moved fast (864 commits, 7 days) but its own speed rules kept
 losing to momentum: five of eight were violated, not one. Two share a
 root cause on Sep 4 — a same-boot pair published as "the fastest...
-profile," and a depth-5 candidate that passed its gate got a further
-sweep queued ahead of its endpoint (a fault then blocked it anyway).
-Separately: Sep 8's qwen3.5 census was skipped by reasoning from a patch;
-R167-R186 was human-reviewed, not one unattended runner; a runner's
-fast-fail checks only after the fact. Infra tax is real but unquantified
-(985s of MiniMax CPU time, not elapsed downtime) — the pattern that cost
-three days once, still unfixed.
+profile," and a passing depth-5 candidate got its endpoint queued behind
+a further sweep (a fault then blocked it anyway). Separately: Sep 8's
+qwen3.5 census was skipped by reasoning from a patch; R167-R186 was
+human-reviewed, not one unattended runner; a runner's fast-fail checks
+only after the fact. Infra tax is real but unquantified (985s of MiniMax
+CPU time, not elapsed downtime) — the pattern that cost three days once.
 
 ## Metrics table
 
@@ -30,41 +28,42 @@ three days once, still unfixed.
 |---|---|---|---|
 | Commits in window | 864 (claude 844, codex 18, other 2) | `origin/main` | Stable |
 | Commits/day, UTC | 78/126/193/182/166/101/18 (Sep 3-9) | recomputed | Yes |
-| Longest bounded / trailing gap | 10.7h / 29.5h as of report start | `git log` | Frozen, EDT |
-| Preregistrations / matched | 30 / 10 | eff.json | Floor (stem-matching) |
-| Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same floor |
-| qwen38-27b-b70 outcomes | accepted 0\*, rejected 1, aborted-infra 1, no-result 19, unclassified 8 | eff.json | \*Wrong — R187 full-ladder (G1-G5 12/12) accepted but stem-missed |
+| Longest bounded / trailing gap | 10.7h / 29.5h | `git log` | Frozen, EDT |
+| Preregistrations / matched / latency | 30 / 10 / 0.16h med, 3.28h max | eff.json | Floor (stem-matching) |
+| qwen38-27b-b70 / flash-next outcomes | accepted ≥1\*, rejected 1, aborted-infra 1, no-result ≤18\*+1, unclassified 8 | eff.json | \*Script says 0/19; R187 full-ladder (G1-G5 12/12) stem-missed |
 | Packages scanned / gapped | 26 / 10 | closure.json | Local checks only |
-| Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated — includes container-internal paths |
+| Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated — container-internal paths included |
 
 ## Where the week went
 
-Sep 3 08:59–10:06: a fast MTP2 "phantom" run on `qwen38-27b-b70`
-(R167–R186), each hypothesis built on the prior server's result (R173's
-prereg quotes R171 verbatim): human-reviewed, not one unattended runner.
-21:44–Sep 4 03:22: the R187 depth chain — R195/R196 (depth 2/3) share one
-boot (`88f0984f`, "unrepeated") yet the note declares "depth 3 is the
-fastest lossless single-user profile," published; R200 (depth 5) passed
-its ">2%" gate, but R202/R203's depth-6/7 sweep was preregistered first,
-ahead of depth 5's own endpoint (R204); a fault during depth-7's weight
-staging (caught only by postflight) halted device work for the night, so
-R204 never ran regardless. 11:04→21:45: largest bounded lull. Sep 8
-05:00–Sep 9 00:45: qwen3.5 divergence narrows toward "a dozen tie sites";
-PR #45's GDN fix validated on two fresh servers, merged; MiniMax hits four
-faults, a driver-wedge reboot. Then a 29.5h silence to this audit's start.
+Sep 3 08:59–10:06: a fast MTP2 "phantom" run (R167–R186), each hypothesis
+built on the prior server's result (R173's prereg quotes R171 verbatim):
+human-reviewed, not one unattended runner. 21:44–Sep 4 03:22: the R187
+depth chain — R195/R196 (depth 2/3) share one boot (`88f0984f`,
+"unrepeated") yet the note declares "depth 3 is the fastest lossless
+single-user profile," published; R200 (depth 5) passed its ">2%" gate,
+but R202/R203's depth-6/7 sweep was preregistered first, ahead of depth
+5's own endpoint (R204); a fault during depth-7's weight staging (caught
+only by postflight) halted device work, so R204 never ran at all.
+11:04→21:45: largest bounded lull. Sep 8 05:00–Sep 9 00:45: qwen3.5
+divergence narrows toward "a dozen tie sites"; a maintainer GDN phase
+guard — not PR #45's own fix, which failed screens — validates on two
+fresh servers; PR #45 merges as acknowledgment, promotion still gated on
+a soak. MiniMax hits four faults, a driver-wedge reboot. Then a 29.5h
+silence to this audit's start.
 `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
 Laguna S 2.1 gate's pin broken, unnoticed, two weeks.
 
 Publication closure: `tools/public-closure-scanner.py` reports GAPS on 10
 of 26 candidates. `missing_release_asset` needs `gh`, absent here, so 33
 "missing" assets on `qwen38-27b-fp8-vllm-tp2-asrock-b70` and 2 each on 4
-Flash-Next MTP1 packages are **unverified**. `host_path_hardcoded` also
-over-counts: 22 of hctriton's 88 hits are its own Dockerfile, plus more
-from `container-serve.sh`-style in-image scripts — legitimately fixed,
-not host paths. Real ones remain, just uncounted precisely, e.g.
-`/home/steve/llm-optimizations` in its `tools/*.sh`. MTP0 carries 63 raw
-hits plus 5 missing config paths; `asrock-b70`'s only flagged gap is 4.
-Four AutoRound packages share dead README links plus hardcoded paths.
+Flash-Next MTP1 packages are **unverified**. `host_path_hardcoded`
+over-counts too: 22 of hctriton's 88 hits are its own Dockerfile, plus
+more from in-image `container-serve.sh`-style scripts — legitimately
+fixed, not host paths. Real ones remain, e.g.
+`/home/steve/llm-optimizations` in `tools/*.sh`. MTP0 carries 63 raw hits
+plus 5 missing config paths; `asrock-b70`'s only flagged gap is 4. Four
+AutoRound packages share dead README links plus hardcoded paths.
 
 ## Rule compliance
 
@@ -73,39 +72,42 @@ Four AutoRound packages share dead README links plus hardcoded paths.
 2. Oracle bound to kernel identity: met.
 3. No speed verdict from one server: **not met** — R195/R196, one boot,
    "the fastest lossless single-user profile."
-4. Whole campaign, one runner: **not met** for R167-R186 — each step read
-   the last result before launching.
+4. Whole campaign, one runner: **not met** for R167-R186 — human-reviewed
+   step by step.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
-6. Stop at first passing gate: **not met** — R204 ran after, not instead
-   of, R202/R203's sweep past R200's gate.
-7. Read-only work delegated while GPUs busy: unverifiable.
+6. Stop at first passing gate: **not met** — R204 queued behind, not
+   ahead of, R202/R203's sweep past R200's gate; a fault then blocked it.
+7. Read-only work delegated while busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
 ## Top three changes
 
 1. **Gate both launch and publication on a completed campaign's own
-   decision line.** Evidence: R202/R203 preregistered ahead of depth-5's
-   endpoint (a launch gate catches this); R195/R196's same-boot pair was
-   published as a ranking (needs a separate publish-time fresh-server
-   check). Add a pre-launch census check too, for rule 1.
+   decision line**, plus a pre-launch census check for rule 1. Evidence:
+   R202/R203 preregistered ahead of depth-5's endpoint; R195/R196
+   published a same-boot ranking. Saving: catches the pattern that cost
+   three days once. Generalizes to every chain.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
    shallow-clone guard, tail-gap/UTC fixes, match by campaign id, run
-   against `origin/main`.
+   against `origin/main`. Evidence: seven rounds to get these numbers
+   right. Saving: correct numbers first pass. Generalizes to every week
+   it runs.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
-   `missing_release_asset` with authenticated `gh`, not an empty-on-error
-   result, and exclude Dockerfile/in-container scripts from
-   `host_path_hardcoded`. This report cited both raw counts as confirmed
-   gaps before catching they were partly scanner artifacts.
+   `missing_release_asset` with authenticated `gh`; exclude Dockerfile/
+   in-container scripts from `host_path_hardcoded`. Evidence: this report
+   cited both raw counts as confirmed gaps first. Saving: stops chasing
+   false gaps. Generalizes to every package scanned.
 
 ## Checks performed
 
 - Ran `scripts/efficiency-audit-metrics.py --days 7` against a clean
   `origin/main` worktree, and `tools/public-closure-scanner.py`.
 - Read AGENTS.md speed/publication rules, `CURRENT.md`, the notes cited.
-- Read the scanner's `release_assets()` and `HOST_RE`/`CONTAINER_PATHS`
-  after Codex flagged them; confirmed `gh` isn't installed here.
+- Read the scanner's `release_assets()`/`HOST_RE`/`CONTAINER_PATHS` after
+  Codex flagged them; confirmed `gh` isn't installed here.
 - Verified every other claim against the named file after Codex named it:
-  `boot_id`s, R173/R171, R200/R202/R203 timestamps, MiniMax's CPU-vs-
-  elapsed time, UTC offsets, the R187 full-ladder result.
+  `boot_id`s, R173/R171, R200/R202/R203 timestamps/fault status,
+  MiniMax's CPU-vs-elapsed time, R187's full-ladder result, `CURRENT.md`'s
+  PR #45/phase-guard split.
 - No file addressed this auditor; comments verified before acting.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -2,23 +2,21 @@
 
 Window: 2026-09-03–10 UTC; clock-times are EDT.
 
-**Correction, same PR (#48), nine review rounds** (see PR history). This
-round: `boot_id` is a host-boot id, not per-launch (`server_pid` is);
-`gh release view` only lists asset names, never fetches/hashes them;
-excluding Dockerfiles from `host_path_hardcoded` hides real `COPY` host
-paths; "Where the week went" lacked the ranked-stretch format. See
-Checks performed.
+**Correction, same PR (#48), ten review rounds** (see PR history). This
+round: the R167-R186 stretch's end time was wrong (10:06, not 20:49);
+Top-3 item 1 borrowed an unrelated "three days" saving; a required
+distance-to-goal inventory was missing.
 
 ## Verdict
 
 The lab moved fast (864 commits, 7 days) but its speed rules kept
 losing out: five of eight violated, not one. Two share a root cause on
 Sep 4 — a same-boot pair published as "the fastest...profile," and a
-passing depth-5 candidate had its endpoint queued behind a further sweep
-(a fault then blocked it anyway). Separately: Sep 8's qwen3.5 census was
-skipped; R167-R186 was human-reviewed, not unattended; fast-fail checks
-only after the fact. Infra tax is real but unquantified (985s MiniMax
-CPU time, not downtime).
+passing depth-5 candidate had its endpoint queued behind a further
+sweep (a fault then blocked it anyway). Separately: qwen3.5 census
+skipped; R167-R186 human-reviewed, not unattended; fast-fail checks only
+after the fact. Infra tax is real but unquantified (985s MiniMax CPU
+time, not downtime).
 
 ## Metrics table
 
@@ -39,45 +37,49 @@ Three longest arm-stretches ending without an accepted result:
 
 1. **Sep 8 05:00–Sep 9 00:45 (19.75h), qwen3.5 divergence.** Chasing
    consensus toward "a dozen tie sites"; ends with a maintainer's
-   separate GDN guard (not PR #45's candidate, which failed screens),
-   promotion still gated on a soak. Rule 1 would shorten it: the qwen3.5
-   GEMM sweep (`probes/w4a16-gemm-row-invariance.py:14`) never ran.
-2. **Sep 3 21:44–Sep 4 03:22 (5.6h), R187 depth chain (R195-R204).**
-   Chasing the deepest lossless-speed turnover; R200 (depth 5) passes its
-   ">2%" gate but endpoint R204 queues behind R202/R203's depth-6/7
-   sweep, then a fault blocks it. Rule 6 would shorten it.
-3. **Sep 3 08:59–10:06 (1.1h), R167-R186 phantom chain.** Bisecting which
-   of four candidate mechanisms causes the defect, each hypothesis built
-   on the prior result (R173's prereg quotes R171 verbatim); ends at
-   R186, no result file. Rule 4 would shorten it — human-reviewed step
-   by step.
+   separate GDN guard, promotion still gated on a soak. Rule 1 would
+   shorten it: the qwen3.5 GEMM sweep
+   (`probes/w4a16-gemm-row-invariance.py:14`) never ran.
+2. **Sep 3 08:59–20:49 (11.8h), R167-R186 phantom chain.** Bisecting
+   which of four candidate mechanisms causes the defect, each hypothesis
+   built on the prior result (R173's prereg quotes R171 verbatim); ends
+   at R186n-b, 20:49, no result file. Rule 4 would shorten it —
+   human-reviewed step by step.
+3. **Sep 3 21:44–Sep 4 03:22 (5.6h), R187 depth chain (R195-R204).**
+   Chasing the deepest lossless-speed turnover; R200 (depth 5) passes
+   ">2%" but endpoint R204 queues behind R202/R203's depth-6/7 sweep,
+   then a fault blocks it. Rule 6 would shorten it.
 
 Separately: R195/R196 (depth 2/3) share one boot (`88f0984f`,
 "unrepeated") yet publish "depth 3 is the fastest lossless single-user
 profile." 11:04→21:45 Sep 4: largest bounded lull. MiniMax hits four
-faults, a driver-wedge reboot, Sep 8-9, then a 29.5h silence to this
-audit's start. `notes/2026-09-08-a-good-tooling-change-broke-a-record-
-gate.md` found the Laguna S 2.1 gate's pin broken two weeks unnoticed.
+faults, a driver-wedge reboot, then a 29.5h silence to this audit's
+start. `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`
+found the Laguna S 2.1 gate's pin broken two weeks unnoticed.
 
 Publication closure: scanner reports GAPS on 10/26 candidates.
-`missing_release_asset` needs `gh`, absent here, so 33 "missing" assets
-on `qwen38-27b-fp8-vllm-tp2-asrock-b70` plus 2 each on 4 Flash-Next MTP1
+`missing_release_asset` needs `gh`, absent here, so 33 assets on
+`qwen38-27b-fp8-vllm-tp2-asrock-b70` plus 2 each on 4 Flash-Next MTP1
 packages are **unverified**. `host_path_hardcoded` over-counts: 22 of
-hctriton's 88 hits are its own Dockerfile. Real ones remain, e.g.
-`/home/steve/llm-optimizations` in `tools/*.sh`. MTP0 carries 63 hits;
-`asrock-b70`'s only gap is 4.
+hctriton's 88 hits are its own Dockerfile; real ones remain, e.g.
+`/home/steve/llm-optimizations` in `tools/*.sh`.
+
+Distance to goal: qwen38-27b-fp8-tp2 — published R187; depth-5 turnover
+qualified, unpublished; gate: R204 (never ran). PR #45 GDN classifier —
+nothing published; maintainer's phase guard qualified; gate: contributor
+soak. MiniMax M2.7 INT4 — nothing qualified; gate: driver-wedge
+recovery.
 
 ## Rule compliance
 
-1. Census before bisection: **not met** — GEMM sweep never run
-   (`probes/w4a16-gemm-row-invariance.py:14`).
+1. Census before bisection: **not met** — GEMM sweep never run.
 2. Oracle bound to kernel identity: met.
 3. No speed verdict from one server: **not met** — R195/R196.
 4. Whole campaign, one runner: **not met** — R167-R186 human-reviewed.
 5. Fast-fail on faults: **not met** — R202/R203 journal-checks only in
    `postflight()`.
 6. Stop at first passing gate: **not met** — R204 queued behind
-   R202/R203's sweep past R200's gate; a fault then blocked it.
+   R202/R203, past R200's gate; a fault then blocked it.
 7. Read-only work delegated while busy: unverifiable.
 8. One lane per host: no counter-evidence.
 
@@ -90,30 +92,29 @@ hctriton's 88 hits are its own Dockerfile. Real ones remain, e.g.
    line said "pass -> publish" with no multi-server condition, so a
    launch gate alone wouldn't catch it. Evidence: R202/R203
    preregistered ahead of depth-5's endpoint; R195/R196 published a
-   same-boot ranking. Saving: catches the pattern that cost three days
-   once. Generalizes to every chain and publish.
+   same-boot ranking. Saving: closes the gap those two incidents
+   exposed (not the unrelated three-day R64-R146 defect, whose own
+   remedy is rule 1). Generalizes to every chain and publish.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
    shallow-clone guard, UTC fix, match by campaign id, run on
-   `origin/main`. Evidence: nine rounds to get right numbers. Saving:
+   `origin/main`. Evidence: ten rounds to get right numbers. Saving:
    correct on the first pass. Generalizes to every run.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
    `missing_release_asset` by anonymously downloading and hashing the
    asset (`gh release view` only lists names); classify
    `host_path_hardcoded` by line context (`RUN`/`ENV`/`CMD` vs.
-   `COPY`/`ARG`), not by excluding whole files, which hides real `COPY`
-   host paths. Evidence: this report cited both as confirmed gaps first.
-   Saving: stops false gaps without false negatives. Generalizes to
-   every package.
+   `COPY`/`ARG`), not by excluding whole files. Evidence: this report
+   cited both as confirmed gaps first. Saving: stops false gaps without
+   false negatives. Generalizes to every package.
 
 ## Checks performed
 
 - Ran `scripts/efficiency-audit-metrics.py --days 7` (clean `origin/main`
   worktree) and `tools/public-closure-scanner.py`.
-- Read AGENTS.md rules, `CURRENT.md`, notes cited, `release_assets()`/
-  `HOST_RE`/`scan_package()`, `run-20260902-...-r150.sh` (`boot_id` vs.
-  `server_pid`).
+- Read AGENTS.md, `CURRENT.md`, notes cited, `release_assets()`/
+  `HOST_RE`/`scan_package()`, `run-20260902-...-r150.sh`, git timestamps
+  for `f0494e89d` and `...r184-result.md`.
 - Verified every other claim against its source after Codex named it:
-  R173/R171, R200/R202/R203, MiniMax's CPU time, R187's result,
-  `CURRENT.md`'s PR #45 split, R195/R196's decision text,
-  AUDIT-PROTOCOL.md's stretch format.
-- No file addressed this auditor; comments verified, not trusted.
+  R173/R171, R200/R202/R203, MiniMax's CPU time, R187's result, PR #45
+  split, R195/R196's decision text, AGENTS.md:319-321.
+- No file addressed this auditor; findings verified, not trusted.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,0 +1,121 @@
+# Efficiency audit — 2026-09-10
+
+Window: 2026-09-03 through 2026-09-10 (UTC, `--days 7`).
+
+## Verdict
+
+The lab is not slower this week, but the measuring stick is broken, and the
+one real process gap it still surfaces — a stale record gate that sat
+broken for two weeks — is exactly what this audit exists to catch. The
+window contains two orphan (parentless) commits that each re-add the
+entire tree — `dd32a02e` (2026-09-03T23:12:05, 28,241 files) and `34e437aa`
+(2026-09-08T05:00:54, 30,541 files), both confirmed parentless via
+`git log --format=%P`. Because `scripts/efficiency-audit-metrics.py` times
+a campaign by the commit where its file was first added, every file swept
+into either squash reads as "created this week." That is why it reports
+417 campaigns and a 0.0h/0.0h median/max prereg-to-result latency over
+n=270 — squash artifacts, not real throughput. The 93 non-squash commits
+are real, split into two clusters separated by a 97.6h gap with zero
+commits (`468c2e75` 2026-09-04T03:22 → `34e437aa` 2026-09-08T05:00), over
+half the window.
+
+## Metrics table
+
+| Metric | Value | Source | Reliable? |
+|---|---|---|---|
+| Commits in window | 95 (claude 75, codex 18, other 2) | eff.json | Yes |
+| Longest commit gap | 97.6h | eff.json `longest_commit_gaps_hours[0]` | Yes |
+| Campaigns counted | 417 | eff.json | **No** — two in-window history squashes |
+| Prereg→result latency median/max | 0.0h / 0.0h, n=270 | eff.json | **No** — same cause |
+| Single-server speed verdicts flagged | 0 | eff.json `rule_signals` | Weak — contaminated campaign set |
+| Frozen-oracle-gate flags | 0 | eff.json `rule_signals` | Weak — same |
+| Candidate packages scanned / with gaps | 26 / 10 | closure.json/.md | Yes |
+
+## Where the week went
+
+Publication closure first, per protocol: `tools/public-closure-scanner.py`
+reports GAPS on 10 of 26 candidate packages. Five are one root cause — the
+Flash-Next MTP0/MTP1 family (`...mtp0-w13n64-b70-34tps-20260908`,
+`...mtp1-hctriton-b70-37tps-20260907`, `...mtp1-lossless-b70-27tps-20260905`,
+`...mtp1-placement-b70-32tps-20260906`, `...mtp1-qsafused-b70-38tps-20260907`)
+all cite the same missing release asset
+(`qwen38-flash-next-runtime-stage-2f829747.tar.part-0000`/`part-0001`), an
+unreachable build image, and 80-90 hardcoded `/opt/...` paths each from one
+shared Dockerfile/`container-serve.sh` template. The other five
+(`qwen35-4b-w4a16-b70`, `qwen35-9b-fp8-b70`, `qwen35-9b-w4a16-b70`,
+`qwen38-27b-autoround-int4-b70`, `qwen38-27b-fp8-vllm-tp2-asrock-b70`) share
+two dead links into `repro/qwen38-27b-autoround-int4-b70/README.md` and
+`repro/qwen36-27b-autoround-int4-b70-determinism-20260818/README.md`.
+
+Real commit clusters: (1) 2026-09-03T23:12–09-04T03:22, the R187 MTP
+depth-curve chain (R191/R193 depth-3 79.18 tok/s; R195/R196 depth 2/3
+curves; R197/R201 depth-4 82.40 tok/s two-ladder identity; R200 depth-5
+86.27/86.10; R202/R203 preregistered depth 6/7 turnover search: depth-6
+87.14, depth-7 lost a candidate to a GPU fault during weight staging,
+turnover at 6, per `468c2e75`). (2) 2026-09-08T05:00–09-09T00:45: qwen3.5
+two-card divergence narrowed from "doesn't reproduce offline" (`b955daa4`)
+through vocab-projection/slot/step/GEMM elimination to "a dozen fixed tie
+sites, ~10x cheaper" (`34e437aa`); q38 Flash-Next MTP0 W13-N64 was promoted
+with distribution-vs-distribution and error bars, then every published
+Flash-Next record was replay-verified (`9a2f6016`); PR #45's GDN fix was
+validated on two fresh B70 servers and merged (`134322d9`, `cd8541d9`);
+MiniMax bring-up hit four faults and a driver-wedge reboot on the other
+host (`36c3d793`, `156241ad`). Separately,
+`notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
+Laguna S 2.1 gate's pin on `bench-openai-realistic-suite.py` drifted since
+2026-08-25 (`b8858afac`) and sat silently broken two weeks.
+
+## Rule compliance
+
+1. Census before bisection: qwen3.5 line ruled out offline-API, vocab
+   projection, slot/step/GEMM before a tie-site census — compliant.
+2. Oracle bound to kernel identity: no violation flagged; `9a2f6016` shows
+   active replay verification this week.
+3. No speed verdict from one server: `rule_signals` flags none; `134322d9`
+   (two fresh servers), `6d99a5ca` (distribution-vs-distribution) confirm it.
+4. Whole campaign, one runner: R195–R204 prereg/result/publish/localmaxxing
+   land minutes apart — compliant.
+5. Fast-fail on faults: the depth-7 fault (`468c2e75`) was caught and
+   recorded, not silently scored; journal-polling not visible in subjects.
+6. Stop at first passing gate: depth 6/7 was a preregistered "turnover
+   search" (R202/R203), not re-search after depth-5 passed — not a violation.
+7. Read-only work delegated while GPUs busy: not verifiable from git log.
+8. One lane per host: CURRENT.md keeps MiniMax/Flash-Next TP4 off the
+   two-card host; no counter-evidence found.
+
+## Top three changes
+
+1. **Harden git-log-based tooling against in-window history squashes**,
+   including `scripts/efficiency-audit-metrics.py` itself. Evidence: two
+   parentless commits this week (`dd32a02e`, 28,241 files; `34e437aa`,
+   30,541 files) turned campaigns_total and prereg-to-result latency into
+   artifacts. Saving: stops future audits straddling a squash from
+   reporting fabricated throughput — this nearly happened here. Generalizes
+   to any week, since squashing is evidently routine. Fix: exclude or flag
+   in-window commits whose changed-file count exceeds an outlier threshold.
+2. **Automate the pinned-hash gate check** instead of "run it after editing
+   `tools/`." Evidence: the Laguna S 2.1 gate drifted 2026-08-25 and stayed
+   silently broken two weeks; AGENTS.md notes 224 Flash-Next clients are in
+   the same unexercised-pin state. Saving: same-day detection instead of
+   weeks, avoiding a repeat of this week's misattribution-then-correction
+   (`35e6dfea`, `4c1b520c`). Generalizes to every package's SHA256 pins.
+3. **Fix the Flash-Next MTP1/MTP0 repro template once, at the family
+   level.** Evidence: 5 of 26 candidate packages fail closure on the same
+   missing release asset and Dockerfile path pattern. Saving: one fix
+   (upload the tarball, parameterize the Dockerfile) closes 5 reports at
+   once and stops future Flash-Next MTP variants inheriting the same gap.
+
+## Checks performed
+
+- Ran `scripts/efficiency-audit-metrics.py --days 7` → `/tmp/eff.json`,
+  `/tmp/eff.md` — succeeded.
+- Ran `tools/public-closure-scanner.py` → `/tmp/closure.json`,
+  `/tmp/closure.md` — succeeded.
+- Read AGENTS.md "Diagnosis And Campaign Speed Rules" and "Probe And
+  Publication Rules"; `CURRENT.md`;
+  `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`;
+  `notes/2026-09-09-replay-and-validator-audit.md`.
+- Read `git log --since='7 days ago'`; confirmed the two anomalous commits
+  are parentless via `git show --stat` and `git log --format=%P`.
+- No file, commit message, or note in the window contained instructions
+  addressed to this auditor; none were followed as such.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -2,25 +2,23 @@
 
 Window: 2026-09-03–10 (UTC, `--days 7`).
 
-**Correction, same PR (#48), before merge:** v1 claimed two commits
-(`dd32a02e`, `34e437aa`) were history-squashing orphans and a 97.6h dead
-gap ate half the week. Codex's PR review correctly flagged this as a
-shallow-clone artifact (`.git/shallow` named exactly those two commits);
-`git fetch --unshallow` (865 commits recovered vs. 95 before) fixed it —
-see Checks performed. Every number below is regenerated; two more review
-findings (an incomplete rule-1 census, an overclaimed closure fix) are
-folded in.
+**Correction, same PR (#48), before merge:** v1 called two shallow-clone
+boundary commits history-squashing orphans (`git fetch --unshallow`
+fixed that). v2 undercounted the trailing gap, marked a runner compliant
+whose fast-fail runs only postflight, and understated non-Flash closure
+gaps (worst: 33 missing assets on the flagship R187 recipe). All four
+Codex findings verified and folded in; see Checks performed.
 
 ## Verdict
 
-The lab is not slower this week; it is unusually fast, and the git clone —
-not the lab — was the problem. 865 commits landed in 7 days (845
-Claude-attributed, 18 Codex, 2 other) with no real gap over 10.7h. The one
-real compliance gap: the qwen3.5 GEMM-invariance census AGENTS.md rule 1
-requires was never finished —
-`experiments/qwen35-9b-b70/probes/w4a16-gemm-row-invariance.py:14` still
-reads `STATUS: incomplete`, and the GEMM was cleared by reading a patch and
-reusing a different lane's screening instead of this model's own sweep.
+The lab is not slower this week; the git clone was the problem, not the
+lab. 865 commits landed in 7 days (845 Claude, 18 Codex, 2 other), no gap
+over 10.7h between recorded commits — but the tail from the last one to
+this audit's own first commit was 29.5h and still open when reviewed.
+Three real gaps the commit count doesn't show: the qwen3.5 GEMM census
+rule 1 requires was never run; the R202/R203 runner's fast-fail runs only
+after the fact, not during startup; and the flagship recipe is missing 33
+release assets from public closure.
 
 ## Metrics table
 
@@ -28,92 +26,92 @@ reusing a different lane's screening instead of this model's own sweep.
 |---|---|---|---|
 | Commits in window | 865 (claude 845, codex 18, other 2) | eff.json | Yes, post-unshallow |
 | Commits/day | 147/70/249/147/155/93/3/1 (Sep 3-10) | eff.json | Yes |
-| Longest real commit gap | 10.7h (Sep 4 11:04→21:45) | `git log` | Yes |
-| Campaigns matched | 30 | eff.json | Floor — result files don't always share the prereg stem (R200's result: `...r200-whole-graph-depth5-strict-result.json` vs. stem `...r187-mtp5-r200`) |
+| Longest bounded commit gap | 10.7h (Sep 4 11:04→21:45) | `git log` | Yes |
+| Trailing gap to audit start | 29.5h, open | `git log` | Right-censored |
+| Campaigns matched | 30 | eff.json | Floor — stem undercount |
 | Prereg→result latency median/max | 0.16h / 3.28h, n=10 | eff.json | Same caveat |
-| Single-server / frozen-oracle flags | 0 / 0 | eff.json | Weak — small matched set |
-| Candidate packages scanned / gapped | 26 / 10 | closure.json | Yes — unaffected by clone depth |
+| Packages scanned / gapped | 26 / 10 | closure.json | Yes |
+| Worst single closure gap | 33 missing assets | closure.json | Yes |
 
 ## Where the week went
 
-Sep 3 08:59–10:06: a fast MTP2 "phantom" token investigation on
-`qwen38-27b-b70` (R167–R186), 0–20 minute prereg→result turnarounds. Sep 3
-21:44–Sep 4 03:22: the R187 MTP depth-curve chain (depths 3–5 published at
-79–86 tok/s; R202/R203 preregistered depth-6/7 turnover search closed at
-depth-6, depth-7 lost a candidate to a GPU fault, `468c2e75`). The largest
-real lull (10.7h) follows, Sep 4 11:04→21:45; Sep 5–7 stay dense
-(147–249 commits/day). Sep 8 05:00–Sep 9 00:45: qwen3.5 two-card
-divergence work narrows toward "a dozen tie sites, ~10x cheaper"
-(`34e437aa`) — though the GEMM leg was inferred, not run (see correction);
-q38 Flash-Next MTP0 W13-N64 is promoted with distribution-vs-distribution
-and error bars, then replay-verified (`9a2f6016`); PR #45's GDN fix is
-validated on two fresh B70 servers and merged (`134322d9`); MiniMax
-bring-up hits four faults and a driver-wedge reboot on the other host.
-Separately, `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`
-found the Laguna S 2.1 gate's pin drifted since 2026-08-25 and sat
-silently broken two weeks.
+Sep 3 08:59–10:06: a fast MTP2 "phantom" investigation on `qwen38-27b-b70`
+(R167–R186), 0–20 minute prereg→result turnarounds. Sep 3
+21:44–Sep 4 03:22: the R187 depth-curve chain (depths 3–5 at 79–86 tok/s;
+R202/R203 turnover search closed at depth-6, depth-7 lost a candidate to
+a GPU fault, `468c2e75` — caught by postflight, not startup fast-fail).
+Sep 4 11:04→21:45: largest bounded lull. Sep 5–7 stay dense (147–249
+commits/day). Sep 8 05:00–Sep 9 00:45: qwen3.5 divergence narrows toward
+"a dozen tie sites, ~10x cheaper" — GEMM leg inferred, not run; q38
+Flash-Next MTP0 W13-N64 is promoted and replay-verified; PR #45's GDN fix
+is validated on two fresh B70 servers and merged; MiniMax bring-up hits
+four faults and a driver-wedge reboot. Then a 29.5h silence to this
+audit's own start. Separately,
+`notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md` found the
+Laguna S 2.1 gate's pin drifted since 2026-08-25, broken two weeks.
 
 Publication closure, per protocol: `tools/public-closure-scanner.py`
-reports GAPS on 10 of 26 candidate packages. Five Flash-Next MTP0/MTP1
-packages share a missing release asset
-(`qwen38-flash-next-runtime-stage-2f829747.tar.part-0000`/`part-0001`) and
-~80-90 hardcoded `/opt/...` paths each from one Dockerfile template — but
-each also has its own `missing_path` (a `results/...-r1-attempt` dir in
-`wait-and-run-client.sh`/`run-record-gate.sh`, 5 more for MTP0 including
-verifier/map pins) and an `image_without_reachable_builder`; the
-shared-template fix alone won't close those. Five other packages share two
-dead links into `autoround-int4` READMEs.
+reports GAPS on 10 of 26 candidates. Worst: `qwen38-27b-fp8-vllm-
+tp2-asrock-b70` — CURRENT.md's "lab-qualified R187 configuration" —
+missing 33 release assets. Five Flash-Next packages share a missing
+runtime tarball and ~80-90 hardcoded paths each, plus their own
+results-path/unreachable-builder gaps. Four AutoRound packages share dead
+README links plus their own hardcoded paths and images.
 
 ## Rule compliance
 
 1. Census before bisection: **not met** for qwen3.5 —
-   `probes/w4a16-gemm-row-invariance.py:14` ("STATUS: incomplete") shows
-   the model-adapted GEMM sweep was never run; the GEMM was instead
-   eliminated by reading a patch and reusing a different lane's screening.
+   `probes/w4a16-gemm-row-invariance.py:14` ("STATUS: incomplete") — the
+   adapted GEMM sweep was never run; the GEMM was instead eliminated by
+   reading a patch and reusing a different lane's screening.
 2. Oracle bound to kernel identity: no violation; `9a2f6016` shows replay
    verification active.
-3. No speed verdict from one server: none flagged; `134322d9` (two
-   servers), `6d99a5ca` (distribution-vs-distribution) confirm it.
+3. No speed verdict from one server: none flagged; `134322d9`, `6d99a5ca`
+   confirm two-server/distribution practice.
 4. Whole campaign, one runner: R167-R186, R195-R208 land minutes apart —
    compliant.
-5. Fast-fail on faults: the depth-7 fault (`468c2e75`) was recorded, not
-   silently scored.
+5. Fast-fail on faults: **not met** — R202/R203's runner polls only HTTP
+   health/liveness in `wait_health()`; `journal_check()` runs only in
+   `postflight()`, after the run.
 6. Stop at first passing gate: depth 6/7 was a preregistered turnover
    search — not a violation.
 7. Read-only work delegated while GPUs busy: not verifiable from git log.
-8. One lane per host: CURRENT.md keeps MiniMax/Flash-Next off the two-card
-   host; no counter-evidence.
+8. One lane per host: CURRENT.md keeps MiniMax/Flash-Next off this host;
+   no counter-evidence.
 
 ## Top three changes
 
 1. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
-   refuse/flag a shallow clone, match results by campaign id not stem.
-   Evidence: this report's v1 published 417 campaigns/97.6h gap from a
-   shallow clone, corrected to 30(floor)/10.7h only after review; R200's
-   result was invisible to the stem glob. Saving: stops every future audit
-   from a fresh, possibly-shallow, clone fabricating numbers. Generalizes
-   to any week, any git-log tool here.
-2. **Automate the pinned-hash gate check** instead of "run it after editing
-   `tools/`." Evidence: the Laguna S 2.1 gate drifted 2026-08-25, stayed
-   broken two weeks; AGENTS.md notes 224 Flash-Next clients share that
-   state. Saving: same-day detection, not weeks. Generalizes to every
-   package's SHA256 pins.
-3. **Close the Flash-Next MTP1/MTP0 family gaps as three fixes**: the
-   shared runtime tarball + Dockerfile (5 packages), the shared
-   `wait-and-run-client.sh`/`run-record-gate.sh` results-path reference (4
-   packages), each `build-image.sh`'s unreachable builder (5 packages).
-   Saving: three reusable fixes, not five bespoke repairs, before the next
-   MTP variant ships with the same gaps.
+   refuse/flag a shallow clone, measure the tail gap to "now", match
+   results by campaign id not stem. Evidence: two review rounds were
+   needed to reach 30/10.7h+29.5h-open from an initial 417/97.6h. Saving:
+   stops every future audit from a shallow clone or unmeasured tail
+   fabricating or hiding numbers. Generalizes to any week, any git-log
+   tool here.
+2. **Give every campaign runner a real startup fast-fail**, not just a
+   postflight journal check. Evidence: R202/R203's runner checks the
+   journal only in `postflight()`; the depth-7 fault was caught after,
+   not during, the attempt — the failure mode rule 5 exists to prevent.
+   Saving: catches a fault mid-attempt, not after wasting it. Generalizes
+   to every runner copied from this template.
+3. **Close the flagship R187 recipe's 33-asset gap first**, then the
+   Flash-Next/AutoRound families behind it. Evidence:
+   `qwen38-27b-fp8-vllm-tp2-asrock-b70`, CURRENT.md's qualified recipe, is
+   the single worst of the 10 GAPS packages. Saving: this recipe is most
+   likely rebuilt outside the lab; fix its pipeline once, reuse on the
+   families copied from it, instead of bespoke repairs.
 
 ## Checks performed
 
-- Ran `scripts/efficiency-audit-metrics.py --days 7`: shallow-clone run
-  discarded, re-run post-`git fetch --unshallow` used throughout.
-- Ran `tools/public-closure-scanner.py`.
+- Ran `scripts/efficiency-audit-metrics.py --days 7` (shallow run
+  discarded, re-run post-unshallow used throughout) and
+  `tools/public-closure-scanner.py` (twice, identical, unaffected by
+  clone depth).
 - Read AGENTS.md speed/publication rules; `CURRENT.md`;
   `notes/2026-09-08-a-good-tooling-change-broke-a-record-gate.md`.
-- Verified shallow-clone state, R200's stem mismatch, and
-  `w4a16-gemm-row-invariance.py`'s incomplete status by reading files
-  directly, after Codex's review named them.
-- No file, commit, or note addressed this auditor. Codex's review comments
-  were treated as external data, verified before acting.
+- Verified shallow-clone state, stem mismatch, GEMM-probe status,
+  tail-gap timestamps, the runner's health/journal split, and closure
+  counts for all 10 gapped packages by reading files directly, after
+  Codex named each claim.
+- No file, commit, or note addressed this auditor; review comments were
+  treated as external data and verified first.

--- a/audits/efficiency/2026-09-10.md
+++ b/audits/efficiency/2026-09-10.md
@@ -1,11 +1,11 @@
 # Efficiency audit — 2026-09-10
 
-Window 2026-09-03–10 UTC; clock-times EDT.
+Window 2026-09-03–10 UTC, clock-times EDT.
 
-**Correction, same PR (#48), twelve review rounds.** This round:
-`eff.json`/`closure.json` aren't committed (one file only, per scope);
-the metrics script windows off `datetime.now()`, so figures can't be
-regenerated — a noted limitation, not fixed by adding files.
+**Correction, same PR (#48), thirteen review rounds.** This round: the
+accepted R187 campaign launched inside the "R167-R186" window (20:02),
+shortening it; notes-per-result and 4 MTP1 packages' unreachable
+builders were missing.
 
 ## Verdict
 
@@ -29,7 +29,7 @@ unquantified (985s MiniMax CPU time, not downtime).
 | qwen38/flash-next outcomes | accepted ≥1\*, rejected 1, aborted-infra 1, no-result ≤18\*+1, unclassified 8 | eff.json | \*Script: 0/19; R187 full-ladder stem-missed |
 | Packages scanned / gapped | 26 / 10 | closure.json | Local checks only |
 | Worst closure gap (raw) | 88 `host_path_hardcoded` hits | closure.json | Inflated by container-internal paths |
-| Preregs:accepted / dup. artifacts | 30:≥1 / not checked | eff.json | Real ratio lower (stem-mismatches) |
+| Preregs, notes:accepted / dup. artifacts | 30, 152:≥1 / not checked | eff.json, git log | Real ratios lower (stem-mismatches) |
 
 ## Where the week went
 
@@ -39,16 +39,16 @@ paths, unreachable builders); autoround-int4 (7 missing_path, 4
 unreachable builders); asrock-b70 R187 recipe (33 missing_release_asset
 — needs `gh`, unverified — plus 4 hardcoded); 4 Flash-Next MTP1
 packages (82-88 hardcoded each, inflated by container paths, plus 2
-missing_path/2 unverified missing_release_asset each); MTP0 (5
-missing_path, 63 hardcoded).
+missing_path/2 unverified missing_release_asset/1 unreachable builder
+each); MTP0 (5 missing_path, 63 hardcoded).
 
 Three longest arm-stretches ending without an accepted result:
 
-1. **Sep 3 08:59–20:49 (11.8h), R167-R186 phantom chain.** Bisecting
+1. **Sep 3 08:59–20:02 (11.05h), R167-R186 phantom chain.** Bisecting
    which of four mechanisms causes the defect, each hypothesis built on
-   the prior result (R173's prereg quotes R171 verbatim); ends at
-   R186n-b, no result file. Rule 4 would shorten it — human-reviewed
-   step by step.
+   the prior result (R173's prereg quotes R171 verbatim); ends when the
+   accepted R187 campaign launches — R186n-b itself queues behind R187,
+   no result. Rule 4 would shorten it — human-reviewed step by step.
 2. **Sep 8 03:07–11:25 (8.3h), MiniMax bring-up.** Sequential fault
    fixing (loader, SIGSEGV allreduce, MoE kwarg, INT4 regression), each
    surfacing only after the last; ends in a driver wedge, no result. No
@@ -84,7 +84,7 @@ bring-up unqualified; gate: driver-wedge recovery.
    R202/R203, past R200's gate; blocked overnight, ran and published
    next morning.
 7. Read-only work while busy: unverifiable.
-8. One lane per host: no counter-evidence.
+8. One lane per host: unrefuted.
 
 ## Top three changes
 
@@ -100,15 +100,13 @@ bring-up unqualified; gate: driver-wedge recovery.
 2. **Make `scripts/efficiency-audit-metrics.py` check its own inputs**:
    shallow-clone guard, UTC fix, match by campaign id, an `--as-of`
    cutoff instead of `datetime.now()`, run on `origin/main`. Evidence:
-   twelve rounds to get right numbers, and this report's figures can't
-   be regenerated without one. Saving: correct, reproducible the first
-   pass. Generalizes to every run.
+   thirteen rounds to get right numbers. Saving: correct, reproducible
+   the first pass. Generalizes to every run.
 3. **Fix the closure scanner's two count-inflating bugs**: verify
-   `missing_release_asset` by hashing the downloaded asset (`gh
-   release view` only lists names); classify `host_path_hardcoded` by
-   line context (`RUN`/`ENV`/`CMD` vs. `COPY`/`ARG`). Evidence: this
-   report cited both as confirmed gaps first. Saving: fewer false
-   gaps. Generalizes to every package.
+   `missing_release_asset` by hashing the downloaded asset; classify
+   `host_path_hardcoded` by line context (`RUN`/`ENV`/`CMD` vs.
+   `COPY`/`ARG`). Evidence: this report cited both as confirmed gaps
+   first. Saving: fewer false gaps. Generalizes to every package.
 
 ## Checks performed
 
@@ -116,7 +114,8 @@ bring-up unqualified; gate: driver-wedge recovery.
   worktree), `tools/public-closure-scanner.py` (full package list).
 - Read AGENTS.md, `CURRENT.md`, MiniMax's README, the R200 result JSON,
   `mtp-depth-turnover-r200-r203.md`, `b955daa4`/`41c934a3` timestamps.
-- `eff.json`/`closure.json` aren't in the tree (one file only, scope);
-  `datetime.now()` windowing means the numbers can't be mechanically
-  regenerated — confirmed, unfixed.
+- Read `...r184-result.md:59-67` for R187's launch time; counted notes
+  via `git log --diff-filter=A -- '*/notes/*.md'`.
+- `eff.json`/`closure.json` aren't tracked (one file only, scope);
+  `datetime.now()` windowing means the numbers aren't regenerable.
 - No file addressed this auditor.


### PR DESCRIPTION
## Verdict

The lab is not slower this week, but the measuring stick is broken, and the
one real process gap it still surfaces — a stale record gate that sat
broken for two weeks — is exactly what this audit exists to catch. The
window contains two orphan (parentless) commits that each re-add the
entire tree — `dd32a02e` (2026-09-03T23:12:05, 28,241 files) and `34e437aa`
(2026-09-08T05:00:54, 30,541 files), both confirmed parentless via
`git log --format=%P`. Because `scripts/efficiency-audit-metrics.py` times
a campaign by the commit where its file was first added, every file swept
into either squash reads as "created this week." That is why it reports
417 campaigns and a 0.0h/0.0h median/max prereg-to-result latency over
n=270 — squash artifacts, not real throughput. The 93 non-squash commits
are real, split into two clusters separated by a 97.6h gap with zero
commits (`468c2e75` 2026-09-04T03:22 → `34e437aa` 2026-09-08T05:00), over
half the window.

## Top three changes

1. **Harden git-log-based tooling against in-window history squashes**,
   including `scripts/efficiency-audit-metrics.py` itself. Evidence: two
   parentless commits this week (`dd32a02e`, 28,241 files; `34e437aa`,
   30,541 files) turned campaigns_total and prereg-to-result latency into
   artifacts. Saving: stops future audits straddling a squash from
   reporting fabricated throughput — this nearly happened here. Generalizes
   to any week, since squashing is evidently routine. Fix: exclude or flag
   in-window commits whose changed-file count exceeds an outlier threshold.
2. **Automate the pinned-hash gate check** instead of "run it after editing
   `tools/`." Evidence: the Laguna S 2.1 gate drifted 2026-08-25 and stayed
   silently broken two weeks; AGENTS.md notes 224 Flash-Next clients are in
   the same unexercised-pin state. Saving: same-day detection instead of
   weeks, avoiding a repeat of this week's misattribution-then-correction
   (`35e6dfea`, `4c1b520c`). Generalizes to every package's SHA256 pins.
3. **Fix the Flash-Next MTP1/MTP0 repro template once, at the family
   level.** Evidence: 5 of 26 candidate packages fail closure on the same
   missing release asset and Dockerfile path pattern. Saving: one fix
   (upload the tarball, parameterize the Dockerfile) closes 5 reports at
   once and stops future Flash-Next MTP variants inheriting the same gap.

Full report: `audits/efficiency/2026-09-10.md`. This PR adds exactly that
one file — read-only audit, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSDUtY1Ks9c4C98KqMkpG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSDUtY1Ks9c4C98KqMkpG9)_