### PR TITLE
Efficiency audit 2026-09-11

### DIFF
--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,8 +1,8 @@
 # Efficiency audit — 2026-09-11
 
 **Correction, same PR, round 3.** Rounds 1–2 diagnosed a "history squash" from a
-parentless `34e437aa` — wrong: this clone was merely shallow, `34e437aa` sat at the
-fetch boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
+parentless `34e437aa` — wrong: this clone was shallow, `34e437aa` sat at the fetch
+boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
 690-commit window, not 54 or 693. Confirmed from each branch's own
 `audits/efficiency/2026-09-{04..10}.md`: all 7 prior daily audits hit this exact bug.
 
@@ -12,29 +12,29 @@ fetch boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a
 Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3/day) two
 single-day investigations each spanned most of a day without a verdict: qwen35's
 two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
-(03:07–11:25, ~8.3h; only ~985s of that is measured lost time, the rest unquantified).
-A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per side,
-self-corrected by `A338`–`A339`. Every "no open gate" distance-to-goal reaches for is
-a publication-closure gap instead — R187 and five Flash-Next packages carry missing
-release assets, hardcoded paths, or unreachable builders.
+(03:07–11:25, ~8.3h span; only ~985s is measured lost time, the rest unquantified,
+most of the span an internal gap). A qualified Flash-Next MTP1 gap (`A306`/`A272`)
+rested on one suite per side, self-corrected by `A338`–`A339`. R187 and five
+Flash-Next packages are still `candidate` status (`packages/catalog.json`) with
+missing release assets, hardcoded paths, or unreachable builders — their real gate.
 
 ## Metrics table
 
 |Metric(source)|Value|
 |---|---|
 |Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
-|Commits/day Sep4–9|43/249/147/155/93/3|
+|Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted vs. rejected/DNR by lane (manual subject-line grep)|qwen38/flash-next 35/36, qwen35-9b 3/6, minimax 1/0|
-|Notes added, 7d, by lane|66 total: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
+|Accepted vs. rejected/DNR by lane (manual subject-line grep)|qwen38/flash-next 35/36, qwen35-9b 3/6, minimax 0/0, 1 infra-abort|
+|Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
-*Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-196/
-R205/R208-213 never match); the manual row is approximate too, but clone-depth-safe.
+*Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-213
+never match); manual row approximate too, but clone-depth-safe.
 
-**Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 packages, 25
-clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
+**Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 pkgs, 25
+clean). Counts: missing_path/hardcoded_path/no_builder/missing_asset:
 
 - `qwen35-4b-w4a16-b70` 5/5/2/0
 - `qwen35-9b-fp8-b70` 5/3/2/0
@@ -50,47 +50,47 @@ clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_releas
   0/3/0/0, `qwen36-27b-autoround-int4-b70-determinism-20260818` 2/0/0/0,
   `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
 
-**Distance to goal** (`CURRENT.md` + closure scan): qwen38-27b-fp8-TP2 depth-5
-published, gate is its own closure row; PR45 fix qualified-unpublished, gate is the
-mixed-session soak; Flash-Next MTP0/MTP1 published, gate is its five closure rows;
-qwen35-9b-b70 no candidate, gate is closing the divergence; MiniMax INT4 no
-candidate, gate is post-wedge recovery.
+**Distance to goal**: qwen38-27b-fp8-TP2 depth-5 `status: candidate`
+(`packages/catalog.json`), gate is its own closure row; PR45 fix qualified-
+unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1 `status:
+candidate`, gate is its five closure rows; qwen35-9b-b70 no candidate, gate is the
+divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
 
 ## Where the week went
 
-1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits.** Longest
-   stretch. Chased a two-card decode divergence through norm-serialization and
-   vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
-   `probes/w4a16-gemm-row-invariance.py` rejects synthetic weights before any
-   comparison — so the GEMM was eliminated via older R220/R221 screening from a
-   *different* model's shapes, not a finished census on this one. Closed by moving
-   the search to the serving path, no verdict. Rule 1 still isn't met.
-2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h), 3 commits**
-   (`notes/…-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`). Sequential
-   fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time burned
-   with zero output before dmesg caught it; further GPU time lost isn't quantified.
-   Rules 5/8 apply (four-card host).
-3. **Flash-Next MTP0 MoE step-cost attribution, Sep5 00:16–02:24 (~2.1h), 16
-   packets (`A148`→`A159`).** Chased where a 72.7ms graph step's cost goes: isolated
-   the grouped-GEMM launches, timed them in-server, isolated the MoE all-reduce,
-   profiled per-site, ruled out a config lever (`A155`) — ends on `A159`, "result
-   discarded," an open question. No rule targets this; it's careful, not slow.
-   (Replaces the Flash-Next re-suite this slot previously cited, which had an
-   accepted outcome — see Rule compliance #6.)
+1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits, no
+   internal gap.** Chased a two-card decode divergence through norm-serialization
+   and vocabulary-projection dead ends. The GEMM census (`90c70d68`) never
+   completed — synthetic weights are rejected before any comparison — so the GEMM
+   was eliminated via older R220/R221 screening from a *different* model's shapes,
+   not a finished census here. Closed by moving to the serving path, no verdict.
+   Rule 1 still isn't met.
+2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 3 commits,
+   ~7h42m an internal gap)** (`notes/…-wedged-driver.md`;
+   `notes/NEXT-minimax-after-reboot.md`: "the run that never got a number").
+   Sequential fault-fixing ends in the `xe` driver wedging: ~985s of system CPU
+   burned with zero output before dmesg caught it; further GPU time lost is
+   unquantified; infrastructure-aborted, not accepted. Rules 5/8 apply.
+3. **No third stretch verified to this standard.** The Sep5 Flash-Next MoE
+   step-cost chain (`A148`→`A159`→`A169`) looked promising but its later notes
+   reach a real mechanism (`A163`) and two rejected fixes, not an open question,
+   and its ~13h span is mostly a gap filled by other lanes' work (R208–R222), not
+   lost time. Re-deriving a real third across 690 commits was beyond this pass's
+   budget; two verified beats a forced third.
 
 ## Rule compliance
 
-1. Census before bisection — not met: the qwen35 GEMM census is still incomplete;
+1. Census before bisection — not met: qwen35's GEMM census is still incomplete;
    elimination leaned on a different model's screening instead.
-2. Oracle bound to kernel identity — met; `A336` refused the wrong overlay.
-3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each, same
-   boot; corrected by `A338`–`A339`.
-4. Preregister whole campaign, one runner — unchecked.
-5. Fast-fail GPU faults — MiniMax's wedge gave zero log lines for ~985s before
-   dmesg caught it; not confirmed fast-failed.
+2. Oracle bound to kernel identity — met (`A336`).
+3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each;
+   corrected by `A338`–`A339`.
+4. Preregister whole campaign — unchecked.
+5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s before dmesg
+   caught it; not confirmed fast-failed.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
-   were each motivated corrections, not repeat search past a passing gate.
-7. Delegate read-only work while GPUs busy — unverified from CPU-only work.
+   were motivated corrections, not repeat search past a passing gate.
+7. Delegate read-only work while GPUs busy — unverified.
 8. One lane per host — unconfirmed.
 
 ## Top three changes
@@ -101,21 +101,22 @@ candidate, gate is post-wedge recovery.
    Saving: the single highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: this PR mislabeled `A333` and `A334` as excess in two
-   separate rounds; both were motivated corrections. Saving: stops the audit
-   manufacturing false findings that cost review rounds.
-3. **Close publication-closure gaps before calling any lane "no open gate."**
-   Evidence: R187 and 5 Flash-Next packages are published yet carry missing release
-   assets, hardcoded paths, or unreachable builders. Saving: trustworthy
-   distance-to-goal assessments.
+   rounds; both were motivated corrections. Saving: stops the audit manufacturing
+   false findings that cost review rounds.
+3. **Name publication-closure gaps as the gate for still-`candidate` lanes, not
+   "no open gate."** Evidence: R187 and 5 Flash-Next packages are `status:
+   candidate` yet carry missing release assets, hardcoded paths, or unreachable
+   builders. Saving: trustworthy distance-to-goal.
 
 ## Checks performed
 
-- `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean worktree
-  of `origin/main` (excludes this session's own commits).
-- Ran `public-closure-scanner.py` (exit 1, gaps above; unaffected by clone depth).
-- Read `AGENTS.md`'s speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
+- `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
+  `origin/main` worktree (excludes this session's own commits).
+- Ran `public-closure-scanner.py` (exit 1, gaps above, unaffected by clone depth).
+- Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
-  script's real state, and all three stretches against notes/`git log` directly.
+  script, MiniMax's real outcome, `packages/catalog.json` status fields, and the
+  A148–A169 chain's real end and gap, against notes and `git log` directly.
 - Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none merged
   except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -25,7 +25,7 @@ missing release assets, hardcoded paths, or unreachable builders — their real 
 |Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted vs. rejected/DNR by lane (manual subject-line grep)|qwen38/flash-next 35/36, qwen35-9b 3/6, minimax 0/0, 1 infra-abort|
+|Accepted vs. rejected/DNR by lane (manual grep; infra-aborts folded in except MiniMax's)|qwen38/flash-next 35/36 (≥3 known aborts: `A174`, `A248`, `R219`), qwen35-9b 3/6, minimax 0/0 +1 abort|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
@@ -50,46 +50,46 @@ clean). Counts: missing_path/hardcoded_path/no_builder/missing_asset:
   0/3/0/0, `qwen36-27b-autoround-int4-b70-determinism-20260818` 2/0/0/0,
   `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
 
-**Distance to goal**: qwen38-27b-fp8-TP2 depth-5 `status: candidate`
-(`packages/catalog.json`), gate is its own closure row; PR45 fix qualified-
-unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1 `status:
-candidate`, gate is its five closure rows; qwen35-9b-b70 no candidate, gate is the
-divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
+**Distance to goal** (`packages/catalog.json` all `status: candidate`):
+qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is its
+five closure rows; qwen35-9b-fp8/w4a16 and minimax-m27-89tps are existing
+candidates, both now blocked behind newer unresolved work (qwen35's divergence
+hunt; MiniMax's post-wedge recovery), not just a closure gap. PR45 is two separate
+candidates, not one: the classifier patch still fails tiny/mixed probes; the
+maintainer's GDN phase guard passed its bounded follow-up and awaits the soak.
 
 ## Where the week went
 
 1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits, no
-   internal gap.** Chased a two-card decode divergence through norm-serialization
-   and vocabulary-projection dead ends. The GEMM census (`90c70d68`) never
-   completed — synthetic weights are rejected before any comparison — so the GEMM
-   was eliminated via older R220/R221 screening from a *different* model's shapes,
-   not a finished census here. Closed by moving to the serving path, no verdict.
-   Rule 1 still isn't met.
+   gap.** Chased a two-card decode divergence through norm-serialization and
+   vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
+   synthetic weights are rejected before any comparison — so the GEMM was
+   eliminated via older R220/R221 screening from a *different* model's shapes, not
+   a finished census here. Closed by moving to the serving path, no verdict. Rule 1
+   still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 3 commits,
-   ~7h42m an internal gap)** (`notes/…-wedged-driver.md`;
-   `notes/NEXT-minimax-after-reboot.md`: "the run that never got a number").
-   Sequential fault-fixing ends in the `xe` driver wedging: ~985s of system CPU
-   burned with zero output before dmesg caught it; further GPU time lost is
-   unquantified; infrastructure-aborted, not accepted. Rules 5/8 apply.
+   ~7h42m gap)** (`notes/…-wedged-driver.md`; `notes/NEXT-minimax-after-reboot.md`:
+   "the run that never got a number"). Sequential fault-fixing ends in the `xe`
+   driver wedging: ~985s of system CPU burned with zero output before dmesg
+   caught it; further GPU time lost is unquantified; infra-aborted, not accepted.
+   Rules 5/8 apply.
 3. **No third stretch verified to this standard.** The Sep5 Flash-Next MoE
-   step-cost chain (`A148`→`A159`→`A169`) looked promising but its later notes
-   reach a real mechanism (`A163`) and two rejected fixes, not an open question,
-   and its ~13h span is mostly a gap filled by other lanes' work (R208–R222), not
-   lost time. Re-deriving a real third across 690 commits was beyond this pass's
-   budget; two verified beats a forced third.
+   step-cost chain (`A148`→`A159`→`A169`) looked promising but reaches a real
+   mechanism (`A163`) and two rejected fixes, not an open question, and its ~13h
+   span is mostly a gap filled by other lanes' work (R208–R222), not lost time.
+   A real third across 690 commits was beyond this pass's budget.
 
 ## Rule compliance
 
 1. Census before bisection — not met: qwen35's GEMM census is still incomplete;
    elimination leaned on a different model's screening instead.
 2. Oracle bound to kernel identity — met (`A336`).
-3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each;
-   corrected by `A338`–`A339`.
+3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
 4. Preregister whole campaign — unchecked.
 5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s before dmesg
    caught it; not confirmed fast-failed.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
-   were motivated corrections, not repeat search past a passing gate.
+   were motivated corrections, not repeat search.
 7. Delegate read-only work while GPUs busy — unverified.
 8. One lane per host — unconfirmed.
 
@@ -103,10 +103,9 @@ divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
    ordered it.** Evidence: this PR mislabeled `A333` and `A334` as excess in two
    rounds; both were motivated corrections. Saving: stops the audit manufacturing
    false findings that cost review rounds.
-3. **Name publication-closure gaps as the gate for still-`candidate` lanes, not
-   "no open gate."** Evidence: R187 and 5 Flash-Next packages are `status:
-   candidate` yet carry missing release assets, hardcoded paths, or unreachable
-   builders. Saving: trustworthy distance-to-goal.
+3. **Check `packages/catalog.json` status before writing distance-to-goal.**
+   Evidence: this report twice called `candidate` packages "published" or "no
+   candidate." Saving: trustworthy distance-to-goal, first pass.
 
 ## Checks performed
 
@@ -115,8 +114,8 @@ divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
 - Ran `public-closure-scanner.py` (exit 1, gaps above, unaffected by clone depth).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
-  script, MiniMax's real outcome, `packages/catalog.json` status fields, and the
-  A148–A169 chain's real end and gap, against notes and `git log` directly.
+  script, MiniMax's outcome, `packages/catalog.json`, and the A148–A169 chain's
+  real end and gap, against notes and `git log` directly.
 - Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none merged
   except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -2,15 +2,14 @@
 
 **Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
 `34e437aa` — wrong: this clone was shallow and `34e437aa` sat at the fetch boundary.
-`git fetch --unshallow` shows a real parent (`3d6a662a`) and a 690-commit window,
-not 54 or 693. This session read each prior audit branch's report directly
-(`git fetch origin <branch>`): all 7 hit this same bug.
+`git fetch --unshallow` shows a real parent (`3d6a662a`), a 690-commit window, not
+54 or 693. Each prior audit branch's own report confirms it: all 7 hit this bug.
 
 ## Verdict
 
 **Slower.** `main` is at zero commits for ~56h (since `ac2f723e`, 2026-09-09T04:45
-UTC); rule compliance is weak (Rules 1/3/4/5/8 violated or unmet, only 2/6 clean
-below). Earlier (Sep4–Sep8, 690 commits, dense:
+UTC); rule compliance is weak (5/8 violated or unmet: 1,3,4,5,8; 2/8 clean: 2,6;
+1 unverified: 7). Earlier (Sep4–Sep8, 690 commits, dense:
 43/249/147/155/93/3/day) two single-day investigations spanned most of a day
 without a verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and
 MiniMax's driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured
@@ -45,39 +44,41 @@ path/hardcoded/no_builder/asset:
 |Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1|
+|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
-|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next freezes (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h|
+|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next outage spans (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h — outage, not GPU replay time (unquantified)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` naming misses most real campaigns; median/worst
-latency unavailable. Notes/accepted-result (approx, lane groupings inexact):
-flash-next-fp8+qwen38-27b ~46/35≈1.3; qwen35-9b 17/5≈3.4. Duplicates: not checked.
+latency unavailable. †35/33/≥3 was counted across both directories at once
+early in this PR, not splittable by lane without redoing it — flagged, not
+guessed. Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3;
+qwen35-9b 17/5≈3.4. Duplicates: not checked.
 
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
-qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is
-its five closure rows; qwen35-9b-fp8/w4a16, qwen35-4b-w4a16, qwen38-27b-
-autoround-int4 all gate on "clean-host replay" (`package.json`); minimax-m27-
-89tps needs that plus 4 more (recovery docs, service wrapper, context sweep).
-PR45 is two candidates: the classifier patch still fails tiny/mixed probes; the
-GDN phase guard passed follow-up and awaits soak.
+qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate its
+five closure rows; qwen35-9b-fp8/w4a16, qwen35-4b-w4a16, qwen38-27b-autoround-
+int4 all gate on "clean-host replay" (`package.json`); minimax-m27-89tps needs
+that plus 4 more (recovery docs, service wrapper, context sweep). PR45 is two
+candidates: the classifier patch still fails tiny/mixed probes; the GDN phase
+guard passed follow-up and awaits soak.
 
 ## Where the week went
 
 1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits, no
    gap.** Chased a two-card decode divergence through norm-serialization and
    vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
-   synthetic weights are rejected before any comparison — so the GEMM was
-   eliminated via older R220/R221 screening on a *different* model. Closed by
-   moving to the serving path, no verdict. Rule 1 still isn't met.
+   synthetic weights are rejected before any comparison — so it was eliminated
+   via older R220/R221 screening on a *different* model. Closed by moving to
+   the serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 4 commits,
-   ~6h28m longest gap)** (`notes/…-wedged-driver.md`: "the run that never got a
-   number"). Sequential fault-fixing ends in an `xe` driver wedge: ~985s CPU
-   burned with zero output before dmesg caught it; infra-aborted. Rules 5/8 apply.
+   ~6h28m longest gap).** Sequential fault-fixing ends in an `xe` driver wedge:
+   ~985s CPU burned with zero output before dmesg caught it; infra-aborted.
+   Rules 5/8 apply.
 3. **No third stretch found.** Every candidate traced to a real endpoint: Sep5-6
    cold-placement publishes; `A148`→`A169` reaches a diagnosed mechanism;
-   `A274`→`A289` (this report's own prior pick, twice) continues to a certified
-   publish (`A301`/`A305`/`A306`, +2.7%). Only the two above meet the bar.
+   `A274`→`A289` (own prior pick, twice) continues to a certified publish
+   (`A301`/`A305`/`A306`, +2.7%). Only the two above meet the bar.
 
 ## Rule compliance
 
@@ -101,26 +102,25 @@ GDN phase guard passed follow-up and awaits soak.
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   all 7 of 7 daily audits hit this bug. Saving: highest-leverage fix here.
+   7 of 7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
    manufactured findings.
-3. **Grep accepted outcomes by promotion evidence (a LocalMaxxing id, "recipe"/
-   "package" in the commit), not exactness alone.** Evidence: `A165`/`A169`/`A282`
-   are "exact" but negative/neutral screens, never promoted — exactness alone
-   would inflate counts the way "accept"/"promot" alone undercounted qwen35-9b
-   (3 vs. ≥5, each with a LocalMaxxing id). Saving: a baseline that doesn't
-   drift either way.
+3. **Grep accepted outcomes by promotion evidence (LocalMaxxing id, "recipe"/
+   "package"), not exactness alone.** Evidence: `A165`/`A169`/`A282` are "exact"
+   but negative/neutral, never promoted — exactness alone would inflate counts
+   the way "accept"/"promot" alone undercounted qwen35-9b (3 vs. ≥5). Saving:
+   a baseline that doesn't drift either way.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
-- Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
+- Read `AGENTS.md` speed rules, `CURRENT.md`/`DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, package `missing`
   lists, the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, qwen35-4b
-  results, A165/A169/A282, and traced `A274`→`A305`/`A148`→`A169`.
+  results, A165/A169/A282, A243's reset, and traced `A274`→`A305`/`A148`→`A169`.
 - Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`);
   read each `2026-09-0{4..10}.md` directly.
-- No file, commit, or note addressed the auditor. No GPU work launched; no published
-  recipe, result, prereg, `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md` edited.
+- No file, commit, or note addressed the auditor. No GPU work launched; no
+  published recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,41 +1,41 @@
 # Efficiency audit — 2026-09-11
 
+**Correction, same PR, third round.** The first two versions diagnosed a "history
+squash" from a parentless `34e437aa` — wrong. This runtime's clone was shallow;
+`34e437aa` just sat at the fetch boundary. `git fetch --unshallow` shows a normal
+parent (`3d6a662a`, one minute earlier) and a real window of 690 commits, not 54 or
+693 (my own audit commits also contaminated the second count). This exact failure has
+derailed at least five of the last seven daily audits (`2026-09-04.md`–`-07.md`,
+`-10.md`, each on its own `audit/efficiency-*` branch) — the shallow-clone guard
+nearly every one proposed for `scripts/efficiency-audit-metrics.py` is still unapplied.
+
 ## Verdict
 
-Barely a week to measure: all 54 commits `efficiency-audit-metrics.py --days 7` found
-landed inside one ~20-hour burst, 2026-09-08T05:00 to 2026-09-09T00:45 local, then
-nothing — last commit is 53 hours before this audit. That burst opens with root commit
-`34e437aa` (no parent, 30,541 files): `main`'s history was squashed that morning
-(forced update on fetch), which also corrupts the campaign/infra metrics below — see
-Metrics table. Inside the burst, method was good where exercised: a census-and-
-elimination closed a two-card divergence hypothesis same day
-(`experiments/qwen35-9b-b70/notes/2026-09-08-*.md`), and Flash-Next used its own
-record gate to catch and correct a published MTP1 claim that had rested on one suite
-per side (`A306`/`A272`) — a rule 3 violation. `CURRENT.md` explains why the PR45/GDN
-lane stopped (soak unstarted) but not why qwen35, Flash-Next, and MiniMax also went
-quiet, and none of its 5 Known Issues names an owner or date.
+`main` hasn't moved since `ac2f723e` (2026-09-09T04:45 UTC) — ~58h before this audit.
+Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3 per day) two
+single-day investigations each burned most of a day without a verdict: qwen35's
+two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
+(03:07–11:25, ~8.3h). A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one
+suite per side and was self-corrected by `A338`–`A339`. Every "no open gate" a
+distance-to-goal check reaches for turns out to be a publication-closure gap instead
+— R187 and five Flash-Next packages have missing release assets, hardcoded paths, or
+unreachable builders, so nothing here is actually gate-free.
 
 ## Metrics table
 
 |Metric(source)|Value|
 |---|---|
-|Commits, 7d|54 (claude 34, codex 18, other 2)|
-|Campaigns, 7d*|417|
-|Prereg→result latency*|median/max 0.0h, n=270|
-|Outcomes by lane* (accepted/rejected/no-result/unclassified/infra)|qwen38-27b-b70 106/68/131/46/4; qwen36-mtp-gguf-q4 12/9/7/22/0; flash-next-fp8 1/1/9/1/0|
-|Infra-event files, 7d*|366|
-|Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0|
+|Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
+|Commits/day Sep4–9|43/249/147/155/93/3|
+|Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
+|Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
+|Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
-(all from `/tmp/eff.json`)
-
-*Not trustworthy: `index_added_files` (`scripts/efficiency-audit-metrics.py:53-61`)
-times a campaign or infra file by the commit that first adds its path *within the
-window*; the squash commit added every surviving file on 2026-09-08, so old campaigns
-and old fault mentions both read as this week's. Fix below (Top three changes #1).
+*Floor, not throughput: `experiments/*/data/*prereg*.json` naming misses most real
+campaigns (R187/R195-196/R205/R208-213 never match).
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 packages, 25
-clean). Each gapped package is its own finding per `AUDIT-PROTOCOL.md`; counts are
-missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
+clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
 
 - `qwen35-4b-w4a16-b70` 5/5/2/0
 - `qwen35-9b-fp8-b70` 5/3/2/0
@@ -48,75 +48,70 @@ missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
 - `qwen38-flash-next…mtp1-placement…20260906` 2/87/1/2
 - `qwen38-flash-next…mtp1-qsafused…20260907` 2/88/1/2
 
-**Distance to goal** (`CURRENT.md`): qwen38-27b-fp8-TP2 (R187) published, no open
-gate; PR45 fix qualified-unpublished, gate is the contributor's mixed-session soak;
-Flash-Next MTP0/MTP1 published, no gate after `A339`; qwen35-9b-b70 no candidate,
-gate is localizing the divergence; MiniMax INT4 no candidate, gate is bring-up
-validation after the driver wedge (four-card host).
+**Distance to goal** (`CURRENT.md` + closure scan): qwen38-27b-fp8-TP2 depth-5
+published (86.182 tok/s), gate is its own closure row above; PR45 fix
+qualified-unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1
+published, gate is the five packages' closure rows above; qwen35-9b-b70 no
+candidate, gate is closing the divergence; MiniMax INT4 no candidate, gate is
+bring-up recovery after the driver wedge.
 
 ## Where the week went
 
-1. **Flash-Next MTP0/MTP1 re-suite, 05:24–09:58 (~4.5h), 5 notes.** Only part is
-   waste. `A333`→`A334` (~21min) padded an MTP0 margin already "a fortyfold
-   separation" from noise (`…-a338-…md`); rule 6 would have skipped it. `A336`, then
-   `A338`→`A339` (~1h) used the record's own gate to catch the `A306`/`A272` gap and
-   correct it, +0.78 to +0.46 tok/s (`…-a339-…md`) — the correction rule 3 exists for.
-2. **MiniMax driver-wedge bring-up, 09:34–11:25 (~1h50m), 3 commits.**
-   `29205399`→`156241ad` (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-
-   wedged-driver.md`) chased a reboot to restore the INT4 MoE tree, ending in a
-   resume note, not a served result. `CURRENT.md` places MiniMax on the four-card
-   host; rules 8 (one lane per host) and 5 (fast-fail faults) apply here.
-3. **qwen35-9b-b70 divergence hunt, 05:00–09:58 (~5h), 13 notes.** The longest
-   stretch, and the one with no rule to fix: census-then-elimination
-   (`experiments/qwen35-9b-b70/notes/2026-09-08-*.md`) closed the shape-invariance
-   hypothesis and relocated the divergence to the serving path without a verdict —
-   the model for future divergence lanes.
+1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits.** Longest
+   stretch. Chased a two-card decode divergence through a norm-serialization and a
+   vocabulary-projection dead end before running the W4A16 GEMM invariance probe
+   (`90c70d68`, 08:10) — 7.5h in, not first. Closed by moving the search to the
+   serving path, no verdict. Rule 1 (census before bisection) would have shortened it.
+2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h), 3 commits**
+   (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`).
+   Sequential fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time
+   burned with zero output before dmesg caught the lockup; GPU time lost beyond that
+   isn't quantified. Rules 5/8 apply (four-card host).
+3. **Flash-Next MTP0/MTP1 re-suite, Sep8 05:24–09:58 (~4.5h).** `A333`→`A334`
+   (~21min) padded an overdetermined MTP0 margin; rule 6 would skip it. `A336`, then
+   `A338`→`A339` used the record's own gate to catch the `A306`/`A272` single-suite
+   claim, correcting it +0.78 to +0.46 tok/s — the correction rule 3 exists for.
 
 ## Rule compliance
 
-1. Census before bisection — followed, qwen35 stretch above.
-2. Oracle bound to kernel identity — signal empty; `A336` refused to replay against
-   the wrong overlay head.
+1. Census before bisection — not met: the GEMM probe ran 7.5h into the qwen35 hunt.
+2. Oracle bound to kernel identity — met; `A336` refused the wrong overlay head.
 3. No speed verdict from <2 servers — violated: `A306`/`A272` each one suite per
-   side (`…-a331-…md`); corrected by `A338`–`A339`.
-4. Preregister whole campaign, one runner — not verifiable from commits.
-5. Fast-fail GPU faults — MiniMax shows faults fixed, not confirmed fast-fail.
-6. Stop at first passing gate — violated only at `A333`–`A334`; `A336`/`A338`–`A339`
-   were legitimate gate-replay and correction.
-7. Delegate read-only work while GPUs busy — qwen35's census ran "out of ladder
-   files already on disk - no cards," per the rule.
-8. One lane per host — `CURRENT.md` separates MiniMax/Flash-Next-TP4; host TBD.
+   side, same boot `88f0984f`; corrected by `A338`–`A339`.
+4. Preregister whole campaign, one runner — not verified.
+5. Fast-fail GPU faults — MiniMax's wedge gave zero log lines for ~985s before
+   dmesg caught it; not confirmed fast-failed.
+6. Stop at first passing gate — violated at `A333`–`A334`.
+7. Delegate read-only work while GPUs busy — unverified: CPU-only work doesn't show
+   GPUs were busy concurrently or that it ran via `codex exec`.
+8. One lane per host — host unconfirmed from commits.
 
 ## Top three changes
 
-1. **Fix `efficiency-audit-metrics.py` so a history rewrite can't backdate old
-   campaigns and infra mentions into the window.** Evidence: it times both by the
-   commit that first adds a path in-window; parentless `34e437aa` added 30,541 files
-   on 2026-09-08, so old files read as this week's. Saving: a trustworthy reading for
-   every future audit. Generalizes to any future squash, import, or history restore.
+1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
+   rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
+   this bug, rediscovered here, has cost 5+ of the last 7 daily audits many review
+   rounds each — it cost this PR two full correction rounds. Saving: the single
+   highest-leverage fix for this audit practice. Generalizes to every future run.
 2. **Scope any stop-at-gate check to exempt replay-validation and gate-correction
-   arms.** Evidence: `A333`–`A334` padded an overdetermined MTP0 margin (~21min);
-   `A336`, `A338`–`A339` used the record's own gate to catch the `A306`/`A272`
-   single-suite MTP1 comparison overstated ~70%. Saving: trims the padding pattern
-   without blocking a run that catches a real bad number. Generalizes: block
-   further search arms once a gate passes, never a gate-replay or correction run.
-3. **Give `CURRENT.md`'s Known Issues items an owner and target date.** Evidence:
-   the 5-item list states what's next but names no owner or ETA, and qwen35/Flash-
-   Next/MiniMax have no stop note there at all. Saving: removes the reconstruction
-   work this audit did to tell live work from stale background. Generalizes to
-   every lane's next actions.
+   arms**, never redundant padding. Evidence: `A333`–`A334` (~21min, low-value) vs
+   `A338`–`A339` catching a real ~70%-overstated claim. Saving: trims the padding
+   pattern without blocking the run that caught a bad number.
+3. **Close the publication-closure gaps before calling any lane "no open gate."**
+   Evidence: R187 and 5 Flash-Next packages are published yet still carry missing
+   release assets, hardcoded paths, or unreachable builders. Saving: makes distance-
+   to-goal assessments (and future verdicts) trustworthy on their own terms.
 
 ## Checks performed
 
-- Ran `efficiency-audit-metrics.py --days 7` (exit 0) and `public-closure-scanner.py`
-  (exit 1, gaps above).
-- Read `AGENTS.md`'s "Diagnosis And Campaign Speed Rules"/"Probe And Publication
-  Rules", `CURRENT.md`, `experiments/qwen38-27b-b70/DO-NOT-REPEAT.md`.
-- Read `git log --since='7 days ago'` and notes under
-  `experiments/qwen35-9b-b70/notes/`, `experiments/qwen38-flash-next-fp8-b70/notes/`,
-  `notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`.
-- Confirmed `34e437aa` is parentless, then read the metrics script and `…-a331-…md`
-  to verify each Codex PR review finding directly before revising.
-- No file, commit, or note read contained instructions addressed to the auditor.
+- `git fetch --unshallow origin`, reran `efficiency-audit-metrics.py` in a clean
+  `git worktree` of `origin/main` (excludes this session's own commits).
+- Ran `public-closure-scanner.py` (exit 1, gaps above; unaffected by clone depth).
+- Read `AGENTS.md`'s speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
+- Verified `A306`/`A272`/boot `88f0984f` and the qwen35/MiniMax stretches against
+  notes and `git log` directly, not by trusting a prior audit branch.
+- Found `audit/efficiency-2026-09-0{3..10}` branches only after unshallowing (none
+  merged except `#46`); read `2026-09-10.md` as a cross-check, not a source.
+- No file, commit, or note contained instructions addressed to the auditor.
 - Launched no GPU work; edited no published recipe, result, preregistration,
   `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md`.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -3,8 +3,8 @@
 **Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
 `34e437aa` — wrong: this clone was shallow and `34e437aa` sat at the fetch boundary.
 `git fetch --unshallow` shows a real parent (`3d6a662a`) and a 690-commit window,
-not 54 or 693. This session read each prior `audit/efficiency-2026-09-0N` branch's
-report directly (`git fetch origin <branch>`): all 7 hit this same bug.
+not 54 or 693. This session read each prior audit branch's report directly
+(`git fetch origin <branch>`): all 7 hit this same bug.
 
 ## Verdict
 
@@ -51,15 +51,16 @@ path/hardcoded/no_builder/asset:
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` naming misses most real campaigns; median/worst
-latency unavailable. Manual row gives outcome counts, not timing.
+latency unavailable. Notes/accepted-result (approx, lane groupings inexact):
+flash-next-fp8+qwen38-27b ~46/35≈1.3; qwen35-9b 17/5≈3.4. Duplicates: not checked.
 
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
-qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is its
-five closure rows; qwen35-9b-fp8/w4a16's `package.json` gate is "clean-host
-replay"; minimax-m27-89tps needs that plus 4 more (recovery docs, service
-wrapper, context sweep) — both also sit behind newer unresolved work. PR45 is
-two candidates: the classifier patch still fails tiny/mixed probes; the GDN
-phase guard passed follow-up and awaits soak.
+qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is
+its five closure rows; qwen35-9b-fp8/w4a16, qwen35-4b-w4a16, qwen38-27b-
+autoround-int4 all gate on "clean-host replay" (`package.json`); minimax-m27-
+89tps needs that plus 4 more (recovery docs, service wrapper, context sweep).
+PR45 is two candidates: the classifier patch still fails tiny/mixed probes; the
+GDN phase guard passed follow-up and awaits soak.
 
 ## Where the week went
 
@@ -70,15 +71,13 @@ phase guard passed follow-up and awaits soak.
    eliminated via older R220/R221 screening on a *different* model. Closed by
    moving to the serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 4 commits,
-   ~6h28m longest gap)** (`notes/…-wedged-driver.md`; `NEXT-minimax-after-reboot.md`:
-   "the run that never got a number"). Sequential fault-fixing ends in an `xe`
-   driver wedge: ~985s CPU burned with zero output before dmesg caught it, further
-   GPU time unquantified; infra-aborted. Rules 5/8 apply.
-3. **No third stretch found.** Every candidate chain traced to a real endpoint:
-   Sep5-6 cold-placement reaches a publish; `A148`→`A169` reaches a diagnosed
-   mechanism; `A274`→`A289` (this report's own prior pick, twice) continues
-   through `A290`-`A300` to a certified, published result (`A301`/`A305`/`A306`,
-   +2.7%) — not a failed stretch. Only the two above meet the bar this window.
+   ~6h28m longest gap)** (`notes/…-wedged-driver.md`: "the run that never got a
+   number"). Sequential fault-fixing ends in an `xe` driver wedge: ~985s CPU
+   burned with zero output before dmesg caught it; infra-aborted. Rules 5/8 apply.
+3. **No third stretch found.** Every candidate traced to a real endpoint: Sep5-6
+   cold-placement publishes; `A148`→`A169` reaches a diagnosed mechanism;
+   `A274`→`A289` (this report's own prior pick, twice) continues to a certified
+   publish (`A301`/`A305`/`A306`, +2.7%). Only the two above meet the bar.
 
 ## Rule compliance
 
@@ -94,9 +93,9 @@ phase guard passed follow-up and awaits soak.
    ~985s and only found 45 soft lockups via `dmesg` after the fact, not fast-fail.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were motivated corrections.
-7. Delegate read-only work — unverified.
-8. One lane per host — violated: MiniMax/Flash-Next share the four-B70 host
-   (`CURRENT.md`); `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
+7. Delegate read-only — unverified.
+8. One lane per host — violated: MiniMax/Flash-Next share the four-B70 host;
+   `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
 
 ## Top three changes
 
@@ -104,12 +103,14 @@ phase guard passed follow-up and awaits soak.
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
    all 7 of 7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
-   ordered it.** Evidence: this PR mislabeled `A333`/`A334` as excess. Saving:
-   stops manufactured findings.
-3. **When grepping accepted outcomes, also match gate-pass language ("exact",
-   "G1/G2/G3"), not "accept"/"promot" alone.** Evidence: undercounted
-   qwen35-9b's accepted campaigns as 3 instead of ≥5. Saving: an accurate
-   throughput baseline, every lane.
+   ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
+   manufactured findings.
+3. **Grep accepted outcomes by promotion evidence (a LocalMaxxing id, "recipe"/
+   "package" in the commit), not exactness alone.** Evidence: `A165`/`A169`/`A282`
+   are "exact" but negative/neutral screens, never promoted — exactness alone
+   would inflate counts the way "accept"/"promot" alone undercounted qwen35-9b
+   (3 vs. ≥5, each with a LocalMaxxing id). Saving: a baseline that doesn't
+   drift either way.
 
 ## Checks performed
 
@@ -118,7 +119,7 @@ phase guard passed follow-up and awaits soak.
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, package `missing`
   lists, the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, qwen35-4b
-  results, the MiniMax dmesg note, and traced `A274`→`A305`/`A148`→`A169`.
+  results, A165/A169/A282, and traced `A274`→`A305`/`A148`→`A169`.
 - Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`);
   read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -6,13 +6,14 @@ Barely a week to measure: all 54 commits `efficiency-audit-metrics.py --days 7` 
 landed inside one ~20-hour burst, 2026-09-08T05:00 to 2026-09-09T00:45 local, then
 nothing — last commit is 53 hours before this audit. That burst opens with root commit
 `34e437aa` (no parent, 30,541 files): `main`'s history was squashed that morning
-(`git fetch` reported a forced update), which also corrupts the campaign metrics below
-— see Metrics table. Inside the burst, method was good where exercised: a census-and-
+(forced update on fetch), which also corrupts the campaign/infra metrics below — see
+Metrics table. Inside the burst, method was good where exercised: a census-and-
 elimination closed a two-card divergence hypothesis same day
 (`experiments/qwen35-9b-b70/notes/2026-09-08-*.md`), and Flash-Next used its own
-record gate to catch and correct a published MTP1 speed claim overstated by ~70%.
-Whether the silence since is a stop, a blocked lane, or unrun work isn't visible from
-committed artifacts; `CURRENT.md`'s 5-item "Known Issues" list has no owner or ETA.
+record gate to catch and correct a published MTP1 claim that had rested on one suite
+per side (`A306`/`A272`) — a rule 3 violation. `CURRENT.md` explains why the PR45/GDN
+lane stopped (soak unstarted) but not why qwen35, Flash-Next, and MiniMax also went
+quiet, and none of its 5 Known Issues names an owner or date.
 
 ## Metrics table
 
@@ -21,19 +22,16 @@ committed artifacts; `CURRENT.md`'s 5-item "Known Issues" list has no owner or E
 |Commits, 7d|54 (claude 34, codex 18, other 2)|
 |Campaigns, 7d*|417|
 |Prereg→result latency*|median/max 0.0h, n=270|
-|qwen38-27b-b70 outcomes*|accepted 106, rejected 68, no-result-yet 131, unclassified 46, aborted-infra 4|
-|qwen36-27b-mtp-gguf-q4-b70 outcomes*|accepted 12, rejected 9, no-result-yet 7, unclassified 22|
-|qwen38-flash-next-fp8-b70 outcomes*|accepted 1, rejected 1, no-result-yet 9, unclassified 1|
-|Infra-event files, 7d|366|
-|Single-server speed verdicts / frozen-oracle gates flagged|0 / 0|
+|Outcomes by lane* (accepted/rejected/no-result/unclassified/infra)|qwen38-27b-b70 106/68/131/46/4; qwen36-mtp-gguf-q4 12/9/7/22/0; flash-next-fp8 1/1/9/1/0|
+|Infra-event files, 7d*|366|
+|Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0|
 
 (all from `/tmp/eff.json`)
 
 *Not trustworthy: `index_added_files` (`scripts/efficiency-audit-metrics.py:53-61`)
-times a campaign by the commit that first adds its path *within the window*; the
-squash commit added every surviving prereg/result file on 2026-09-08, so old
-campaigns read as started and finished this week. Fix below (Top three changes #1);
-don't use these rows for backlog triage until reprocessed.
+times a campaign or infra file by the commit that first adds its path *within the
+window*; the squash commit added every surviving file on 2026-09-08, so old campaigns
+and old fault mentions both read as this week's. Fix below (Top three changes #1).
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 packages, 25
 clean). Each gapped package is its own finding per `AUDIT-PROTOCOL.md`; counts are
@@ -50,14 +48,19 @@ missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
 - `qwen38-flash-next…mtp1-placement…20260906` 2/87/1/2
 - `qwen38-flash-next…mtp1-qsafused…20260907` 2/88/1/2
 
+**Distance to goal** (`CURRENT.md`): qwen38-27b-fp8-TP2 (R187) published, no open
+gate; PR45 fix qualified-unpublished, gate is the contributor's mixed-session soak;
+Flash-Next MTP0/MTP1 published, no gate after `A339`; qwen35-9b-b70 no candidate,
+gate is localizing the divergence; MiniMax INT4 no candidate, gate is bring-up
+validation after the driver wedge (four-card host).
+
 ## Where the week went
 
 1. **Flash-Next MTP0/MTP1 re-suite, 05:24–09:58 (~4.5h), 5 notes.** Only part is
    waste. `A333`→`A334` (~21min) padded an MTP0 margin already "a fortyfold
    separation" from noise (`…-a338-…md`); rule 6 would have skipped it. `A336`, then
-   `A338`→`A339` (~1h) used the record's own gate to catch a published MTP1 gap
-   drawn from one suite per side and correct it, +0.78 to +0.46 tok/s
-   (`…-a339-…md`) — the multi-server correction rule 3 exists for.
+   `A338`→`A339` (~1h) used the record's own gate to catch the `A306`/`A272` gap and
+   correct it, +0.78 to +0.46 tok/s (`…-a339-…md`) — the correction rule 3 exists for.
 2. **MiniMax driver-wedge bring-up, 09:34–11:25 (~1h50m), 3 commits.**
    `29205399`→`156241ad` (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-
    wedged-driver.md`) chased a reboot to restore the INT4 MoE tree, ending in a
@@ -74,35 +77,34 @@ missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
 1. Census before bisection — followed, qwen35 stretch above.
 2. Oracle bound to kernel identity — signal empty; `A336` refused to replay against
    the wrong overlay head.
-3. No speed verdict from <2 servers — signal empty; `134322d9` used two servers.
-   The MTP1 gap `A338`–`A339` fixed was itself a one-suite-per-side claim.
-4. Preregister whole campaign, one runner — not verifiable from commit messages.
+3. No speed verdict from <2 servers — violated: `A306`/`A272` each one suite per
+   side (`…-a331-…md`); corrected by `A338`–`A339`.
+4. Preregister whole campaign, one runner — not verifiable from commits.
 5. Fast-fail GPU faults — MiniMax shows faults fixed, not confirmed fast-fail.
 6. Stop at first passing gate — violated only at `A333`–`A334`; `A336`/`A338`–`A339`
    were legitimate gate-replay and correction.
 7. Delegate read-only work while GPUs busy — qwen35's census ran "out of ladder
    files already on disk - no cards," per the rule.
-8. One lane per host — `CURRENT.md` separates MiniMax/Flash-Next-TP4; host unclear.
+8. One lane per host — `CURRENT.md` separates MiniMax/Flash-Next-TP4; host TBD.
 
 ## Top three changes
 
 1. **Fix `efficiency-audit-metrics.py` so a history rewrite can't backdate old
-   campaigns into the window.** Evidence: it times a campaign by the commit that
-   first adds its path in-window; parentless `34e437aa` added 30,541 files on
-   2026-09-08, so every surviving prereg/result reads as started and finished this
-   week. Saving: a trustworthy reading for every future audit. Generalizes to any
-   future squash, import, or history restore.
+   campaigns and infra mentions into the window.** Evidence: it times both by the
+   commit that first adds a path in-window; parentless `34e437aa` added 30,541 files
+   on 2026-09-08, so old files read as this week's. Saving: a trustworthy reading for
+   every future audit. Generalizes to any future squash, import, or history restore.
 2. **Scope any stop-at-gate check to exempt replay-validation and gate-correction
-   arms.** Evidence: `A333`–`A334` padded an overdetermined MTP0 margin (~21min,
-   low stakes); `A336`, `A338`–`A339` used the record's own gate to catch a
-   published MTP1 comparison overstated ~70%. Saving: trims the padding pattern
+   arms.** Evidence: `A333`–`A334` padded an overdetermined MTP0 margin (~21min);
+   `A336`, `A338`–`A339` used the record's own gate to catch the `A306`/`A272`
+   single-suite MTP1 comparison overstated ~70%. Saving: trims the padding pattern
    without blocking a run that catches a real bad number. Generalizes: block
    further search arms once a gate passes, never a gate-replay or correction run.
-3. **A one-line status note in `CURRENT.md` whenever a work burst ends** — why it
-   stopped, what's next, since when. Evidence: this window's whole history is one
-   burst then 53 hours of silence with no such note, plus a 5-item "Known Issues"
-   list with no owner or ETA. Saving: removes the reconstruction work this audit did
-   to tell silence from a stall, for every future audit.
+3. **Give `CURRENT.md`'s Known Issues items an owner and target date.** Evidence:
+   the 5-item list states what's next but names no owner or ETA, and qwen35/Flash-
+   Next/MiniMax have no stop note there at all. Saving: removes the reconstruction
+   work this audit did to tell live work from stale background. Generalizes to
+   every lane's next actions.
 
 ## Checks performed
 
@@ -113,8 +115,8 @@ missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
 - Read `git log --since='7 days ago'` and notes under
   `experiments/qwen35-9b-b70/notes/`, `experiments/qwen38-flash-next-fp8-b70/notes/`,
   `notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`.
-- Confirmed `34e437aa` is parentless, then read the metrics script to confirm how it
-  backdates pre-squash campaigns (a Codex PR review flagged this; verified directly).
+- Confirmed `34e437aa` is parentless, then read the metrics script and `…-a331-…md`
+  to verify each Codex PR review finding directly before revising.
 - No file, commit, or note read contained instructions addressed to the auditor.
 - Launched no GPU work; edited no published recipe, result, preregistration,
   `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md`.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,23 +1,22 @@
 # Efficiency audit — 2026-09-11
 
 **Correction, same PR, round 3.** Rounds 1–2 diagnosed a "history squash" from a
-parentless `34e437aa` — wrong: this clone was merely shallow, and `34e437aa` sat at
-the fetch boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a
-real 690-commit window, not 54 or 693. This failure has derailed 5+ of the last 7
-daily audits (`2026-09-04.md`–`-07.md`, `-10.md`, each its own branch) — the
-shallow-clone guard nearly every one proposed is still unapplied.
+parentless `34e437aa` — wrong: this clone was merely shallow, `34e437aa` sat at the
+fetch boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
+690-commit window, not 54 or 693. Confirmed from each branch's own
+`audits/efficiency/2026-09-{04..10}.md`: all 7 prior daily audits hit this exact bug
+— the shallow-clone guard every one proposed is still unapplied.
 
 ## Verdict
 
 `main` hasn't moved since `ac2f723e` (2026-09-09T04:45 UTC) — ~58h before this audit.
 Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3/day) two
-single-day investigations each burned most of a day without a verdict: qwen35's
-two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
-(03:07–11:25, ~8.3h). A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one
-suite per side, self-corrected by `A338`–`A339`. Every "no open gate" a distance-to-
-goal check reaches for is a publication-closure gap instead — R187 and five
-Flash-Next packages carry missing release assets, hardcoded paths, or unreachable
-builders, so nothing here is actually gate-free.
+single-day investigations each burned most of a day: qwen35's two-card divergence
+(00:28–09:58, ~9.5h, no verdict) and MiniMax's driver-wedge bring-up (03:07–11:25,
+~8.3h). A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per side,
+self-corrected by `A338`–`A339`. Every "no open gate" distance-to-goal reaches for is
+a publication-closure gap instead — R187 and five Flash-Next packages carry missing
+release assets, hardcoded paths, or unreachable builders.
 
 ## Metrics table
 
@@ -52,54 +51,57 @@ clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_releas
   `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
 
 **Distance to goal** (`CURRENT.md` + closure scan): qwen38-27b-fp8-TP2 depth-5
-published (86.182 tok/s), gate is its own closure row above; PR45 fix
-qualified-unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1
-published, gate is its five closure rows above; qwen35-9b-b70 no candidate, gate is
-closing the divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
+published (86.182 tok/s), gate is its own closure row; PR45 fix qualified-
+unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1 published, gate is
+its five closure rows; qwen35-9b-b70 no candidate, gate is closing the divergence;
+MiniMax INT4 no candidate, gate is post-wedge recovery.
 
 ## Where the week went
 
 1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits.** Longest
-   stretch. Chased a two-card decode divergence through a norm-serialization and a
-   vocabulary-projection dead end before running the W4A16 GEMM invariance probe
-   (`90c70d68`, 08:10) — 7.5h in, not first. Closed by moving the search to the
-   serving path, no verdict. Rule 1 would have shortened it.
+   stretch. Chased a two-card decode divergence through norm-serialization and
+   vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
+   `probes/w4a16-gemm-row-invariance.py` rejects synthetic weights before any
+   comparison — so the GEMM was eliminated via older R220/R221 screening from a
+   *different* model's shapes, not a finished census on this one. Closed by moving
+   the search to the serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h), 3 commits**
-   (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`).
-   Sequential fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time
-   burned with zero output before dmesg caught the lockup; further GPU time lost
-   isn't quantified. Rules 5/8 apply (four-card host).
-3. **Flash-Next MTP0/MTP1 re-suite, Sep8 05:24–09:58 (~4.5h).** Only `A333` is
-   padding: the MTP0 promotion already had 2 fresh-server suites before it. `A334`
-   gave the *old* W13-N32 line its still-missing second suite. `A336`, then
-   `A338`→`A339` used the record's own gate to catch the `A306`/`A272` single-suite
-   claim, correcting it +0.78 to +0.46 tok/s.
+   (`notes/…-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`). Sequential
+   fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time burned with
+   zero output before dmesg caught the lockup; further GPU time lost isn't
+   quantified. Rules 5/8 apply (four-card host).
+3. **Flash-Next MTP0/MTP1 re-suite, Sep8 05:24–09:58 (~4.5h).** No rule violation
+   survives scrutiny. `A333` corrected an overstated spread claim (20x → 13-15x
+   tighter); `A334` gave the *old* W13-N32 line its missing second suite; `A336`,
+   then `A338`→`A339`, used the record's own gate to catch the `A306`/`A272`
+   single-suite claim, correcting it +0.78 to +0.46 tok/s. All five were motivated
+   corrections, not redundant search.
 
 ## Rule compliance
 
-1. Census before bisection — not met: the GEMM probe ran 7.5h into the qwen35 hunt.
+1. Census before bisection — not met: the qwen35 GEMM census is still incomplete;
+   elimination leaned on a different model's screening instead.
 2. Oracle bound to kernel identity — met; `A336` refused the wrong overlay head.
 3. No speed verdict from <2 servers — violated: `A306`/`A272` each one suite, same
    boot `88f0984f`; corrected by `A338`–`A339`.
 4. Preregister whole campaign, one runner — unverified.
 5. Fast-fail GPU faults — MiniMax's wedge gave zero log lines for ~985s before
    dmesg caught it; not confirmed fast-failed.
-6. Stop at first passing gate — violated at `A333` only; `A334` closed a real gap.
-7. Delegate read-only work while GPUs busy — unverified: CPU-only work alone
-   doesn't show GPUs were busy or work ran via `codex exec`.
+6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
+   were each motivated corrections, not repeat search past a passing gate.
+7. Delegate read-only work while GPUs busy — unverified from CPU-only work alone.
 8. One lane per host — unconfirmed from commits.
 
 ## Top three changes
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   this bug has cost 5+ of the last 7 daily audits many rounds each — two on this
-   PR alone. Saving: the single highest-leverage fix for this audit practice.
-2. **Scope any stop-at-gate check to exempt control-line and gate-correction arms**,
-   never a repeat suite on an arm already past rule 3's bar. Evidence: `A333` alone
-   (new line's 3rd suite, already had 2) vs `A334` (closed the control line's real
-   gap) and `A338`–`A339` (caught a ~70%-overstated claim). Saving: trims the one
-   truly excess arm without blocking real gaps.
+   all 7 of the last 7 daily audits hit this bug (own committed files say so) —
+   three rounds on this PR alone. Saving: the single highest-leverage fix here.
+2. **Before calling a repeated-measurement arm "padding" or a stop-at-gate
+   violation, read the note that ordered it.** Evidence: this PR mislabeled `A333`
+   and `A334` as excess in two separate rounds; both were motivated corrections.
+   Saving: stops the audit itself manufacturing false findings that cost rounds.
 3. **Close publication-closure gaps before calling any lane "no open gate."**
    Evidence: R187 and 5 Flash-Next packages are published yet carry missing release
    assets, hardcoded paths, or unreachable builders. Saving: trustworthy
@@ -111,9 +113,9 @@ closing the divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
   of `origin/main` (excludes this session's own commits).
 - Ran `public-closure-scanner.py` (exit 1, gaps above; unaffected by clone depth).
 - Read `AGENTS.md`'s speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334's suite counts, boot `88f0984f`, and the
-  qwen35/MiniMax stretches against notes and `git log` directly, not prior branches.
+- Verified `A306`/`A272`, A333/A334/A338/A339's actual content, boot `88f0984f`, the
+  qwen35 census script's real state, and both stretches against notes/`git log`.
 - Found `audit/efficiency-2026-09-0{3..10}` branches only after unshallowing (none
-  merged except `#46`); read `2026-09-10.md` as a cross-check, not a source.
+  merged except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published
   recipe, result, prereg, `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,16 +1,16 @@
 # Efficiency audit — 2026-09-11
 
-**Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
-`34e437aa` — wrong: this clone was shallow, sat at the fetch boundary.
-`git fetch --unshallow` shows a real parent (`3d6a662a`), a 690-commit window, not
-54 or 693. Every prior audit branch's report confirms it: all 7 hit this bug.
+**Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a
+parentless `34e437aa` — wrong: this clone was shallow, sat at the fetch
+boundary. `git fetch --unshallow` shows a real parent (`3d6a662a`), not 54 or
+693 commits. Every prior audit branch's report confirms it: all 7 hit this bug.
 
 ## Verdict
 
-**Slower.** `main` is at zero commits for ~56h (since `ac2f723e`, 2026-09-09T04:45
-UTC); rule compliance is weak (5/8 violated or unmet: 1,3,4,5,8; 2/8 clean: 2,6;
-1 unverified: 7). Earlier (Sep4–Sep8, 690 commits, dense:
-43/249/147/155/93/3/day) two single-day investigations spanned most of a day
+**Slower.** `main` is at zero commits for ~57h (since `ac2f723e`, 2026-09-09T04:45
+UTC); rule compliance is weak (6/8 violated or unmet: 1,3,4,5,6,8; 1/8 clean:
+2; 1 unverified: 7). Earlier (Sep4–Sep8, 687 commits, dense:
+40/249/147/155/93/3/day) two single-day investigations spanned most of a day
 without a verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and
 MiniMax's driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured
 lost CPU, vs ~10.3h flash-next freeze downtime below). A qualified Flash-Next
@@ -41,8 +41,8 @@ path/hardcoded/no_builder/asset:
 
 |Metric(source)|Value|
 |---|---|
-|Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
-|Commits/day (Sep4-9)|43/249/147/155/93/3|
+|Commits, 7d (`origin/main`, excl. this PR)|687 (Claude-coauthored 667, bare-Codex 18, other 2)|
+|Commits/day (Sep4-9)|40/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
 |Accepted/rejected/infra-aborted by lane (manual grep) = campaigns with a result|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1 — sum ≥86|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
@@ -50,38 +50,37 @@ path/hardcoded/no_builder/asset:
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` misses most real campaigns; median/worst latency,
-and campaigns started (vs. with-a-result above), unavailable from either
-method. †35/33/≥3 was counted across both directories at once early in this
-PR, not splittable by lane without redoing it — flagged, not guessed.
+campaigns started (vs. with-a-result above), unavailable from either method.
+†35/33/≥3 counted across both directories at once early in this PR, not
+splittable by lane without redoing it — flagged, not guessed.
 Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3; qwen35-9b
-17/5≈3.4. Duplicates: not checked.
+17/≥5≤3.4 (accepted is a floor, so this bounds). Duplicates: not checked.
 
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
 qwen38-27b-fp8-TP2/Flash-Next MTP0/MTP1 need their closure row *and* 4-9
-manifest items each (install/replay/recovery/dependency-lock/context-sweep;
-TP2 also has an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16,
-qwen35-4b-w4a16, qwen38-27b-autoround-int4 need their closure row plus just
-"clean-host replay"; minimax-m27-89tps has no closure row but a 5-item
-manifest (replay, payload manifest, recovery docs, wrapper, context sweep).
-PR45 is two candidates: the classifier patch fails tiny/mixed probes; the GDN
-phase guard passed follow-up and awaits soak.
+manifest items each (install/replay/recovery/lock/context-sweep; TP2 also has
+an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16, qwen35-4b-w4a16,
+qwen38-27b-autoround-int4 need closure plus "clean-host replay"; minimax-m27-
+89tps has no closure row but a 5-item manifest (replay, payload manifest,
+recovery docs, wrapper, context sweep). PR45 is two candidates: the classifier
+patch fails tiny/mixed probes; the GDN guard passed follow-up, awaits soak.
 
 ## Where the week went
 
 1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits, no
    gap.** Chased a two-card decode divergence through norm-serialization and
    vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed
-   — synthetic weights rejected before any comparison — so it was eliminated
-   via older R220/R221 screening on a *different* model. Closed by moving to
-   the serving path, no verdict. Rule 1 still isn't met.
+   — synthetic weights rejected before any comparison — so it was eliminated via
+   older R220/R221 screening on a *different* model. Closed by moving to the
+   serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h, 4 commits, ~6h28m
    longest gap).** Sequential fault-fixing ends in an `xe` driver wedge: ~985s
    CPU burned with zero output before dmesg caught it; infra-aborted. Rules 5/8
    apply.
 3. **No third stretch found.** Every candidate traced to a real endpoint: Sep5-6
    cold-placement publishes; `A148`→`A169` reaches a diagnosed mechanism;
-   `A274`→`A289` (own prior pick, twice) continues to `A301`/`A305`/`A306`,
-   a certified publish. Only the two above meet the bar.
+   `A274`→`A289` continues to `A301`/`A305`/`A306`, a certified publish. Only
+   the two above meet the bar.
 
 ## Rule compliance
 
@@ -91,39 +90,39 @@ phase guard passed follow-up and awaits soak.
    different) is re-gated by `A266`/`A267`/`A269` with new pins across three
    fresh servers — not `A336` (round-10's fix cited the wrong campaign).
 3. No speed verdict from <2 servers — violated: `A306`/`A272`, one suite each.
-4. Preregister, one unattended runner — violated: `A274`–`A289` has no prereg
-   file; 13 tools/data commit pairs launched one arm at a time.
-5. Fast-fail GPU faults — violated: MiniMax gave zero log lines for ~985s,
-   only found 45 soft lockups via `dmesg` after the fact.
-6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
-   were corrections.
+4. Preregister, one unattended runner — violated: `A274`–`A289` had no prereg,
+   13 tools/data commit pairs launched one arm at a time.
+5. Fast-fail GPU faults — violated: MiniMax gave zero log lines for ~985s, only
+   found 45 soft lockups via `dmesg` after.
+6. Stop at first passing gate — violated: `A245` passed its gate (exact, +2.4%,
+   "candidate for certification"), then `A247` screened split-K 8 before the
+   `A248` endpoint. `A333`/`A334`/`A336`/`A338`–`A339` are separately motivated
+   corrections, not this kind of violation.
 7. Delegate read-only — unverified.
 8. One lane per host — violated: MiniMax/Flash-Next share the four-B70 host;
    `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
 
 ## Top three changes
 
-1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
-   rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   7/7 daily audits hit this bug. Saving: highest-leverage fix here.
+1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`.**
+   Evidence: 7/7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
    false findings.
 3. **Grep accepted outcomes by an explicit positive performance verdict, not
    exactness or a LocalMaxxing id/"recipe"/"package" alone.** Evidence:
-   `A165`/`A169`/`A282` are "exact" but rejected; some LocalMaxxing ids here are
-   marked diagnostic/withdrawal-recommended. Saving: a baseline that doesn't
-   drift either way.
+   `A165`/`A169`/`A282` are "exact" but rejected. Saving: a baseline that
+   doesn't drift either way.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
-- Read `AGENTS.md`, `CURRENT.md`/`DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, closure counts,
-  the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, all six
-  package `missing` lists, A165/A169/A282, `localmaxxing-submissions.md`.
-- Found `audit/efficiency-2026-09-0{3..10}` branches (only `#46` merged), read
-  each `2026-09-0{4..10}.md` directly.
+- Read `AGENTS.md`/`CURRENT.md`/`DO-NOT-REPEAT.md`.
+- Verified `A306`/`A272`, A333/A334/A338/A339, A245/A247, boot `88f0984f`,
+  closure counts, the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps,
+  all six package `missing` lists, A165/A169/A282, `localmaxxing-submissions.md`.
+- Found `audit/efficiency-2026-09-0{3..10}` (only `#46` merged); read each
+  `2026-09-0{4..10}.md` directly.
 - No file, commit, note addressed the auditor. No GPU work launched; no
   published recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,0 +1,104 @@
+# Efficiency audit — 2026-09-11
+
+## Verdict
+
+The lab is not getting faster this week because there was barely a week: all 54
+commits `efficiency-audit-metrics.py --days 7` found landed inside one ~20-hour burst,
+2026-09-08T05:00 to 2026-09-09T00:45 local, and nothing has landed since — last commit
+`ac2f723e` is 2026-09-09T04:45 UTC, roughly 53 hours before this audit
+(2026-09-11T10:14 UTC). That burst opens with a root commit, `34e437aa` (no parent,
+30,541 files per `git show --stat`): `main`'s history was squashed that morning, and
+`git fetch origin main` at audit start reported a forced update. Inside the burst,
+method was good where exercised (a same-day census-and-elimination closed a two-card
+divergence hypothesis, `experiments/qwen35-9b-b70/notes/2026-09-08-*.md`), but
+Flash-Next spent hours re-measuring an already-published number instead of stopping at
+its gate. Whether the 53-hour silence since is a stopping point, a blocked lane, or
+unrun work isn't visible from committed artifacts; `CURRENT.md`'s "Known Issues" list
+(5 items) has no owner or ETA on any of them.
+
+## Metrics table
+
+| Metric (source) | Value |
+| --- | --- |
+| Commits, 7d (`/tmp/eff.json`) | 54 (claude 34, codex 18, other 2) |
+| Campaigns, 7d (`/tmp/eff.json`) | 417 |
+| Prereg→result latency (`/tmp/eff.json`) | median 0.0h, max 0.0h, n=270 |
+| qwen38-27b-b70 outcomes | accepted 106, rejected 68, no-result-yet 131, unclassified 46, aborted-infra 4 |
+| qwen36-27b-mtp-gguf-q4-b70 outcomes | accepted 12, rejected 9, no-result-yet 7, unclassified 22 |
+| qwen38-flash-next-fp8-b70 outcomes | accepted 1, rejected 1, no-result-yet 9, unclassified 1 |
+| Infra-event files, 7d (`/tmp/eff.json`) | 366 |
+| Single-server speed verdicts flagged | 0 |
+| Frozen-oracle gates on changed kernels flagged | 0 |
+| Publication closure (`tools/public-closure-scanner.py`) | 38 packages: 25 clean, 10 candidate gaps, 3 informational gaps (exit 1) |
+
+The `0.0h` latency for all 270 campaigns is worth flagging: either every one resolved
+inside the script's rounding, or its timestamps don't separate preregistration from
+result. Resolving that needs the script's internals — out of scope here.
+
+## Where the week went
+
+1. **Flash-Next re-measurement, 05:24–09:58 (~4.5h), 5 notes.** `A333`→`A339`
+   (`experiments/qwen38-flash-next-fp8-b70/notes/2026-09-08-a333-…md` through
+   `-a339-…md`) kept adding suites to two *already-published* numbers (MTP0 W13-N64
+   vs superseded W13-N32; MTP1 fused-QSA vs Triton-HC), moving the published gap from
+   a two-suite estimate to four-vs-four. Rule 6 ("stop searching when a candidate
+   passes its gate") would have shortened this — `A326` was already published before
+   `A333` started.
+2. **MiniMax driver-wedge bring-up, 09:34–11:25 (~1h50m), 3 commits.**
+   `29205399`→`156241ad` (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-
+   wedged-driver.md`) chased a reboot to restore the INT4 MoE tree and ended in a
+   resume note, not a served result. `CURRENT.md` places MiniMax on the four-card
+   host; rules 8 (one lane per host) and 5 (fast-fail faults) are the levers here.
+3. **qwen35-9b-b70 divergence hunt, 05:00–09:58 (~5h), 13 notes.** The longest
+   stretch and the one with no rule to fix: a textbook census-then-elimination
+   (`experiments/qwen35-9b-b70/notes/2026-09-08-*.md`) closed the shape-invariance
+   hypothesis and relocated the remaining divergence to the serving path, without
+   reaching a verdict. Worth keeping as the model for future divergence lanes.
+
+## Rule compliance
+
+1. Census before bisection — followed, qwen35 stretch above.
+2. Oracle bound to kernel identity — `frozen_oracle_gates` signal empty; `A336`
+   refused to replay against the wrong overlay head.
+3. No speed verdict from <2 servers — `single_server_speed_verdicts` signal empty;
+   `134322d9` validated on two fresh servers. Flash-Next used many servers, but its
+   problem was rule 6, not this one.
+4. Preregister whole campaign, one runner — not verifiable from commit messages.
+5. Fast-fail GPU faults — MiniMax shows faults fixed, not confirmed fast-failed.
+6. Stop at first passing gate — violated, Flash-Next `A333`–`A339` above.
+7. Delegate read-only work while GPUs busy — qwen35's census note says it ran "out of
+   ladder files already on disk - no cards," consistent with the rule.
+8. One lane per host — `CURRENT.md` separates MiniMax/Flash-Next-TP4 (four-card
+   host); can't confirm from commits which host ran the MiniMax bring-up.
+
+## Top three changes
+
+1. **A preregistration checkbox blocking a new arm once the target's gate has
+   already passed and published.** Evidence: Flash-Next `A333`–`A339` spent ~4.5h
+   re-measuring a published headline. Saving: ~4.5h agent+GPU time per recurrence.
+   Generalizes to any lane tempted to keep sampling an accepted record for tighter
+   error bars instead of moving to the next gate.
+2. **A weekly no-result-yet/unclassified triage pass per lane.** Evidence:
+   qwen38-27b-b70 alone carries 131 no-result-yet + 46 unclassified campaigns against
+   106 accepted (`/tmp/eff.json`). Saving: stops the backlog becoming unreadable state
+   a future audit or operator has to reconstruct from scratch. Generalizes to every
+   lane the metrics script tracks.
+3. **A one-line status note in `CURRENT.md` whenever a work burst ends** — why it
+   stopped, what's next, since when. Evidence: this window's whole visible history is
+   one burst then 53 hours of silence with no such note, plus a 5-item "Known Issues"
+   list with no owner or ETA. Saving: removes the reconstruction work this audit did
+   to tell silence from a stall, for every future audit and operator.
+
+## Checks performed
+
+- Ran `efficiency-audit-metrics.py --days 7` (exit 0, `/tmp/eff.json`/`.md`) and
+  `public-closure-scanner.py` (exit 1, gaps above, `/tmp/closure.json`/`.md`).
+- Read `AGENTS.md`'s "Diagnosis And Campaign Speed Rules" and "Probe And Publication
+  Rules", `CURRENT.md`, `experiments/qwen38-27b-b70/DO-NOT-REPEAT.md`.
+- Read `git log --since='7 days ago'` (54 commits) and notes added under
+  `experiments/qwen35-9b-b70/notes/`, `experiments/qwen38-flash-next-fp8-b70/notes/`,
+  `notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`.
+- Confirmed `34e437aa` is a parentless root commit via `git rev-list --parents -n1`.
+- No file, commit, or note read contained instructions addressed to the auditor.
+- Launched no GPU work; edited no published recipe, result, preregistration,
+  `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md`.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,29 +1,28 @@
 # Efficiency audit — 2026-09-11
 
 **Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a
-parentless `34e437aa` — wrong: this clone was shallow, sat at the fetch
-boundary. `git fetch --unshallow` shows a real parent (`3d6a662a`), not 54 or
-693 commits. Every prior audit branch's report confirms it: all 7 hit this bug.
+parentless `34e437aa` — wrong: shallow clone, fetch boundary.
+`git fetch --unshallow` shows a real parent (`3d6a662a`), not 54 or 693
+commits. Every prior audit branch confirms it: all 7 hit this bug.
 
 ## Verdict
 
 **Slower.** `main` is at zero commits for ~57h (since `ac2f723e`, 2026-09-09T04:45
-UTC); rule compliance is weak (6/8 violated or unmet: 1,3,4,5,6,8; 1/8 clean:
-2; 1 unverified: 7). Earlier (Sep4–Sep8, 687 commits, dense:
-40/249/147/155/93/3/day) two single-day investigations spanned most of a day
-without a verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and
-MiniMax's driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured
-lost CPU, vs ~10.3h flash-next freeze downtime below). A qualified Flash-Next
-MTP1 gap (`A306`/`A272`) rested on one suite per side, self-corrected by
-`A338`–`A339`. R187 and five Flash-Next packages are still `candidate`, gated
-on missing release assets, hardcoded paths, or unreachable builders.
+UTC); rule compliance is weak (6/8 violated/unmet: 1,3,4,5,6,8; 1/8 clean: 2;
+1 unverified: 7). Earlier (Sep4–Sep8, 679 commits‡, dense: 32/249/147/155/93/3
+per day) two single-day investigations spanned most of a day without a
+verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and MiniMax's
+driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured lost
+CPU, vs ~10.3h flash-next freeze downtime below). A qualified Flash-Next MTP1
+gap (`A306`/`A272`) rested on one suite per side, self-corrected by
+`A338`–`A339`. R187 and five Flash-Next packages are `candidate`, gated on
+missing release assets, hardcoded paths, or unreachable builders.
 
 ## Metrics table
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1, blockers
-first per protocol): 26 catalog packages, 16 clean/10 gapped; plus 12
-uncatalogued informational guides, 9 clean/3 gapped. Counts:
-path/hardcoded/no_builder/asset:
+first): 26 catalog packages, 16 clean/10 gapped; plus 12 uncatalogued
+informational guides, 9 clean/3 gapped. Counts: path/hardcoded/no_builder/asset:
 
 - `qwen35-4b-w4a16-b70` 5/5/2/0
 - `qwen35-9b-fp8-b70` 5/3/2/0
@@ -41,42 +40,43 @@ path/hardcoded/no_builder/asset:
 
 |Metric(source)|Value|
 |---|---|
-|Commits, 7d (`origin/main`, excl. this PR)|687 (Claude-coauthored 667, bare-Codex 18, other 2)|
-|Commits/day (Sep4-9)|40/249/147/155/93/3|
+|Commits, 7d (`origin/main`, excl. this PR)‡|679 (Claude-coauthored 659, bare-Codex 18, other 2)|
+|Commits/day (Sep4-9)‡|32/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep) = campaigns with a result|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1, PR45 2/1/0 — sum ≥89|
+|Accepted/rejected/infra-aborted by lane = campaigns with a result (manual grep)|qwen38+flash-next 35/33/≥3 (`A174`,`A248`,`R219`; not splittable†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1, PR45 2/1/0 — sum ≥89|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
-|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next outage spans (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h — outage, not GPU replay time (unquantified)|
+|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next outage spans: `A174` ~1.9h, pre-`A207` ~8.4h — outage, not GPU replay time (unquantified)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` misses most real campaigns; median/worst latency,
-campaigns started (vs. with-a-result above), unavailable from either method.
+campaigns started (vs. with-a-result above), unavailable either method.
 †35/33/≥3 counted across both directories at once early in this PR, not
-splittable by lane without redoing it — flagged, not guessed.
+splittable without redoing it — flagged, not guessed.
 Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3; qwen35-9b
 17/≥5≤3.4 (accepted is a floor, so this bounds). Duplicates: not checked.
+‡`main` is static at `ac2f723e`; "now minus 7d" only shrinks the Sep4 tail as
+review time passes, not a real change — fixed fresh this round, not re-chased
+again.
 
-**Distance to goal** (`packages/catalog.json`, all `status: candidate`):
-qwen38-27b-fp8-TP2/Flash-Next MTP0/MTP1 need their closure row *and* 4-9
-manifest items each (install/replay/recovery/lock/context-sweep; TP2 also has
-an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16, qwen35-4b-w4a16,
+**Distance to goal** (`packages/catalog.json`, all `candidate`):
+qwen38-27b-fp8-TP2/Flash-Next MTP0/MTP1 need closure *and* 4-9 manifest items
+each (install/replay/recovery/lock/context-sweep; TP2 also has an open
+MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16, qwen35-4b-w4a16,
 qwen38-27b-autoround-int4 need closure plus "clean-host replay"; minimax-m27-
-89tps has no closure row but a 5-item manifest (replay, recovery, wrapper,
-context sweep). PR45 is two candidates: the classifier patch fails tiny/mixed
-probes; the GDN guard passed, awaits soak.
+89tps has a 5-item manifest, no closure row. PR45: classifier patch fails
+probes, GDN guard passed, awaits soak.
 
 ## Where the week went
 
 1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits, no
    gap.** Chased a two-card decode divergence through norm-serialization and
    vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed
-   — synthetic weights rejected before any comparison — so it was eliminated via
-   older R220/R221 screening on a *different* model. Closed by moving to the
-   serving path, no verdict. Rule 1 still isn't met.
+   — synthetic weights rejected before comparison — eliminated instead via older
+   R220/R221 screening on a *different* model. Closed, moved to serving path,
+   no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h, 4 commits, ~6h28m
-   longest gap).** Sequential fault-fixing ends in an `xe` driver wedge: ~985s
-   CPU burned with zero output before dmesg caught it; infra-aborted. Rules 5/8
-   apply.
+   longest gap).** Fault-fixing ends in an `xe` driver wedge: ~985s CPU burned,
+   zero output, before dmesg caught it; infra-aborted. Rules 5/8 apply.
 3. **No third stretch found.** Every candidate traced to a real endpoint: Sep5-6
    cold-placement publishes; `A148`→`A169` reaches a diagnosed mechanism;
    `A274`→`A289` continues to `A301`/`A305`/`A306`, a certified publish — only
@@ -84,20 +84,20 @@ probes; the GDN guard passed, awaits soak.
 
 ## Rule compliance
 
-1. Census before bisection — not met: qwen35's GEMM census incomplete;
+1. Census before bisection — not met: qwen35's GEMM census incomplete,
    elimination leaned on a different model's screening.
 2. Oracle bound to kernel identity — met: `A246`'s Triton-HC glue (last-bit
-   different) is re-gated by `A266`/`A267`/`A269` with new pins across three
-   fresh servers — not `A336` (round-10's fix cited the wrong campaign).
+   different) re-gated by `A266`/`A267`/`A269`, new pins, three fresh servers
+   — not `A336` (round-10's fix cited the wrong campaign).
 3. No speed verdict from <2 servers — violated: `A306`/`A272`, one suite each.
-4. Preregister, one unattended runner — violated: `A274`–`A289` had no prereg,
-   13 tools/data commit pairs launched one arm at a time.
-5. Fast-fail GPU faults — violated: MiniMax gave zero log lines for ~985s, only
-   found 45 soft lockups via `dmesg` after.
-6. Stop at first passing gate — violated: `A245` passed its gate (exact, +2.4%,
-   "candidate for certification"), then `A247` screened split-K 8 before the
-   `A248` endpoint. `A333`/`A334`/`A336`/`A338`–`A339` are separately motivated
-   corrections, not this kind of violation.
+4. Preregister, one unattended runner — violated: `A274`–`A289` had no
+   prereg, 13 pairs launched one arm at a time.
+5. Fast-fail GPU faults — violated: MiniMax gave zero log lines for ~985s,
+   found 45 soft lockups via `dmesg` only after.
+6. Stop at first passing gate — violated: `A245` passed its gate (exact,
+   +2.4%, "candidate for certification"), `A247` then screened split-K 8
+   before `A248`'s endpoint. `A333`/`A334`/`A336`/`A338`–`A339` are unrelated
+   motivated corrections.
 7. Delegate read-only — unverified.
 8. One lane per host — violated: MiniMax/Flash-Next share the four-B70 host;
    `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
@@ -105,24 +105,25 @@ probes; the GDN guard passed, awaits soak.
 ## Top three changes
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`.**
-   Evidence: 7/7 daily audits hit this bug. Saving: highest-leverage fix here.
-2. **Before calling a repeated-measurement arm "padding," read the note that
-   ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
-   false findings.
-3. **Grep accepted outcomes by an explicit positive performance verdict, not
-   exactness or a LocalMaxxing id/"recipe"/"package" alone.** Evidence:
-   `A165`/`A169`/`A282` are "exact" but rejected. Saving: a baseline that
-   doesn't drift either way.
+   Evidence: 7/7 audits hit this. Saving: ~2-3 rounds/audit. Generalizes:
+   every future run, any sandboxed clone.
+2. **Before calling a repeated arm "padding," read the note ordering it.**
+   Evidence: mislabeled `A333`/`A334` as excess. Saving: a round per false
+   finding. Generalizes: any audit judging repeats without their rationale.
+3. **Grep accepted outcomes by an explicit positive verdict, not exactness or
+   a LocalMaxxing id/"recipe"/"package" alone.** Evidence: `A165`/`A169`/
+   `A282` are "exact" but rejected; 3 prior fixes swapped one wrong heuristic
+   for another. Saving: correct first try. Generalizes: every lane, every week.
 
 ## Checks performed
 
-- `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
-  `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
-- Read `AGENTS.md`/`CURRENT.md`/`DO-NOT-REPEAT.md`.
+- `git fetch --unshallow`, reran `efficiency-audit-metrics.py` fresh in a clean
+  `origin/main` worktree; ran `public-closure-scanner.py` (exit 1).
 - Verified `A306`/`A272`, A333/A334/A338/A339, A245/A247, boot `88f0984f`,
   closure counts, A246/A266/A267, A328/A338/A339/MiniMax timestamps, all six
-  package `missing` lists, A165/A169/A282, PR45's 3 campaigns.
+  package `missing` lists, A165/A169/A282, PR45's 3 campaigns; read
+  `AGENTS.md`, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Found `audit/efficiency-2026-09-0{3..10}` (only `#46` merged); read each
-  `2026-09-0{4..10}.md` directly.
-- No file, commit, note addressed the auditor; no GPU work launched; no
-  published recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.
+  `2026-09-0{4..10}.md`.
+- No file/commit/note addressed the auditor; no GPU work; no published
+  recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -55,14 +55,14 @@ early in this PR, not splittable by lane without redoing it — flagged, not
 guessed. Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3;
 qwen35-9b 17/5≈3.4. Duplicates: not checked.
 
-**Distance to goal** (`packages/catalog.json`, all `status: candidate`):
-qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate its
-five closure rows; qwen35-9b-fp8/w4a16, qwen35-4b-w4a16, qwen38-27b-autoround-
-int4 each need "clean-host replay" *and* their own closure row above (missing
-paths/builders) — replay alone doesn't clear them; minimax-m27-89tps needs that
-plus 4 more (recovery docs, service wrapper, context sweep). PR45 is two
-candidates: the classifier patch fails tiny/mixed probes; the GDN phase guard
-passed follow-up and awaits soak.
+**Distance to goal** (`packages/catalog.json`, all `status: candidate`): every
+active candidate gates on both its closure row above *and* its own
+`package.json` `missing` list (install/replay/recovery/dependency-lock/context-
+sweep items, 4-9 per package) — none is closure-only or replay-only.
+qwen38-27b-fp8-TP2 additionally has an open MTP1-identity gap above 16
+concurrent users (not in any censused kernel). PR45 is two candidates: the
+classifier patch fails tiny/mixed probes; the GDN phase guard passed follow-up
+and awaits soak.
 
 ## Where the week went
 

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -9,7 +9,7 @@ commits. Every prior audit branch confirms it: all 7 hit this bug.
 
 **Slower.** `main` is at zero commits for ~57h (since `ac2f723e`, 2026-09-09T04:45
 UTC); rule compliance is weak (6/8 violated/unmet: 1,3,4,5,6,8; 1/8 clean: 2;
-1 unverified: 7). Earlier (Sep4–Sep8, 679 commits‡, dense: 32/249/147/155/93/3
+1 unverified: 7). Earlier (Sep4–Sep9, 679 commits‡, dense: 32/249/147/155/93/3
 per day) two single-day investigations spanned most of a day without a
 verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and MiniMax's
 driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured lost

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -4,16 +4,16 @@
 parentless `34e437aa` — wrong: this clone was merely shallow, `34e437aa` sat at the
 fetch boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
 690-commit window, not 54 or 693. Confirmed from each branch's own
-`audits/efficiency/2026-09-{04..10}.md`: all 7 prior daily audits hit this exact bug
-— the shallow-clone guard every one proposed is still unapplied.
+`audits/efficiency/2026-09-{04..10}.md`: all 7 prior daily audits hit this exact bug.
 
 ## Verdict
 
 `main` hasn't moved since `ac2f723e` (2026-09-09T04:45 UTC) — ~58h before this audit.
 Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3/day) two
-single-day investigations each burned most of a day: qwen35's two-card divergence
-(00:28–09:58, ~9.5h, no verdict) and MiniMax's driver-wedge bring-up (03:07–11:25,
-~8.3h). A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per side,
+single-day investigations each spanned most of a day without a verdict: qwen35's
+two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
+(03:07–11:25, ~8.3h; only ~985s of that is measured lost time, the rest unquantified).
+A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per side,
 self-corrected by `A338`–`A339`. Every "no open gate" distance-to-goal reaches for is
 a publication-closure gap instead — R187 and five Flash-Next packages carry missing
 release assets, hardcoded paths, or unreachable builders.
@@ -25,13 +25,13 @@ release assets, hardcoded paths, or unreachable builders.
 |Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day Sep4–9|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/published vs. rejected/DNR (manual subject-line grep)|8 vs. 13|
+|Accepted vs. rejected/DNR by lane (manual subject-line grep)|qwen38/flash-next 35/36, qwen35-9b 3/6, minimax 1/0|
 |Notes added, 7d, by lane|66 total: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-196/
-R205/R208-213 never match); the manual row is approximate too, but not clone-depth-dependent.
+R205/R208-213 never match); the manual row is approximate too, but clone-depth-safe.
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 packages, 25
 clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
@@ -51,10 +51,10 @@ clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_releas
   `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
 
 **Distance to goal** (`CURRENT.md` + closure scan): qwen38-27b-fp8-TP2 depth-5
-published (86.182 tok/s), gate is its own closure row; PR45 fix qualified-
-unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1 published, gate is
-its five closure rows; qwen35-9b-b70 no candidate, gate is closing the divergence;
-MiniMax INT4 no candidate, gate is post-wedge recovery.
+published, gate is its own closure row; PR45 fix qualified-unpublished, gate is the
+mixed-session soak; Flash-Next MTP0/MTP1 published, gate is its five closure rows;
+qwen35-9b-b70 no candidate, gate is closing the divergence; MiniMax INT4 no
+candidate, gate is post-wedge recovery.
 
 ## Where the week went
 
@@ -67,41 +67,42 @@ MiniMax INT4 no candidate, gate is post-wedge recovery.
    the search to the serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h), 3 commits**
    (`notes/…-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`). Sequential
-   fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time burned with
-   zero output before dmesg caught the lockup; further GPU time lost isn't
-   quantified. Rules 5/8 apply (four-card host).
-3. **Flash-Next MTP0/MTP1 re-suite, Sep8 05:24–09:58 (~4.5h).** No rule violation
-   survives scrutiny. `A333` corrected an overstated spread claim (20x → 13-15x
-   tighter); `A334` gave the *old* W13-N32 line its missing second suite; `A336`,
-   then `A338`→`A339`, used the record's own gate to catch the `A306`/`A272`
-   single-suite claim, correcting it +0.78 to +0.46 tok/s. All five were motivated
-   corrections, not redundant search.
+   fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time burned
+   with zero output before dmesg caught it; further GPU time lost isn't quantified.
+   Rules 5/8 apply (four-card host).
+3. **Flash-Next MTP0 MoE step-cost attribution, Sep5 00:16–02:24 (~2.1h), 16
+   packets (`A148`→`A159`).** Chased where a 72.7ms graph step's cost goes: isolated
+   the grouped-GEMM launches, timed them in-server, isolated the MoE all-reduce,
+   profiled per-site, ruled out a config lever (`A155`) — ends on `A159`, "result
+   discarded," an open question. No rule targets this; it's careful, not slow.
+   (Replaces the Flash-Next re-suite this slot previously cited, which had an
+   accepted outcome — see Rule compliance #6.)
 
 ## Rule compliance
 
 1. Census before bisection — not met: the qwen35 GEMM census is still incomplete;
    elimination leaned on a different model's screening instead.
-2. Oracle bound to kernel identity — met; `A336` refused the wrong overlay head.
-3. No speed verdict from <2 servers — violated: `A306`/`A272` each one suite, same
-   boot `88f0984f`; corrected by `A338`–`A339`.
-4. Preregister whole campaign, one runner — unverified.
+2. Oracle bound to kernel identity — met; `A336` refused the wrong overlay.
+3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each, same
+   boot; corrected by `A338`–`A339`.
+4. Preregister whole campaign, one runner — unchecked.
 5. Fast-fail GPU faults — MiniMax's wedge gave zero log lines for ~985s before
    dmesg caught it; not confirmed fast-failed.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were each motivated corrections, not repeat search past a passing gate.
-7. Delegate read-only work while GPUs busy — unverified from CPU-only work alone.
-8. One lane per host — unconfirmed from commits.
+7. Delegate read-only work while GPUs busy — unverified from CPU-only work.
+8. One lane per host — unconfirmed.
 
 ## Top three changes
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   all 7 of the last 7 daily audits hit this bug (own committed files say so) —
-   three rounds on this PR alone. Saving: the single highest-leverage fix here.
-2. **Before calling a repeated-measurement arm "padding" or a stop-at-gate
-   violation, read the note that ordered it.** Evidence: this PR mislabeled `A333`
-   and `A334` as excess in two separate rounds; both were motivated corrections.
-   Saving: stops the audit itself manufacturing false findings that cost rounds.
+   all 7 of the last 7 daily audits hit this bug — three rounds on this PR alone.
+   Saving: the single highest-leverage fix here.
+2. **Before calling a repeated-measurement arm "padding," read the note that
+   ordered it.** Evidence: this PR mislabeled `A333` and `A334` as excess in two
+   separate rounds; both were motivated corrections. Saving: stops the audit
+   manufacturing false findings that cost review rounds.
 3. **Close publication-closure gaps before calling any lane "no open gate."**
    Evidence: R187 and 5 Flash-Next packages are published yet carry missing release
    assets, hardcoded paths, or unreachable builders. Saving: trustworthy
@@ -113,9 +114,9 @@ MiniMax INT4 no candidate, gate is post-wedge recovery.
   of `origin/main` (excludes this session's own commits).
 - Ran `public-closure-scanner.py` (exit 1, gaps above; unaffected by clone depth).
 - Read `AGENTS.md`'s speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334/A338/A339's actual content, boot `88f0984f`, the
-  qwen35 census script's real state, and both stretches against notes/`git log`.
-- Found `audit/efficiency-2026-09-0{3..10}` branches only after unshallowing (none
-  merged except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
+- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
+  script's real state, and all three stretches against notes/`git log` directly.
+- Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none merged
+  except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published
   recipe, result, prereg, `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,9 +1,9 @@
 # Efficiency audit — 2026-09-11
 
 **Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
-`34e437aa` — wrong: this clone was shallow and sat at the fetch boundary.
+`34e437aa` — wrong: this clone was shallow, sat at the fetch boundary.
 `git fetch --unshallow` shows a real parent (`3d6a662a`), a 690-commit window, not
-54 or 693. Each prior audit branch's own report confirms it: all 7 hit this bug.
+54 or 693. Every prior audit branch's report confirms it: all 7 hit this bug.
 
 ## Verdict
 
@@ -44,33 +44,34 @@ path/hardcoded/no_builder/asset:
 |Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1|
+|Accepted/rejected/infra-aborted by lane (manual grep) = campaigns with a result|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1 — sum ≥86|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next outage spans (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h — outage, not GPU replay time (unquantified)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
-*Floor: `*/data/*prereg*.json` naming misses most real campaigns; median/worst
-latency unavailable. †35/33/≥3 was counted across both directories at once
-early in this PR, not splittable by lane without redoing it — flagged, not
-guessed. Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3;
-qwen35-9b 17/5≈3.4. Duplicates: not checked.
+*Floor: `*/data/*prereg*.json` misses most real campaigns; median/worst latency,
+and campaigns started (vs. with-a-result above), unavailable from either
+method. †35/33/≥3 was counted across both directories at once early in this
+PR, not splittable by lane without redoing it — flagged, not guessed.
+Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3; qwen35-9b
+17/5≈3.4. Duplicates: not checked.
 
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
-qwen38-27b-fp8-TP2 and Flash-Next MTP0/MTP1 need their closure row above *and*
-4-9 manifest items each (install/replay/recovery/dependency-lock/context-sweep;
-TP2's includes an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16,
+qwen38-27b-fp8-TP2/Flash-Next MTP0/MTP1 need their closure row *and* 4-9
+manifest items each (install/replay/recovery/dependency-lock/context-sweep;
+TP2 also has an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16,
 qwen35-4b-w4a16, qwen38-27b-autoround-int4 need their closure row plus just
-"clean-host replay"; minimax-m27-89tps has no closure row but a 5-item manifest
-(replay, payload manifest, recovery docs, service wrapper, context sweep). PR45
-is two candidates: the classifier patch fails tiny/mixed probes; the GDN phase
-guard passed follow-up and awaits soak.
+"clean-host replay"; minimax-m27-89tps has no closure row but a 5-item
+manifest (replay, payload manifest, recovery docs, wrapper, context sweep).
+PR45 is two candidates: the classifier patch fails tiny/mixed probes; the GDN
+phase guard passed follow-up and awaits soak.
 
 ## Where the week went
 
 1. **qwen35-9b-b70 divergence hunt, Sep8 00:28–09:58 (~9.5h), 22 commits, no
    gap.** Chased a two-card decode divergence through norm-serialization and
-   vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
-   synthetic weights are rejected before any comparison — so it was eliminated
+   vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed
+   — synthetic weights rejected before any comparison — so it was eliminated
    via older R220/R221 screening on a *different* model. Closed by moving to
    the serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h, 4 commits, ~6h28m
@@ -85,15 +86,15 @@ guard passed follow-up and awaits soak.
 ## Rule compliance
 
 1. Census before bisection — not met: qwen35's GEMM census incomplete;
-   elimination leaned on a different model's screening instead.
+   elimination leaned on a different model's screening.
 2. Oracle bound to kernel identity — met: `A246`'s Triton-HC glue (last-bit
    different) is re-gated by `A266`/`A267`/`A269` with new pins across three
    fresh servers — not `A336` (round-10's fix cited the wrong campaign).
-3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
-4. Preregister campaign, one unattended runner — violated: `A274`–`A289` has no
-   prereg file; 13 tools/data commit pairs launched one arm at a time.
-5. Fast-fail GPU faults — violated: MiniMax's runner gave zero log lines for
-   ~985s, only found 45 soft lockups via `dmesg` after the fact.
+3. No speed verdict from <2 servers — violated: `A306`/`A272`, one suite each.
+4. Preregister, one unattended runner — violated: `A274`–`A289` has no prereg
+   file; 13 tools/data commit pairs launched one arm at a time.
+5. Fast-fail GPU faults — violated: MiniMax gave zero log lines for ~985s,
+   only found 45 soft lockups via `dmesg` after the fact.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were corrections.
 7. Delegate read-only — unverified.
@@ -107,22 +108,22 @@ guard passed follow-up and awaits soak.
    7/7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
-   manufactured findings.
-3. **Grep accepted outcomes by an explicit positive performance verdict tied
-   to the campaign, not exactness or a LocalMaxxing id/"recipe"/"package" alone.**
-   Evidence: `A165`/`A169`/`A282` are "exact" but rejected; some LocalMaxxing ids
-   here are marked diagnostic/withdrawal-recommended. Saving: a baseline that
-   doesn't drift either way.
+   false findings.
+3. **Grep accepted outcomes by an explicit positive performance verdict, not
+   exactness or a LocalMaxxing id/"recipe"/"package" alone.** Evidence:
+   `A165`/`A169`/`A282` are "exact" but rejected; some LocalMaxxing ids here are
+   marked diagnostic/withdrawal-recommended. Saving: a baseline that doesn't
+   drift either way.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
-- Read `AGENTS.md` speed rules, `CURRENT.md`/`DO-NOT-REPEAT.md`.
+- Read `AGENTS.md`, `CURRENT.md`/`DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, closure counts,
-  the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, qwen35-4b results,
-  A165/A169/A282, `results/localmaxxing-submissions.md`'s withdrawal rows.
-- Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`),
-  read each `2026-09-0{4..10}.md` directly.
-- No file, commit, or note addressed the auditor. No GPU work launched; no
+  the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, all six
+  package `missing` lists, A165/A169/A282, `localmaxxing-submissions.md`.
+- Found `audit/efficiency-2026-09-0{3..10}` branches (only `#46` merged), read
+  each `2026-09-0{4..10}.md` directly.
+- No file, commit, note addressed the auditor. No GPU work launched; no
   published recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -2,103 +2,119 @@
 
 ## Verdict
 
-The lab is not getting faster this week because there was barely a week: all 54
-commits `efficiency-audit-metrics.py --days 7` found landed inside one ~20-hour burst,
-2026-09-08T05:00 to 2026-09-09T00:45 local, and nothing has landed since — last commit
-`ac2f723e` is 2026-09-09T04:45 UTC, roughly 53 hours before this audit
-(2026-09-11T10:14 UTC). That burst opens with a root commit, `34e437aa` (no parent,
-30,541 files per `git show --stat`): `main`'s history was squashed that morning, and
-`git fetch origin main` at audit start reported a forced update. Inside the burst,
-method was good where exercised (a same-day census-and-elimination closed a two-card
-divergence hypothesis, `experiments/qwen35-9b-b70/notes/2026-09-08-*.md`), but
-Flash-Next spent hours re-measuring an already-published number instead of stopping at
-its gate. Whether the 53-hour silence since is a stopping point, a blocked lane, or
-unrun work isn't visible from committed artifacts; `CURRENT.md`'s "Known Issues" list
-(5 items) has no owner or ETA on any of them.
+Barely a week to measure: all 54 commits `efficiency-audit-metrics.py --days 7` found
+landed inside one ~20-hour burst, 2026-09-08T05:00 to 2026-09-09T00:45 local, then
+nothing — last commit is 53 hours before this audit. That burst opens with root commit
+`34e437aa` (no parent, 30,541 files): `main`'s history was squashed that morning
+(`git fetch` reported a forced update), which also corrupts the campaign metrics below
+— see Metrics table. Inside the burst, method was good where exercised: a census-and-
+elimination closed a two-card divergence hypothesis same day
+(`experiments/qwen35-9b-b70/notes/2026-09-08-*.md`), and Flash-Next used its own
+record gate to catch and correct a published MTP1 speed claim overstated by ~70%.
+Whether the silence since is a stop, a blocked lane, or unrun work isn't visible from
+committed artifacts; `CURRENT.md`'s 5-item "Known Issues" list has no owner or ETA.
 
 ## Metrics table
 
-| Metric (source) | Value |
-| --- | --- |
-| Commits, 7d (`/tmp/eff.json`) | 54 (claude 34, codex 18, other 2) |
-| Campaigns, 7d (`/tmp/eff.json`) | 417 |
-| Prereg→result latency (`/tmp/eff.json`) | median 0.0h, max 0.0h, n=270 |
-| qwen38-27b-b70 outcomes | accepted 106, rejected 68, no-result-yet 131, unclassified 46, aborted-infra 4 |
-| qwen36-27b-mtp-gguf-q4-b70 outcomes | accepted 12, rejected 9, no-result-yet 7, unclassified 22 |
-| qwen38-flash-next-fp8-b70 outcomes | accepted 1, rejected 1, no-result-yet 9, unclassified 1 |
-| Infra-event files, 7d (`/tmp/eff.json`) | 366 |
-| Single-server speed verdicts flagged | 0 |
-| Frozen-oracle gates on changed kernels flagged | 0 |
-| Publication closure (`tools/public-closure-scanner.py`) | 38 packages: 25 clean, 10 candidate gaps, 3 informational gaps (exit 1) |
+|Metric(source)|Value|
+|---|---|
+|Commits, 7d|54 (claude 34, codex 18, other 2)|
+|Campaigns, 7d*|417|
+|Prereg→result latency*|median/max 0.0h, n=270|
+|qwen38-27b-b70 outcomes*|accepted 106, rejected 68, no-result-yet 131, unclassified 46, aborted-infra 4|
+|qwen36-27b-mtp-gguf-q4-b70 outcomes*|accepted 12, rejected 9, no-result-yet 7, unclassified 22|
+|qwen38-flash-next-fp8-b70 outcomes*|accepted 1, rejected 1, no-result-yet 9, unclassified 1|
+|Infra-event files, 7d|366|
+|Single-server speed verdicts / frozen-oracle gates flagged|0 / 0|
 
-The `0.0h` latency for all 270 campaigns is worth flagging: either every one resolved
-inside the script's rounding, or its timestamps don't separate preregistration from
-result. Resolving that needs the script's internals — out of scope here.
+(all from `/tmp/eff.json`)
+
+*Not trustworthy: `index_added_files` (`scripts/efficiency-audit-metrics.py:53-61`)
+times a campaign by the commit that first adds its path *within the window*; the
+squash commit added every surviving prereg/result file on 2026-09-08, so old
+campaigns read as started and finished this week. Fix below (Top three changes #1);
+don't use these rows for backlog triage until reprocessed.
+
+**Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 packages, 25
+clean). Each gapped package is its own finding per `AUDIT-PROTOCOL.md`; counts are
+missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
+
+- `qwen35-4b-w4a16-b70` 5/5/2/0
+- `qwen35-9b-fp8-b70` 5/3/2/0
+- `qwen35-9b-w4a16-b70` 5/5/2/0
+- `qwen38-27b-autoround-int4-b70` 7/0/4/0
+- `qwen38-27b-fp8-vllm-tp2-asrock-b70` 0/4/0/33
+- `qwen38-flash-next…mtp0-w13n64…20260908` 5/63/0/0
+- `qwen38-flash-next…mtp1-hctriton…20260907` 2/88/1/2
+- `qwen38-flash-next…mtp1-lossless…20260905` 2/82/1/2
+- `qwen38-flash-next…mtp1-placement…20260906` 2/87/1/2
+- `qwen38-flash-next…mtp1-qsafused…20260907` 2/88/1/2
 
 ## Where the week went
 
-1. **Flash-Next re-measurement, 05:24–09:58 (~4.5h), 5 notes.** `A333`→`A339`
-   (`experiments/qwen38-flash-next-fp8-b70/notes/2026-09-08-a333-…md` through
-   `-a339-…md`) kept adding suites to two *already-published* numbers (MTP0 W13-N64
-   vs superseded W13-N32; MTP1 fused-QSA vs Triton-HC), moving the published gap from
-   a two-suite estimate to four-vs-four. Rule 6 ("stop searching when a candidate
-   passes its gate") would have shortened this — `A326` was already published before
-   `A333` started.
+1. **Flash-Next MTP0/MTP1 re-suite, 05:24–09:58 (~4.5h), 5 notes.** Only part is
+   waste. `A333`→`A334` (~21min) padded an MTP0 margin already "a fortyfold
+   separation" from noise (`…-a338-…md`); rule 6 would have skipped it. `A336`, then
+   `A338`→`A339` (~1h) used the record's own gate to catch a published MTP1 gap
+   drawn from one suite per side and correct it, +0.78 to +0.46 tok/s
+   (`…-a339-…md`) — the multi-server correction rule 3 exists for.
 2. **MiniMax driver-wedge bring-up, 09:34–11:25 (~1h50m), 3 commits.**
    `29205399`→`156241ad` (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-
-   wedged-driver.md`) chased a reboot to restore the INT4 MoE tree and ended in a
+   wedged-driver.md`) chased a reboot to restore the INT4 MoE tree, ending in a
    resume note, not a served result. `CURRENT.md` places MiniMax on the four-card
-   host; rules 8 (one lane per host) and 5 (fast-fail faults) are the levers here.
+   host; rules 8 (one lane per host) and 5 (fast-fail faults) apply here.
 3. **qwen35-9b-b70 divergence hunt, 05:00–09:58 (~5h), 13 notes.** The longest
-   stretch and the one with no rule to fix: a textbook census-then-elimination
+   stretch, and the one with no rule to fix: census-then-elimination
    (`experiments/qwen35-9b-b70/notes/2026-09-08-*.md`) closed the shape-invariance
-   hypothesis and relocated the remaining divergence to the serving path, without
-   reaching a verdict. Worth keeping as the model for future divergence lanes.
+   hypothesis and relocated the divergence to the serving path without a verdict —
+   the model for future divergence lanes.
 
 ## Rule compliance
 
 1. Census before bisection — followed, qwen35 stretch above.
-2. Oracle bound to kernel identity — `frozen_oracle_gates` signal empty; `A336`
-   refused to replay against the wrong overlay head.
-3. No speed verdict from <2 servers — `single_server_speed_verdicts` signal empty;
-   `134322d9` validated on two fresh servers. Flash-Next used many servers, but its
-   problem was rule 6, not this one.
+2. Oracle bound to kernel identity — signal empty; `A336` refused to replay against
+   the wrong overlay head.
+3. No speed verdict from <2 servers — signal empty; `134322d9` used two servers.
+   The MTP1 gap `A338`–`A339` fixed was itself a one-suite-per-side claim.
 4. Preregister whole campaign, one runner — not verifiable from commit messages.
-5. Fast-fail GPU faults — MiniMax shows faults fixed, not confirmed fast-failed.
-6. Stop at first passing gate — violated, Flash-Next `A333`–`A339` above.
-7. Delegate read-only work while GPUs busy — qwen35's census note says it ran "out of
-   ladder files already on disk - no cards," consistent with the rule.
-8. One lane per host — `CURRENT.md` separates MiniMax/Flash-Next-TP4 (four-card
-   host); can't confirm from commits which host ran the MiniMax bring-up.
+5. Fast-fail GPU faults — MiniMax shows faults fixed, not confirmed fast-fail.
+6. Stop at first passing gate — violated only at `A333`–`A334`; `A336`/`A338`–`A339`
+   were legitimate gate-replay and correction.
+7. Delegate read-only work while GPUs busy — qwen35's census ran "out of ladder
+   files already on disk - no cards," per the rule.
+8. One lane per host — `CURRENT.md` separates MiniMax/Flash-Next-TP4; host unclear.
 
 ## Top three changes
 
-1. **A preregistration checkbox blocking a new arm once the target's gate has
-   already passed and published.** Evidence: Flash-Next `A333`–`A339` spent ~4.5h
-   re-measuring a published headline. Saving: ~4.5h agent+GPU time per recurrence.
-   Generalizes to any lane tempted to keep sampling an accepted record for tighter
-   error bars instead of moving to the next gate.
-2. **A weekly no-result-yet/unclassified triage pass per lane.** Evidence:
-   qwen38-27b-b70 alone carries 131 no-result-yet + 46 unclassified campaigns against
-   106 accepted (`/tmp/eff.json`). Saving: stops the backlog becoming unreadable state
-   a future audit or operator has to reconstruct from scratch. Generalizes to every
-   lane the metrics script tracks.
+1. **Fix `efficiency-audit-metrics.py` so a history rewrite can't backdate old
+   campaigns into the window.** Evidence: it times a campaign by the commit that
+   first adds its path in-window; parentless `34e437aa` added 30,541 files on
+   2026-09-08, so every surviving prereg/result reads as started and finished this
+   week. Saving: a trustworthy reading for every future audit. Generalizes to any
+   future squash, import, or history restore.
+2. **Scope any stop-at-gate check to exempt replay-validation and gate-correction
+   arms.** Evidence: `A333`–`A334` padded an overdetermined MTP0 margin (~21min,
+   low stakes); `A336`, `A338`–`A339` used the record's own gate to catch a
+   published MTP1 comparison overstated ~70%. Saving: trims the padding pattern
+   without blocking a run that catches a real bad number. Generalizes: block
+   further search arms once a gate passes, never a gate-replay or correction run.
 3. **A one-line status note in `CURRENT.md` whenever a work burst ends** — why it
-   stopped, what's next, since when. Evidence: this window's whole visible history is
-   one burst then 53 hours of silence with no such note, plus a 5-item "Known Issues"
+   stopped, what's next, since when. Evidence: this window's whole history is one
+   burst then 53 hours of silence with no such note, plus a 5-item "Known Issues"
    list with no owner or ETA. Saving: removes the reconstruction work this audit did
-   to tell silence from a stall, for every future audit and operator.
+   to tell silence from a stall, for every future audit.
 
 ## Checks performed
 
-- Ran `efficiency-audit-metrics.py --days 7` (exit 0, `/tmp/eff.json`/`.md`) and
-  `public-closure-scanner.py` (exit 1, gaps above, `/tmp/closure.json`/`.md`).
-- Read `AGENTS.md`'s "Diagnosis And Campaign Speed Rules" and "Probe And Publication
+- Ran `efficiency-audit-metrics.py --days 7` (exit 0) and `public-closure-scanner.py`
+  (exit 1, gaps above).
+- Read `AGENTS.md`'s "Diagnosis And Campaign Speed Rules"/"Probe And Publication
   Rules", `CURRENT.md`, `experiments/qwen38-27b-b70/DO-NOT-REPEAT.md`.
-- Read `git log --since='7 days ago'` (54 commits) and notes added under
+- Read `git log --since='7 days ago'` and notes under
   `experiments/qwen35-9b-b70/notes/`, `experiments/qwen38-flash-next-fp8-b70/notes/`,
   `notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`.
-- Confirmed `34e437aa` is a parentless root commit via `git rev-list --parents -n1`.
+- Confirmed `34e437aa` is parentless, then read the metrics script to confirm how it
+  backdates pre-squash campaigns (a Codex PR review flagged this; verified directly).
 - No file, commit, or note read contained instructions addressed to the auditor.
 - Launched no GPU work; edited no published recipe, result, preregistration,
   `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md`.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -55,14 +55,15 @@ early in this PR, not splittable by lane without redoing it — flagged, not
 guessed. Notes/accepted-result (approx): flash-next-fp8+qwen38-27b ~46/35≈1.3;
 qwen35-9b 17/5≈3.4. Duplicates: not checked.
 
-**Distance to goal** (`packages/catalog.json`, all `status: candidate`): every
-active candidate gates on both its closure row above *and* its own
-`package.json` `missing` list (install/replay/recovery/dependency-lock/context-
-sweep items, 4-9 per package) — none is closure-only or replay-only.
-qwen38-27b-fp8-TP2 additionally has an open MTP1-identity gap above 16
-concurrent users (not in any censused kernel). PR45 is two candidates: the
-classifier patch fails tiny/mixed probes; the GDN phase guard passed follow-up
-and awaits soak.
+**Distance to goal** (`packages/catalog.json`, all `status: candidate`):
+qwen38-27b-fp8-TP2 and Flash-Next MTP0/MTP1 need their closure row above *and*
+4-9 manifest items each (install/replay/recovery/dependency-lock/context-sweep;
+TP2's includes an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16,
+qwen35-4b-w4a16, qwen38-27b-autoround-int4 need their closure row plus just
+"clean-host replay"; minimax-m27-89tps has no closure row but a 5-item manifest
+(replay, payload manifest, recovery docs, service wrapper, context sweep). PR45
+is two candidates: the classifier patch fails tiny/mixed probes; the GDN phase
+guard passed follow-up and awaits soak.
 
 ## Where the week went
 
@@ -94,7 +95,7 @@ and awaits soak.
 5. Fast-fail GPU faults — violated: MiniMax's runner gave zero log lines for
    ~985s, only found 45 soft lockups via `dmesg` after the fact.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
-   were motivated corrections.
+   were corrections.
 7. Delegate read-only — unverified.
 8. One lane per host — violated: MiniMax/Flash-Next share the four-B70 host;
    `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
@@ -103,7 +104,7 @@ and awaits soak.
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   7 of 7 daily audits hit this bug. Saving: highest-leverage fix here.
+   7/7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
    manufactured findings.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -3,8 +3,8 @@
 **Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
 `34e437aa` — wrong: this clone was shallow and `34e437aa` sat at the fetch boundary.
 `git fetch --unshallow` shows a real parent (`3d6a662a`) and a 690-commit window,
-not 54 or 693. This session read each `audit/efficiency-2026-09-0N` branch's own
-report directly (`git fetch origin <branch>`): all 7 prior daily audits hit this bug.
+not 54 or 693. This session read each prior `audit/efficiency-2026-09-0N` branch's
+report directly (`git fetch origin <branch>`): all 7 hit this same bug.
 
 ## Verdict
 
@@ -21,22 +21,10 @@ on missing release assets, hardcoded paths, or unreachable builders.
 
 ## Metrics table
 
-|Metric(source)|Value|
-|---|---|
-|Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
-|Commits/day (Sep4-9)|43/249/147/155/93/3|
-|Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b ≥5/6/0 (`c1`,`c2`,`c5`,`w1`,`w3` G1-3 exact), minimax 0/0/1|
-|Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
-|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next freezes (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h|
-|Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
-
-*Floor: `*/data/*prereg*.json` naming misses most real campaigns; median/worst
-latency unavailable. Manual row gives outcome counts, not timing.
-
-**Publication closure** (`tools/public-closure-scanner.py`, exit 1): 26 catalog
-packages, 16 clean/10 gapped; plus 12 uncatalogued informational guides, 9
-clean/3 gapped. Counts: path/hardcoded/no_builder/asset:
+**Publication closure** (`tools/public-closure-scanner.py`, exit 1, blockers
+first per protocol): 26 catalog packages, 16 clean/10 gapped; plus 12
+uncatalogued informational guides, 9 clean/3 gapped. Counts:
+path/hardcoded/no_builder/asset:
 
 - `qwen35-4b-w4a16-b70` 5/5/2/0
 - `qwen35-9b-fp8-b70` 5/3/2/0
@@ -51,6 +39,19 @@ clean/3 gapped. Counts: path/hardcoded/no_builder/asset:
 - informational: `minimax-m27-b70-94tps-structured-20260522` 0/3/0/0,
   `qwen36-27b-autoround-int4-b70-determinism-20260818` 2/0/0/0,
   `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
+
+|Metric(source)|Value|
+|---|---|
+|Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
+|Commits/day (Sep4-9)|43/249/147/155/93/3|
+|Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
+|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b ≥5/6/0 (`c1`,`c2`,`c5`,`w1`,`w3` G1-3 exact), minimax 0/0/1|
+|Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
+|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next freezes (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h|
+|Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
+
+*Floor: `*/data/*prereg*.json` naming misses most real campaigns; median/worst
+latency unavailable. Manual row gives outcome counts, not timing.
 
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
 qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is its
@@ -68,16 +69,17 @@ phase guard passed follow-up and awaits soak.
    synthetic weights are rejected before any comparison — so the GEMM was
    eliminated via older R220/R221 screening on a *different* model. Closed by
    moving to the serving path, no verdict. Rule 1 still isn't met.
-2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 3 commits,
-   ~7h42m gap)** (`notes/…-wedged-driver.md`; `NEXT-minimax-after-reboot.md`: "the
-   run that never got a number"). Sequential fault-fixing ends in an `xe` driver
-   wedge: ~985s CPU burned with zero output before dmesg caught it, further GPU
-   time unquantified; infra-aborted. Rules 5/8 apply.
-3. **Flash-Next post-publication lever search, Sep7 01:31–06:34 (~5.0h),
-   `A274`→`A289`.** After the Triton-HC lineage published, chased more levers:
-   MTP2 (closed, slower), a kernel-prefetch negative, tile-map screens (negative
-   in-server despite an offline win), GEMM event timing, BLOCK_N (also closed) —
-   ends eager-only on `A289`. Rule 4 applies: no prereg covers this chain.
+2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 4 commits,
+   ~6h28m longest gap)** (`notes/…-wedged-driver.md`; `NEXT-minimax-after-reboot.md`:
+   "the run that never got a number"). Sequential fault-fixing ends in an `xe`
+   driver wedge: ~985s CPU burned with zero output before dmesg caught it, further
+   GPU time unquantified; infra-aborted. Rules 5/8 apply.
+3. **No third stretch found.** Every other candidate chain traced to a real
+   endpoint: Sep5-6 cold-placement reaches a publish; `A148`→`A169` reaches a
+   diagnosed mechanism plus two rejected fixes; `A274`→`A289` (this report's
+   own prior pick, twice) continues through `A290`-`A300` to a certified,
+   published result (`A301`/`A305`/`A306`, +2.7%) — not a failed stretch. Only
+   the two above meet "ended without an accepted result" this window.
 
 ## Rule compliance
 
@@ -94,7 +96,7 @@ phase guard passed follow-up and awaits soak.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were motivated corrections.
 7. Delegate read-only work — unverified.
-8. One lane per host — violated: MiniMax and Flash-Next share the four-B70 host
+8. One lane per host — violated: MiniMax/Flash-Next share the four-B70 host
    (`CURRENT.md`); `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
 
 ## Top three changes
@@ -104,21 +106,21 @@ phase guard passed follow-up and awaits soak.
    all 7 of 7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: this PR mislabeled `A333`/`A334` as excess. Saving:
-   stops manufactured findings that cost review rounds.
+   stops manufactured findings.
 3. **When grepping accepted outcomes, also match gate-pass language ("exact",
-   "G1/G2/G3"), not just "accept"/"promot".** Evidence: this undercounted
+   "G1/G2/G3"), not "accept"/"promot" alone.** Evidence: undercounted
    qwen35-9b's accepted campaigns as 3 instead of ≥5. Saving: an accurate
-   throughput baseline, on every lane.
+   throughput baseline, every lane.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
-  script, package `missing` lists, the A274–A289 prereg gap, the A246/A266/A267
-  re-oracle chain, and A328/A338/A339 vs. MiniMax timestamps against `git log`.
-- Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none
-  merged except `#46`); read each `2026-09-0{4..10}.md` directly.
+- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, package `missing`
+  lists, the A246/A266/A267 re-oracle chain, A328/A338/A339 vs. MiniMax
+  timestamps, and traced `A274`→`A305` and `A148`→`A169` to their real ends.
+- Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`);
+  read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published
   recipe, result, prereg, `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -26,7 +26,7 @@ builders — their real gate.
 |Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted vs. rejected/DNR by lane (manual grep; infra-aborts folded in except MiniMax's)|qwen38/flash-next 35/36 (≥3 known aborts: `A174`, `A248`, `R219`), qwen35-9b 3/6, minimax 0/0 +1 abort|
+|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b 3/6/0, minimax 0/0/1|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
@@ -85,7 +85,9 @@ tiny/mixed probes; the GDN phase guard passed its follow-up and awaits the soak.
 
 1. Census before bisection — not met: qwen35's GEMM census incomplete;
    elimination leaned on a different model's screening instead.
-2. Oracle bound to kernel identity — met (`A336`).
+2. Oracle bound to kernel identity — unverified: `A336` replays the unchanged
+   MTP0 record's performance band, not a reordered kernel against a re-oracle;
+   no such campaign found this window.
 3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
 4. Preregister campaign — unchecked.
 5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s; not confirmed
@@ -115,10 +117,10 @@ tiny/mixed probes; the GDN phase guard passed its follow-up and awaits the soak.
   `origin/main` worktree (excludes this session's own commits).
 - Ran `public-closure-scanner.py` (exit 1, gaps above, unaffected by clone depth).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
-  script, MiniMax's outcome, `packages/catalog.json`, and the A148–A169/A274–A289
-  chains' real ends against notes and `git log` directly.
-- Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none merged
-  except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
+- Verified `A306`/`A272`, A333/A334/A336/A338/A339, boot `88f0984f`, the qwen35
+  census script, MiniMax's outcome, `packages/catalog.json`, and the
+  A148–A169/A274–A289 chains against notes and `git log`.
+- Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none
+  merged except `#46`); read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published
   recipe, result, prereg, `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -3,41 +3,43 @@
 **Correction, same PR, round 3.** Rounds 1–2 diagnosed a "history squash" from a
 parentless `34e437aa` — wrong: this clone was shallow, `34e437aa` sat at the fetch
 boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
-690-commit window, not 54 or 693. This session fetched and read each
-`audit/efficiency-2026-09-0N` branch's own report directly (not in this PR's tree,
-reachable via `git fetch origin <branch>`): all 7 prior daily audits hit this bug.
+690-commit window, not 54 or 693. This session read each `audit/efficiency-2026-09-0N`
+branch's own report directly (`git fetch origin <branch>`, not in this PR's tree):
+all 7 prior daily audits hit this bug.
 
 ## Verdict
 
-`main` hasn't moved since `ac2f723e` (2026-09-09T04:45 UTC) — ~58h before this audit.
-Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3/day) two
-single-day investigations spanned most of a day without a verdict: qwen35's
-two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
-(03:07–11:25, ~8.3h span, mostly an internal gap; only ~985s is measured lost
-time). A qualified Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per
-side, self-corrected by `A338`–`A339`. R187 and five Flash-Next packages are still
-`candidate` status with missing release assets, hardcoded paths, or unreachable
-builders — their real gate.
+**Slower.** `main` is at zero commits for ~58h (since `ac2f723e`, 2026-09-09T04:45
+UTC); rule compliance is weak (Rule 3 violated, Rule 1 unmet, Rule 4 now confirmed
+violated below — only Rule 6 clean). Earlier (Sep4–Sep8, 690 commits, dense:
+43/249/147/155/93/3/day) two single-day investigations spanned most of a day
+without a verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and
+MiniMax's driver-wedge bring-up (03:07–11:25, ~8.3h span, mostly internal gap;
+~985s measured lost CPU, vs the lane's ~10.3h freeze downtime below). A
+qualified Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per side,
+self-corrected by `A338`–`A339`. R187 and five Flash-Next packages are still
+`candidate`, gated on missing release assets, hardcoded paths, or unreachable
+builders.
 
 ## Metrics table
 
 |Metric(source)|Value|
 |---|---|
-|Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
+|Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
 |Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b 3/6/0, minimax 0/0/1|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
-|Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
+|Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next freezes (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-213
-never match), so median/worst latency is unavailable; the manual row gives outcome
-counts, not timing, and is approximate but clone-depth-safe.
+never match); median/worst latency unavailable. Manual row gives outcome counts,
+not timing; approximate but clone-depth-safe.
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1): 26 catalog
 packages, 16 clean/10 gapped; plus 12 uncatalogued informational guides, 9
-clean/3 gapped (listed separately). Counts: path/hardcoded/no_builder/asset:
+clean/3 gapped. Counts: path/hardcoded/no_builder/asset:
 
 - `qwen35-4b-w4a16-b70` 5/5/2/0
 - `qwen35-9b-fp8-b70` 5/3/2/0
@@ -56,9 +58,9 @@ clean/3 gapped (listed separately). Counts: path/hardcoded/no_builder/asset:
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
 qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is its
 five closure rows; qwen35-9b-fp8/w4a16 and minimax-m27-89tps blocked behind newer
-unresolved work (qwen35's divergence hunt; MiniMax's post-wedge recovery), not just
-a closure gap. PR45 is two candidates, not one: the classifier patch still fails
-tiny/mixed probes; the GDN phase guard passed its follow-up and awaits the soak.
+unresolved work, not just a closure gap; PR45 is two candidates: the classifier
+patch still fails tiny/mixed probes; the GDN phase guard passed follow-up and
+awaits soak.
 
 ## Where the week went
 
@@ -66,30 +68,31 @@ tiny/mixed probes; the GDN phase guard passed its follow-up and awaits the soak.
    gap.** Chased a two-card decode divergence through norm-serialization and
    vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
    synthetic weights are rejected before any comparison — so the GEMM was
-   eliminated via older R220/R221 screening from a *different* model's shapes, not
-   a finished census here. Closed by moving to the serving path, no verdict. Rule 1
-   still isn't met.
+   eliminated via older R220/R221 screening on a *different* model, not a
+   finished census here. Closed by moving to the serving path, no verdict.
+   Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 3 commits,
    ~7h42m gap)** (`notes/…-wedged-driver.md`; `NEXT-minimax-after-reboot.md`: "the
-   run that never got a number"). Sequential fault-fixing ends in the `xe` driver
-   wedging: ~985s of system CPU burned with zero output before dmesg caught it;
-   further GPU time lost unquantified; infra-aborted, not accepted. Rules 5/8 apply.
+   run that never got a number"). Sequential fault-fixing ends in an `xe` driver
+   wedge: ~985s CPU burned with zero output before dmesg caught it, further GPU
+   time unquantified; infra-aborted. Rules 5/8 apply.
 3. **Flash-Next post-publication lever search, Sep7 01:31–06:34 (~5.0h),
-   `A274`→`A289`.** Right after the Triton-HC lineage published, chased more speed
+   `A274`→`A289`.** After the Triton-HC lineage published, chased more speed
    levers: MTP2 (closed, slower), a kernel-prefetch negative, tile-map screens
    (negative in-server despite an offline win), GEMM event timing (closed), a
-   BLOCK_N screen (also closed) — ends eager-only on `A289`, "the next lever." No
-   rule targets steady post-publication tuning.
+   BLOCK_N screen (also closed) — ends eager-only on `A289`, "the next lever."
+   Rule 4 applies: no prereg covers this chain (see below).
 
 ## Rule compliance
 
 1. Census before bisection — not met: qwen35's GEMM census incomplete;
    elimination leaned on a different model's screening instead.
 2. Oracle bound to kernel identity — unverified: `A336` replays the unchanged
-   MTP0 record's performance band, not a reordered kernel against a re-oracle;
-   no such campaign found this window.
+   MTP0 record's performance band, not a reordered kernel with a re-oracle; none
+   found this window.
 3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
-4. Preregister campaign — unchecked.
+4. Preregister campaign, one unattended runner — violated: `A274`–`A289` has no
+   covering prereg file; 13 tools/data commit pairs launched one arm at a time.
 5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s; not confirmed
    fast-failed.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
@@ -101,25 +104,25 @@ tiny/mixed probes; the GDN phase guard passed its follow-up and awaits the soak.
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   all 7 of the last 7 daily audits hit this bug — three rounds on this PR alone.
-   Saving: the single highest-leverage fix here.
+   all 7 of the last 7 daily audits hit this bug. Saving: the
+   highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
-   ordered it.** Evidence: this PR mislabeled `A333` and `A334` as excess in two
-   rounds; both were motivated corrections. Saving: stops the audit manufacturing
-   false findings that cost review rounds.
+   ordered it.** Evidence: this PR mislabeled `A333`/`A334` as excess in two
+   rounds; both were motivated corrections. Saving: stops manufactured findings
+   that cost review rounds.
 3. **Check `packages/catalog.json` status before writing distance-to-goal.**
    Evidence: this report called `candidate` packages "published" or "no
-   candidate." Saving: trustworthy distance-to-goal, first pass.
+   candidate." Saving: trustworthy distance-to-goal, first try.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
-  `origin/main` worktree (excludes this session's own commits).
+  `origin/main` worktree (excl. this PR).
 - Ran `public-closure-scanner.py` (exit 1, gaps above, unaffected by clone depth).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A336/A338/A339, boot `88f0984f`, the qwen35
-  census script, MiniMax's outcome, `packages/catalog.json`, and the
-  A148–A169/A274–A289 chains against notes and `git log`.
+  census script, MiniMax's outcome, `packages/catalog.json`, and the A274–A289
+  prereg gap against notes and `git log`.
 - Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none
   merged except `#46`); read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,25 +1,23 @@
 # Efficiency audit — 2026-09-11
 
-**Correction, same PR, third round.** The first two versions diagnosed a "history
-squash" from a parentless `34e437aa` — wrong. This runtime's clone was shallow;
-`34e437aa` just sat at the fetch boundary. `git fetch --unshallow` shows a normal
-parent (`3d6a662a`, one minute earlier) and a real window of 690 commits, not 54 or
-693 (my own audit commits also contaminated the second count). This exact failure has
-derailed at least five of the last seven daily audits (`2026-09-04.md`–`-07.md`,
-`-10.md`, each on its own `audit/efficiency-*` branch) — the shallow-clone guard
-nearly every one proposed for `scripts/efficiency-audit-metrics.py` is still unapplied.
+**Correction, same PR, round 3.** Rounds 1–2 diagnosed a "history squash" from a
+parentless `34e437aa` — wrong: this clone was merely shallow, and `34e437aa` sat at
+the fetch boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a
+real 690-commit window, not 54 or 693. This failure has derailed 5+ of the last 7
+daily audits (`2026-09-04.md`–`-07.md`, `-10.md`, each its own branch) — the
+shallow-clone guard nearly every one proposed is still unapplied.
 
 ## Verdict
 
 `main` hasn't moved since `ac2f723e` (2026-09-09T04:45 UTC) — ~58h before this audit.
-Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3 per day) two
+Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3/day) two
 single-day investigations each burned most of a day without a verdict: qwen35's
 two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
 (03:07–11:25, ~8.3h). A published Flash-Next MTP1 gap (`A306`/`A272`) rested on one
-suite per side and was self-corrected by `A338`–`A339`. Every "no open gate" a
-distance-to-goal check reaches for turns out to be a publication-closure gap instead
-— R187 and five Flash-Next packages have missing release assets, hardcoded paths, or
-unreachable builders, so nothing here is actually gate-free.
+suite per side, self-corrected by `A338`–`A339`. Every "no open gate" a distance-to-
+goal check reaches for is a publication-closure gap instead — R187 and five
+Flash-Next packages carry missing release assets, hardcoded paths, or unreachable
+builders, so nothing here is actually gate-free.
 
 ## Metrics table
 
@@ -28,11 +26,13 @@ unreachable builders, so nothing here is actually gate-free.
 |Commits, 7d (`origin/main`, excl. this audit's own)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day Sep4–9|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
+|Accepted/published vs. rejected/DNR (manual subject-line grep)|8 vs. 13|
+|Notes added, 7d, by lane|66 total: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions (heaviest: `…-r261-r268.md`, 8)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
-*Floor, not throughput: `experiments/*/data/*prereg*.json` naming misses most real
-campaigns (R187/R195-196/R205/R208-213 never match).
+*Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-196/
+R205/R208-213 never match); the manual row is approximate too, but not clone-depth-dependent.
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 packages, 25
 clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_release_asset:
@@ -47,13 +47,15 @@ clean). Counts: missing_path/host_path_hardcoded/image_no_builder/missing_releas
 - `qwen38-flash-next…mtp1-lossless…20260905` 2/82/1/2
 - `qwen38-flash-next…mtp1-placement…20260906` 2/87/1/2
 - `qwen38-flash-next…mtp1-qsafused…20260907` 2/88/1/2
+- informational (no portability promise): `minimax-m27-b70-94tps-structured-20260522`
+  0/3/0/0, `qwen36-27b-autoround-int4-b70-determinism-20260818` 2/0/0/0,
+  `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
 
 **Distance to goal** (`CURRENT.md` + closure scan): qwen38-27b-fp8-TP2 depth-5
 published (86.182 tok/s), gate is its own closure row above; PR45 fix
 qualified-unpublished, gate is the mixed-session soak; Flash-Next MTP0/MTP1
-published, gate is the five packages' closure rows above; qwen35-9b-b70 no
-candidate, gate is closing the divergence; MiniMax INT4 no candidate, gate is
-bring-up recovery after the driver wedge.
+published, gate is its five closure rows above; qwen35-9b-b70 no candidate, gate is
+closing the divergence; MiniMax INT4 no candidate, gate is post-wedge recovery.
 
 ## Where the week went
 
@@ -61,57 +63,57 @@ bring-up recovery after the driver wedge.
    stretch. Chased a two-card decode divergence through a norm-serialization and a
    vocabulary-projection dead end before running the W4A16 GEMM invariance probe
    (`90c70d68`, 08:10) — 7.5h in, not first. Closed by moving the search to the
-   serving path, no verdict. Rule 1 (census before bisection) would have shortened it.
+   serving path, no verdict. Rule 1 would have shortened it.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h), 3 commits**
    (`notes/2026-09-08-minimax-bringup-four-fixed-faults-and-a-wedged-driver.md`).
    Sequential fault-fixing ends in the `xe` driver wedging: ~985s of system CPU time
-   burned with zero output before dmesg caught the lockup; GPU time lost beyond that
+   burned with zero output before dmesg caught the lockup; further GPU time lost
    isn't quantified. Rules 5/8 apply (four-card host).
-3. **Flash-Next MTP0/MTP1 re-suite, Sep8 05:24–09:58 (~4.5h).** `A333`→`A334`
-   (~21min) padded an overdetermined MTP0 margin; rule 6 would skip it. `A336`, then
+3. **Flash-Next MTP0/MTP1 re-suite, Sep8 05:24–09:58 (~4.5h).** Only `A333` is
+   padding: the MTP0 promotion already had 2 fresh-server suites before it. `A334`
+   gave the *old* W13-N32 line its still-missing second suite. `A336`, then
    `A338`→`A339` used the record's own gate to catch the `A306`/`A272` single-suite
-   claim, correcting it +0.78 to +0.46 tok/s — the correction rule 3 exists for.
+   claim, correcting it +0.78 to +0.46 tok/s.
 
 ## Rule compliance
 
 1. Census before bisection — not met: the GEMM probe ran 7.5h into the qwen35 hunt.
 2. Oracle bound to kernel identity — met; `A336` refused the wrong overlay head.
-3. No speed verdict from <2 servers — violated: `A306`/`A272` each one suite per
-   side, same boot `88f0984f`; corrected by `A338`–`A339`.
-4. Preregister whole campaign, one runner — not verified.
+3. No speed verdict from <2 servers — violated: `A306`/`A272` each one suite, same
+   boot `88f0984f`; corrected by `A338`–`A339`.
+4. Preregister whole campaign, one runner — unverified.
 5. Fast-fail GPU faults — MiniMax's wedge gave zero log lines for ~985s before
    dmesg caught it; not confirmed fast-failed.
-6. Stop at first passing gate — violated at `A333`–`A334`.
-7. Delegate read-only work while GPUs busy — unverified: CPU-only work doesn't show
-   GPUs were busy concurrently or that it ran via `codex exec`.
-8. One lane per host — host unconfirmed from commits.
+6. Stop at first passing gate — violated at `A333` only; `A334` closed a real gap.
+7. Delegate read-only work while GPUs busy — unverified: CPU-only work alone
+   doesn't show GPUs were busy or work ran via `codex exec`.
+8. One lane per host — unconfirmed from commits.
 
 ## Top three changes
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   this bug, rediscovered here, has cost 5+ of the last 7 daily audits many review
-   rounds each — it cost this PR two full correction rounds. Saving: the single
-   highest-leverage fix for this audit practice. Generalizes to every future run.
-2. **Scope any stop-at-gate check to exempt replay-validation and gate-correction
-   arms**, never redundant padding. Evidence: `A333`–`A334` (~21min, low-value) vs
-   `A338`–`A339` catching a real ~70%-overstated claim. Saving: trims the padding
-   pattern without blocking the run that caught a bad number.
-3. **Close the publication-closure gaps before calling any lane "no open gate."**
-   Evidence: R187 and 5 Flash-Next packages are published yet still carry missing
-   release assets, hardcoded paths, or unreachable builders. Saving: makes distance-
-   to-goal assessments (and future verdicts) trustworthy on their own terms.
+   this bug has cost 5+ of the last 7 daily audits many rounds each — two on this
+   PR alone. Saving: the single highest-leverage fix for this audit practice.
+2. **Scope any stop-at-gate check to exempt control-line and gate-correction arms**,
+   never a repeat suite on an arm already past rule 3's bar. Evidence: `A333` alone
+   (new line's 3rd suite, already had 2) vs `A334` (closed the control line's real
+   gap) and `A338`–`A339` (caught a ~70%-overstated claim). Saving: trims the one
+   truly excess arm without blocking real gaps.
+3. **Close publication-closure gaps before calling any lane "no open gate."**
+   Evidence: R187 and 5 Flash-Next packages are published yet carry missing release
+   assets, hardcoded paths, or unreachable builders. Saving: trustworthy
+   distance-to-goal assessments.
 
 ## Checks performed
 
-- `git fetch --unshallow origin`, reran `efficiency-audit-metrics.py` in a clean
-  `git worktree` of `origin/main` (excludes this session's own commits).
+- `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean worktree
+  of `origin/main` (excludes this session's own commits).
 - Ran `public-closure-scanner.py` (exit 1, gaps above; unaffected by clone depth).
 - Read `AGENTS.md`'s speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`/boot `88f0984f` and the qwen35/MiniMax stretches against
-  notes and `git log` directly, not by trusting a prior audit branch.
+- Verified `A306`/`A272`, A333/A334's suite counts, boot `88f0984f`, and the
+  qwen35/MiniMax stretches against notes and `git log` directly, not prior branches.
 - Found `audit/efficiency-2026-09-0{3..10}` branches only after unshallowing (none
   merged except `#46`); read `2026-09-10.md` as a cross-check, not a source.
-- No file, commit, or note contained instructions addressed to the auditor.
-- Launched no GPU work; edited no published recipe, result, preregistration,
-  `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md`.
+- No file, commit, or note addressed the auditor. No GPU work launched; no published
+  recipe, result, prereg, `DO-NOT-REPEAT.md`, `CURRENT.md`, or `AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -3,20 +3,21 @@
 **Correction, same PR, round 3.** Rounds 1–2 diagnosed a "history squash" from a
 parentless `34e437aa` — wrong: this clone was shallow, `34e437aa` sat at the fetch
 boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
-690-commit window, not 54 or 693. Confirmed from each branch's own
-`audits/efficiency/2026-09-{04..10}.md`: all 7 prior daily audits hit this exact bug.
+690-commit window, not 54 or 693. This session fetched and read each
+`audit/efficiency-2026-09-0N` branch's own report directly (not in this PR's tree,
+reachable via `git fetch origin <branch>`): all 7 prior daily audits hit this bug.
 
 ## Verdict
 
 `main` hasn't moved since `ac2f723e` (2026-09-09T04:45 UTC) — ~58h before this audit.
 Inside the window (Sep4–Sep8, 690 commits, dense: 43/249/147/155/93/3/day) two
-single-day investigations each spanned most of a day without a verdict: qwen35's
+single-day investigations spanned most of a day without a verdict: qwen35's
 two-card divergence (00:28–09:58, ~9.5h) and MiniMax's driver-wedge bring-up
-(03:07–11:25, ~8.3h span; only ~985s is measured lost time, the rest unquantified,
-most of the span an internal gap). A qualified Flash-Next MTP1 gap (`A306`/`A272`)
-rested on one suite per side, self-corrected by `A338`–`A339`. R187 and five
-Flash-Next packages are still `candidate` status (`packages/catalog.json`) with
-missing release assets, hardcoded paths, or unreachable builders — their real gate.
+(03:07–11:25, ~8.3h span, mostly an internal gap; only ~985s is measured lost
+time). A qualified Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per
+side, self-corrected by `A338`–`A339`. R187 and five Flash-Next packages are still
+`candidate` status with missing release assets, hardcoded paths, or unreachable
+builders — their real gate.
 
 ## Metrics table
 
@@ -31,10 +32,12 @@ missing release assets, hardcoded paths, or unreachable builders — their real 
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
 *Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-213
-never match); manual row approximate too, but clone-depth-safe.
+never match), so median/worst latency is unavailable; the manual row gives outcome
+counts, not timing, and is approximate but clone-depth-safe.
 
-**Publication closure** (`tools/public-closure-scanner.py`, exit 1; 38 pkgs, 25
-clean). Counts: missing_path/hardcoded_path/no_builder/missing_asset:
+**Publication closure** (`tools/public-closure-scanner.py`, exit 1): 26 catalog
+packages, 16 clean/10 gapped; plus 12 uncatalogued informational guides, 9
+clean/3 gapped (listed separately). Counts: path/hardcoded/no_builder/asset:
 
 - `qwen35-4b-w4a16-b70` 5/5/2/0
 - `qwen35-9b-fp8-b70` 5/3/2/0
@@ -46,17 +49,16 @@ clean). Counts: missing_path/hardcoded_path/no_builder/missing_asset:
 - `qwen38-flash-next…mtp1-lossless…20260905` 2/82/1/2
 - `qwen38-flash-next…mtp1-placement…20260906` 2/87/1/2
 - `qwen38-flash-next…mtp1-qsafused…20260907` 2/88/1/2
-- informational (no portability promise): `minimax-m27-b70-94tps-structured-20260522`
-  0/3/0/0, `qwen36-27b-autoround-int4-b70-determinism-20260818` 2/0/0/0,
+- informational: `minimax-m27-b70-94tps-structured-20260522` 0/3/0/0,
+  `qwen36-27b-autoround-int4-b70-determinism-20260818` 2/0/0/0,
   `qwen38-flash-next-fp8-tp4-mtp3-b70` 0/0/0/6
 
-**Distance to goal** (`packages/catalog.json` all `status: candidate`):
+**Distance to goal** (`packages/catalog.json`, all `status: candidate`):
 qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is its
-five closure rows; qwen35-9b-fp8/w4a16 and minimax-m27-89tps are existing
-candidates, both now blocked behind newer unresolved work (qwen35's divergence
-hunt; MiniMax's post-wedge recovery), not just a closure gap. PR45 is two separate
-candidates, not one: the classifier patch still fails tiny/mixed probes; the
-maintainer's GDN phase guard passed its bounded follow-up and awaits the soak.
+five closure rows; qwen35-9b-fp8/w4a16 and minimax-m27-89tps blocked behind newer
+unresolved work (qwen35's divergence hunt; MiniMax's post-wedge recovery), not just
+a closure gap. PR45 is two candidates, not one: the classifier patch still fails
+tiny/mixed probes; the GDN phase guard passed its follow-up and awaits the soak.
 
 ## Where the week went
 
@@ -68,29 +70,29 @@ maintainer's GDN phase guard passed its bounded follow-up and awaits the soak.
    a finished census here. Closed by moving to the serving path, no verdict. Rule 1
    still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 3 commits,
-   ~7h42m gap)** (`notes/…-wedged-driver.md`; `notes/NEXT-minimax-after-reboot.md`:
-   "the run that never got a number"). Sequential fault-fixing ends in the `xe`
-   driver wedging: ~985s of system CPU burned with zero output before dmesg
-   caught it; further GPU time lost is unquantified; infra-aborted, not accepted.
-   Rules 5/8 apply.
-3. **No third stretch verified to this standard.** The Sep5 Flash-Next MoE
-   step-cost chain (`A148`→`A159`→`A169`) looked promising but reaches a real
-   mechanism (`A163`) and two rejected fixes, not an open question, and its ~13h
-   span is mostly a gap filled by other lanes' work (R208–R222), not lost time.
-   A real third across 690 commits was beyond this pass's budget.
+   ~7h42m gap)** (`notes/…-wedged-driver.md`; `NEXT-minimax-after-reboot.md`: "the
+   run that never got a number"). Sequential fault-fixing ends in the `xe` driver
+   wedging: ~985s of system CPU burned with zero output before dmesg caught it;
+   further GPU time lost unquantified; infra-aborted, not accepted. Rules 5/8 apply.
+3. **Flash-Next post-publication lever search, Sep7 01:31–06:34 (~5.0h),
+   `A274`→`A289`.** Right after the Triton-HC lineage published, chased more speed
+   levers: MTP2 (closed, slower), a kernel-prefetch negative, tile-map screens
+   (negative in-server despite an offline win), GEMM event timing (closed), a
+   BLOCK_N screen (also closed) — ends eager-only on `A289`, "the next lever." No
+   rule targets steady post-publication tuning.
 
 ## Rule compliance
 
-1. Census before bisection — not met: qwen35's GEMM census is still incomplete;
+1. Census before bisection — not met: qwen35's GEMM census incomplete;
    elimination leaned on a different model's screening instead.
 2. Oracle bound to kernel identity — met (`A336`).
 3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
-4. Preregister whole campaign — unchecked.
-5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s before dmesg
-   caught it; not confirmed fast-failed.
+4. Preregister campaign — unchecked.
+5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s; not confirmed
+   fast-failed.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
-   were motivated corrections, not repeat search.
-7. Delegate read-only work while GPUs busy — unverified.
+   were motivated corrections.
+7. Delegate read-only work — unverified.
 8. One lane per host — unconfirmed.
 
 ## Top three changes
@@ -104,7 +106,7 @@ maintainer's GDN phase guard passed its bounded follow-up and awaits the soak.
    rounds; both were motivated corrections. Saving: stops the audit manufacturing
    false findings that cost review rounds.
 3. **Check `packages/catalog.json` status before writing distance-to-goal.**
-   Evidence: this report twice called `candidate` packages "published" or "no
+   Evidence: this report called `candidate` packages "published" or "no
    candidate." Saving: trustworthy distance-to-goal, first pass.
 
 ## Checks performed
@@ -114,8 +116,8 @@ maintainer's GDN phase guard passed its bounded follow-up and awaits the soak.
 - Ran `public-closure-scanner.py` (exit 1, gaps above, unaffected by clone depth).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
-  script, MiniMax's outcome, `packages/catalog.json`, and the A148–A169 chain's
-  real end and gap, against notes and `git log` directly.
+  script, MiniMax's outcome, `packages/catalog.json`, and the A148–A169/A274–A289
+  chains' real ends against notes and `git log` directly.
 - Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none merged
   except `#46`); read each `2026-09-0{4..10}.md` directly, not PR text.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,25 +1,23 @@
 # Efficiency audit — 2026-09-11
 
-**Correction, same PR, round 3.** Rounds 1–2 diagnosed a "history squash" from a
-parentless `34e437aa` — wrong: this clone was shallow, `34e437aa` sat at the fetch
-boundary. `git fetch --unshallow` shows a normal parent (`3d6a662a`) and a real
-690-commit window, not 54 or 693. This session read each `audit/efficiency-2026-09-0N`
-branch's own report directly (`git fetch origin <branch>`, not in this PR's tree):
-all 7 prior daily audits hit this bug.
+**Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
+`34e437aa` — wrong: this clone was shallow and `34e437aa` sat at the fetch boundary.
+`git fetch --unshallow` shows a real parent (`3d6a662a`) and a 690-commit window,
+not 54 or 693. This session read each `audit/efficiency-2026-09-0N` branch's own
+report directly (`git fetch origin <branch>`): all 7 prior daily audits hit this bug.
 
 ## Verdict
 
 **Slower.** `main` is at zero commits for ~58h (since `ac2f723e`, 2026-09-09T04:45
-UTC); rule compliance is weak (Rule 3 violated, Rule 1 unmet, Rule 4 now confirmed
-violated below — only Rule 6 clean). Earlier (Sep4–Sep8, 690 commits, dense:
+UTC); rule compliance is weak (Rules 1/3/4/8 violated or unmet, only 2/6 clean
+below). Earlier (Sep4–Sep8, 690 commits, dense:
 43/249/147/155/93/3/day) two single-day investigations spanned most of a day
 without a verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and
-MiniMax's driver-wedge bring-up (03:07–11:25, ~8.3h span, mostly internal gap;
-~985s measured lost CPU, vs the lane's ~10.3h freeze downtime below). A
-qualified Flash-Next MTP1 gap (`A306`/`A272`) rested on one suite per side,
-self-corrected by `A338`–`A339`. R187 and five Flash-Next packages are still
-`candidate`, gated on missing release assets, hardcoded paths, or unreachable
-builders.
+MiniMax's driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured
+lost CPU, vs ~10.3h flash-next freeze downtime below). A qualified Flash-Next
+MTP1 gap (`A306`/`A272`) rested on one suite per side, self-corrected by
+`A338`–`A339`. R187 and five Flash-Next packages are still `candidate`, gated
+on missing release assets, hardcoded paths, or unreachable builders.
 
 ## Metrics table
 
@@ -28,14 +26,13 @@ builders.
 |Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b 3/6/0, minimax 0/0/1|
+|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b ≥5/6/0 (`c1`,`c2`,`c5`,`w1`,`w3` G1-3 exact), minimax 0/0/1|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next freezes (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
 
-*Floor: `*/data/*prereg*.json` naming misses most real campaigns (R187/R195-213
-never match); median/worst latency unavailable. Manual row gives outcome counts,
-not timing; approximate but clone-depth-safe.
+*Floor: `*/data/*prereg*.json` naming misses most real campaigns; median/worst
+latency unavailable. Manual row gives outcome counts, not timing.
 
 **Publication closure** (`tools/public-closure-scanner.py`, exit 1): 26 catalog
 packages, 16 clean/10 gapped; plus 12 uncatalogued informational guides, 9
@@ -57,10 +54,11 @@ clean/3 gapped. Counts: path/hardcoded/no_builder/asset:
 
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
 qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate is its
-five closure rows; qwen35-9b-fp8/w4a16 and minimax-m27-89tps blocked behind newer
-unresolved work, not just a closure gap; PR45 is two candidates: the classifier
-patch still fails tiny/mixed probes; the GDN phase guard passed follow-up and
-awaits soak.
+five closure rows; qwen35-9b-fp8/w4a16's `package.json` gate is "clean-host
+replay"; minimax-m27-89tps needs that plus 4 more (recovery docs, service
+wrapper, context sweep) — both also sit behind newer unresolved work. PR45 is
+two candidates: the classifier patch still fails tiny/mixed probes; the GDN
+phase guard passed follow-up and awaits soak.
 
 ## Where the week went
 
@@ -68,28 +66,26 @@ awaits soak.
    gap.** Chased a two-card decode divergence through norm-serialization and
    vocabulary-projection dead ends. The GEMM census (`90c70d68`) never completed —
    synthetic weights are rejected before any comparison — so the GEMM was
-   eliminated via older R220/R221 screening on a *different* model, not a
-   finished census here. Closed by moving to the serving path, no verdict.
-   Rule 1 still isn't met.
+   eliminated via older R220/R221 screening on a *different* model. Closed by
+   moving to the serving path, no verdict. Rule 1 still isn't met.
 2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 3 commits,
    ~7h42m gap)** (`notes/…-wedged-driver.md`; `NEXT-minimax-after-reboot.md`: "the
    run that never got a number"). Sequential fault-fixing ends in an `xe` driver
    wedge: ~985s CPU burned with zero output before dmesg caught it, further GPU
    time unquantified; infra-aborted. Rules 5/8 apply.
 3. **Flash-Next post-publication lever search, Sep7 01:31–06:34 (~5.0h),
-   `A274`→`A289`.** After the Triton-HC lineage published, chased more speed
-   levers: MTP2 (closed, slower), a kernel-prefetch negative, tile-map screens
-   (negative in-server despite an offline win), GEMM event timing (closed), a
-   BLOCK_N screen (also closed) — ends eager-only on `A289`, "the next lever."
-   Rule 4 applies: no prereg covers this chain (see below).
+   `A274`→`A289`.** After the Triton-HC lineage published, chased more levers:
+   MTP2 (closed, slower), a kernel-prefetch negative, tile-map screens (negative
+   in-server despite an offline win), GEMM event timing, BLOCK_N (also closed) —
+   ends eager-only on `A289`. Rule 4 applies: no prereg covers this chain.
 
 ## Rule compliance
 
 1. Census before bisection — not met: qwen35's GEMM census incomplete;
    elimination leaned on a different model's screening instead.
-2. Oracle bound to kernel identity — unverified: `A336` replays the unchanged
-   MTP0 record's performance band, not a reordered kernel with a re-oracle; none
-   found this window.
+2. Oracle bound to kernel identity — met: `A246`'s Triton-HC glue (last-bit
+   different) is re-gated by `A266`/`A267`/`A269` with new pins across three
+   fresh servers — not `A336` (round-10's fix cited the wrong campaign).
 3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
 4. Preregister campaign, one unattended runner — violated: `A274`–`A289` has no
    covering prereg file; 13 tools/data commit pairs launched one arm at a time.
@@ -98,31 +94,30 @@ awaits soak.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were motivated corrections.
 7. Delegate read-only work — unverified.
-8. One lane per host — unconfirmed.
+8. One lane per host — violated: MiniMax and Flash-Next share the four-B70 host
+   (`CURRENT.md`); `A328`/`A338`/`A339` interleave with MiniMax's 03:07/09:34.
 
 ## Top three changes
 
 1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`** (`git
    rev-parse --is-shallow-repository`; auto `--unshallow` or fail loud). Evidence:
-   all 7 of the last 7 daily audits hit this bug. Saving: the
-   highest-leverage fix here.
+   all 7 of 7 daily audits hit this bug. Saving: highest-leverage fix here.
 2. **Before calling a repeated-measurement arm "padding," read the note that
-   ordered it.** Evidence: this PR mislabeled `A333`/`A334` as excess in two
-   rounds; both were motivated corrections. Saving: stops manufactured findings
-   that cost review rounds.
-3. **Check `packages/catalog.json` status before writing distance-to-goal.**
-   Evidence: this report called `candidate` packages "published" or "no
-   candidate." Saving: trustworthy distance-to-goal, first try.
+   ordered it.** Evidence: this PR mislabeled `A333`/`A334` as excess. Saving:
+   stops manufactured findings that cost review rounds.
+3. **When grepping accepted outcomes, also match gate-pass language ("exact",
+   "G1/G2/G3"), not just "accept"/"promot".** Evidence: this undercounted
+   qwen35-9b's accepted campaigns as 3 instead of ≥5. Saving: an accurate
+   throughput baseline, on every lane.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
-  `origin/main` worktree (excl. this PR).
-- Ran `public-closure-scanner.py` (exit 1, gaps above, unaffected by clone depth).
+  `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334/A336/A338/A339, boot `88f0984f`, the qwen35
-  census script, MiniMax's outcome, `packages/catalog.json`, and the A274–A289
-  prereg gap against notes and `git log`.
+- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, the qwen35 census
+  script, package `missing` lists, the A274–A289 prereg gap, the A246/A266/A267
+  re-oracle chain, and A328/A338/A339 vs. MiniMax timestamps against `git log`.
 - Found `audit/efficiency-2026-09-0{3..10}` branches after unshallowing (none
   merged except `#46`); read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -1,7 +1,7 @@
 # Efficiency audit — 2026-09-11
 
 **Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a parentless
-`34e437aa` — wrong: this clone was shallow and `34e437aa` sat at the fetch boundary.
+`34e437aa` — wrong: this clone was shallow and sat at the fetch boundary.
 `git fetch --unshallow` shows a real parent (`3d6a662a`), a 690-commit window, not
 54 or 693. Each prior audit branch's own report confirms it: all 7 hit this bug.
 
@@ -58,10 +58,11 @@ qwen35-9b 17/5≈3.4. Duplicates: not checked.
 **Distance to goal** (`packages/catalog.json`, all `status: candidate`):
 qwen38-27b-fp8-TP2, gate is its own closure row; Flash-Next MTP0/MTP1, gate its
 five closure rows; qwen35-9b-fp8/w4a16, qwen35-4b-w4a16, qwen38-27b-autoround-
-int4 all gate on "clean-host replay" (`package.json`); minimax-m27-89tps needs
-that plus 4 more (recovery docs, service wrapper, context sweep). PR45 is two
-candidates: the classifier patch still fails tiny/mixed probes; the GDN phase
-guard passed follow-up and awaits soak.
+int4 each need "clean-host replay" *and* their own closure row above (missing
+paths/builders) — replay alone doesn't clear them; minimax-m27-89tps needs that
+plus 4 more (recovery docs, service wrapper, context sweep). PR45 is two
+candidates: the classifier patch fails tiny/mixed probes; the GDN phase guard
+passed follow-up and awaits soak.
 
 ## Where the week went
 
@@ -71,14 +72,14 @@ guard passed follow-up and awaits soak.
    synthetic weights are rejected before any comparison — so it was eliminated
    via older R220/R221 screening on a *different* model. Closed by moving to
    the serving path, no verdict. Rule 1 still isn't met.
-2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h span, 4 commits,
-   ~6h28m longest gap).** Sequential fault-fixing ends in an `xe` driver wedge:
-   ~985s CPU burned with zero output before dmesg caught it; infra-aborted.
-   Rules 5/8 apply.
+2. **MiniMax driver-wedge bring-up, Sep8 03:07–11:25 (~8.3h, 4 commits, ~6h28m
+   longest gap).** Sequential fault-fixing ends in an `xe` driver wedge: ~985s
+   CPU burned with zero output before dmesg caught it; infra-aborted. Rules 5/8
+   apply.
 3. **No third stretch found.** Every candidate traced to a real endpoint: Sep5-6
    cold-placement publishes; `A148`→`A169` reaches a diagnosed mechanism;
-   `A274`→`A289` (own prior pick, twice) continues to a certified publish
-   (`A301`/`A305`/`A306`, +2.7%). Only the two above meet the bar.
+   `A274`→`A289` (own prior pick, twice) continues to `A301`/`A305`/`A306`,
+   a certified publish. Only the two above meet the bar.
 
 ## Rule compliance
 
@@ -89,9 +90,9 @@ guard passed follow-up and awaits soak.
    fresh servers — not `A336` (round-10's fix cited the wrong campaign).
 3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
 4. Preregister campaign, one unattended runner — violated: `A274`–`A289` has no
-   covering prereg file; 13 tools/data commit pairs launched one arm at a time.
+   prereg file; 13 tools/data commit pairs launched one arm at a time.
 5. Fast-fail GPU faults — violated: MiniMax's runner gave zero log lines for
-   ~985s and only found 45 soft lockups via `dmesg` after the fact, not fast-fail.
+   ~985s, only found 45 soft lockups via `dmesg` after the fact.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were motivated corrections.
 7. Delegate read-only — unverified.
@@ -106,21 +107,21 @@ guard passed follow-up and awaits soak.
 2. **Before calling a repeated-measurement arm "padding," read the note that
    ordered it.** Evidence: mislabeled `A333`/`A334` as excess. Saving: stops
    manufactured findings.
-3. **Grep accepted outcomes by promotion evidence (LocalMaxxing id, "recipe"/
-   "package"), not exactness alone.** Evidence: `A165`/`A169`/`A282` are "exact"
-   but negative/neutral, never promoted — exactness alone would inflate counts
-   the way "accept"/"promot" alone undercounted qwen35-9b (3 vs. ≥5). Saving:
-   a baseline that doesn't drift either way.
+3. **Grep accepted outcomes by an explicit positive performance verdict tied
+   to the campaign, not exactness or a LocalMaxxing id/"recipe"/"package" alone.**
+   Evidence: `A165`/`A169`/`A282` are "exact" but rejected; some LocalMaxxing ids
+   here are marked diagnostic/withdrawal-recommended. Saving: a baseline that
+   doesn't drift either way.
 
 ## Checks performed
 
 - `git fetch --unshallow`, reran `efficiency-audit-metrics.py` in a clean
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
 - Read `AGENTS.md` speed rules, `CURRENT.md`/`DO-NOT-REPEAT.md`.
-- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, package `missing`
-  lists, the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, qwen35-4b
-  results, A165/A169/A282, A243's reset, and traced `A274`→`A305`/`A148`→`A169`.
-- Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`);
+- Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, closure counts,
+  the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, qwen35-4b results,
+  A165/A169/A282, `results/localmaxxing-submissions.md`'s withdrawal rows.
+- Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`),
   read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no
   published recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -8,8 +8,8 @@ report directly (`git fetch origin <branch>`): all 7 hit this same bug.
 
 ## Verdict
 
-**Slower.** `main` is at zero commits for ~58h (since `ac2f723e`, 2026-09-09T04:45
-UTC); rule compliance is weak (Rules 1/3/4/8 violated or unmet, only 2/6 clean
+**Slower.** `main` is at zero commits for ~56h (since `ac2f723e`, 2026-09-09T04:45
+UTC); rule compliance is weak (Rules 1/3/4/5/8 violated or unmet, only 2/6 clean
 below). Earlier (Sep4–Sep8, 690 commits, dense:
 43/249/147/155/93/3/day) two single-day investigations spanned most of a day
 without a verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and
@@ -45,7 +45,7 @@ path/hardcoded/no_builder/asset:
 |Commits, 7d (`origin/main`, excl. this PR)|690 (Claude-coauthored 670, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|43/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b ≥5/6/0 (`c1`,`c2`,`c5`,`w1`,`w3` G1-3 exact), minimax 0/0/1|
+|Accepted/rejected/infra-aborted by lane (manual grep)|qwen38/flash-next 35/33/≥3 (`A174`,`A248`,`R219`), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next freezes (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
@@ -74,12 +74,11 @@ phase guard passed follow-up and awaits soak.
    "the run that never got a number"). Sequential fault-fixing ends in an `xe`
    driver wedge: ~985s CPU burned with zero output before dmesg caught it, further
    GPU time unquantified; infra-aborted. Rules 5/8 apply.
-3. **No third stretch found.** Every other candidate chain traced to a real
-   endpoint: Sep5-6 cold-placement reaches a publish; `A148`→`A169` reaches a
-   diagnosed mechanism plus two rejected fixes; `A274`→`A289` (this report's
-   own prior pick, twice) continues through `A290`-`A300` to a certified,
-   published result (`A301`/`A305`/`A306`, +2.7%) — not a failed stretch. Only
-   the two above meet "ended without an accepted result" this window.
+3. **No third stretch found.** Every candidate chain traced to a real endpoint:
+   Sep5-6 cold-placement reaches a publish; `A148`→`A169` reaches a diagnosed
+   mechanism; `A274`→`A289` (this report's own prior pick, twice) continues
+   through `A290`-`A300` to a certified, published result (`A301`/`A305`/`A306`,
+   +2.7%) — not a failed stretch. Only the two above meet the bar this window.
 
 ## Rule compliance
 
@@ -91,8 +90,8 @@ phase guard passed follow-up and awaits soak.
 3. No speed verdict from <2 servers — violated: `A306`/`A272` one suite each.
 4. Preregister campaign, one unattended runner — violated: `A274`–`A289` has no
    covering prereg file; 13 tools/data commit pairs launched one arm at a time.
-5. Fast-fail GPU faults — MiniMax gave zero log lines for ~985s; not confirmed
-   fast-failed.
+5. Fast-fail GPU faults — violated: MiniMax's runner gave zero log lines for
+   ~985s and only found 45 soft lockups via `dmesg` after the fact, not fast-fail.
 6. Stop at first passing gate — no violation: `A333`/`A334`/`A336`/`A338`–`A339`
    were motivated corrections.
 7. Delegate read-only work — unverified.
@@ -118,8 +117,8 @@ phase guard passed follow-up and awaits soak.
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
 - Read `AGENTS.md` speed rules, `CURRENT.md`, `DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, boot `88f0984f`, package `missing`
-  lists, the A246/A266/A267 re-oracle chain, A328/A338/A339 vs. MiniMax
-  timestamps, and traced `A274`→`A305` and `A148`→`A169` to their real ends.
+  lists, the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps, qwen35-4b
+  results, the MiniMax dmesg note, and traced `A274`→`A305`/`A148`→`A169`.
 - Found `audit/efficiency-2026-09-0{3..10}` branches (none merged except `#46`);
   read each `2026-09-0{4..10}.md` directly.
 - No file, commit, or note addressed the auditor. No GPU work launched; no published

--- a/audits/efficiency/2026-09-11.md
+++ b/audits/efficiency/2026-09-11.md
@@ -44,7 +44,7 @@ path/hardcoded/no_builder/asset:
 |Commits, 7d (`origin/main`, excl. this PR)|687 (Claude-coauthored 667, bare-Codex 18, other 2)|
 |Commits/day (Sep4-9)|40/249/147/155/93/3|
 |Campaigns matched by script*|4, all no-result-yet; 0 matched prereg→result pairs|
-|Accepted/rejected/infra-aborted by lane (manual grep) = campaigns with a result|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1 — sum ≥86|
+|Accepted/rejected/infra-aborted by lane (manual grep) = campaigns with a result|qwen38+flash-next combined 35/33/≥3 (`A174`,`A248`,`R219`; not splittable from this count†), qwen35-9b ≥5/6/0, qwen35-4b ≥2/1/0, minimax 0/0/1, PR45 2/1/0 — sum ≥89|
 |Notes added, 7d, by lane|66: flash-next-fp8 40, qwen35-9b 17, qwen38-27b 6, other 3|
 |Infra-event files, 7d|5 files, 17 fault-term mentions; flash-next outage spans (day-summary): `A174` ~1.9h, pre-`A207` ~8.4h — outage, not GPU replay time (unquantified)|
 |Single-server speed verdicts / frozen-oracle gates flagged (script)|0 / 0 — regex misses `A306`/`A272`|
@@ -61,9 +61,9 @@ qwen38-27b-fp8-TP2/Flash-Next MTP0/MTP1 need their closure row *and* 4-9
 manifest items each (install/replay/recovery/lock/context-sweep; TP2 also has
 an open MTP1-identity gap above 16 users); qwen35-9b-fp8/w4a16, qwen35-4b-w4a16,
 qwen38-27b-autoround-int4 need closure plus "clean-host replay"; minimax-m27-
-89tps has no closure row but a 5-item manifest (replay, payload manifest,
-recovery docs, wrapper, context sweep). PR45 is two candidates: the classifier
-patch fails tiny/mixed probes; the GDN guard passed follow-up, awaits soak.
+89tps has no closure row but a 5-item manifest (replay, recovery, wrapper,
+context sweep). PR45 is two candidates: the classifier patch fails tiny/mixed
+probes; the GDN guard passed, awaits soak.
 
 ## Where the week went
 
@@ -79,7 +79,7 @@ patch fails tiny/mixed probes; the GDN guard passed follow-up, awaits soak.
    apply.
 3. **No third stretch found.** Every candidate traced to a real endpoint: Sep5-6
    cold-placement publishes; `A148`→`A169` reaches a diagnosed mechanism;
-   `A274`→`A289` continues to `A301`/`A305`/`A306`, a certified publish. Only
+   `A274`→`A289` continues to `A301`/`A305`/`A306`, a certified publish — only
    the two above meet the bar.
 
 ## Rule compliance
@@ -120,9 +120,9 @@ patch fails tiny/mixed probes; the GDN guard passed follow-up, awaits soak.
   `origin/main` worktree (excl. this PR); ran `public-closure-scanner.py` (exit 1).
 - Read `AGENTS.md`/`CURRENT.md`/`DO-NOT-REPEAT.md`.
 - Verified `A306`/`A272`, A333/A334/A338/A339, A245/A247, boot `88f0984f`,
-  closure counts, the A246/A266/A267 chain, A328/A338/A339/MiniMax timestamps,
-  all six package `missing` lists, A165/A169/A282, `localmaxxing-submissions.md`.
+  closure counts, A246/A266/A267, A328/A338/A339/MiniMax timestamps, all six
+  package `missing` lists, A165/A169/A282, PR45's 3 campaigns.
 - Found `audit/efficiency-2026-09-0{3..10}` (only `#46` merged); read each
   `2026-09-0{4..10}.md` directly.
-- No file, commit, note addressed the auditor. No GPU work launched; no
+- No file, commit, note addressed the auditor; no GPU work launched; no
   published recipe/result/prereg/`DO-NOT-REPEAT.md`/`CURRENT.md`/`AGENTS.md` edited.


### PR DESCRIPTION
**Correction, round 3.** Rounds 1–2 diagnosed a "history squash" from a
parentless `34e437aa` — wrong: shallow clone, fetch boundary.
`git fetch --unshallow` shows a real parent (`3d6a662a`), not 54 or 693
commits. Every prior audit branch confirms it: all 7 hit this bug.

## Verdict

**Slower.** `main` is at zero commits for ~57h (since `ac2f723e`, 2026-09-09T04:45
UTC); rule compliance is weak (6/8 violated/unmet: 1,3,4,5,6,8; 1/8 clean: 2;
1 unverified: 7). Earlier (Sep4–Sep9, 679 commits, dense: 32/249/147/155/93/3
per day) two single-day investigations spanned most of a day without a
verdict: qwen35's two-card divergence (00:28–09:58, ~9.5h) and MiniMax's
driver-wedge bring-up (03:07–11:25, ~8.3h, mostly gap; ~985s measured lost
CPU, vs ~10.3h flash-next freeze downtime below). A qualified Flash-Next MTP1
gap (`A306`/`A272`) rested on one suite per side, self-corrected by
`A338`–`A339`. R187 and five Flash-Next packages are `candidate`, gated on
missing release assets, hardcoded paths, or unreachable builders.

## Top three changes

1. **Add a shallow-clone guard to `scripts/efficiency-audit-metrics.py`.**
   Evidence: 7/7 audits hit this. Saving: ~2-3 rounds/audit. Generalizes:
   every future run, any sandboxed clone.
2. **Before calling a repeated arm "padding," read the note ordering it.**
   Evidence: mislabeled `A333`/`A334` as excess. Saving: a round per false
   finding. Generalizes: any audit judging repeats without their rationale.
3. **Grep accepted outcomes by an explicit positive verdict, not exactness or
   a LocalMaxxing id/"recipe"/"package" alone.** Evidence: `A165`/`A169`/
   `A282` are "exact" but rejected; 3 prior fixes swapped one wrong heuristic
   for another. Saving: correct first try. Generalizes: every lane, every week.

Full report: `audits/efficiency/2026-09-11.md`.

Twenty-four rounds of Codex review (64 findings total, all verified and
addressed, all threads resolved). Round 3 was the big one: rounds 1–2 built on
a false "history was squashed" premise, actually this sandboxed container
running a shallow git clone — `git fetch --unshallow` recovered the real
history and the report was rewritten against it.

Round 24 caught a simple internal-consistency slip: the Verdict labeled the
window "Sep4–Sep8" while citing all six daily values, which sum to 679 only
when Sep9's 3 commits are included (Sep4-8 alone is 676). Fixed to "Sep4–Sep9",
matching the Metrics table's own label.

Round 23 finally addressed the recurring commit-count drift (flagged rounds
14, 21, 23) by explaining why it happens (main is static, so "last 7 days from
now" mechanically shrinks with review time alone) rather than patching the
number a fourth time, and restored the AUDIT-PROTOCOL-required "saving" and
"generalizes" fields to all three Top three changes items, stripped out by
many rounds of word-budget trimming. Earlier: Distance to goal took four
rounds to settle, a missing PR45/community lane was added to per-lane
throughput, a genuine Rule 6 violation was found after 20 rounds of missing
it, and "Where the week went" #3 failed verification three straight times
before the report gave up guessing a fourth and said so plainly.

Two smaller asks remain only partially satisfied by design: median/worst campaign
latency, and full self-contained verifiability of the "7 of 7 prior audits"
citation (those branches are real and fetchable, just not in this PR's own tree,
since the auditor may add only one file per run).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1Fp9zTidKk9PZVWzRPXif